### PR TITLE
fix(pkgs): use zstd from pkgsBuildBuild

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -2,7 +2,7 @@
 , makeSetupHook
 , jq
 , rsync
-, zstd
+, pkgsBuildBuild
 }:
 
 {
@@ -20,7 +20,7 @@
     {
       name = "inheritCargoArtifactsHook";
       substitutions = {
-        zstd = "${zstd}/bin/zstd";
+        zstd = "${pkgsBuildBuild.zstd}/bin/zstd";
       };
     } ./inheritCargoArtifactsHook.sh;
 
@@ -28,7 +28,7 @@
     {
       name = "installCargoArtifactsHook";
       substitutions = {
-        zstd = "${zstd}/bin/zstd";
+        zstd = "${pkgsBuildBuild.zstd}/bin/zstd";
       };
     } ./installCargoArtifactsHook.sh;
 


### PR DESCRIPTION
This allows for crane to work when `buildPlatform != hostPlatform`, such
as well `crossSystem` is set.

This partially addresses #4
