### PR TITLE
cargoFmt: change behavior to install cargo artifacts by default

### DIFF
--- a/checks/default.nix
+++ b/checks/default.nix
@@ -19,6 +19,12 @@ onlyDrvs (lib.makeScope myLib.newScope (self:
       src = ./simple;
     };
 
+    # https://github.com/ipetkov/crane/issues/6
+    cargoFmtThenClippy = myLib.cargoClippy {
+      src = ./simple;
+      cargoArtifacts = self.cargoFmt;
+    };
+
     cargoTarpaulin = myLib.cargoTarpaulin {
       src = ./simple;
     };

--- a/docs/API.md
+++ b/docs/API.md
@@ -285,7 +285,6 @@ Except where noted below, all derivation attributes are delegated to
   - Default value: `""`
 * `cargoVendorDir` is disabled/cleared
 * `doCheck` is disabled
-* `doInstallCargoArtifacts` is disabled
 * `doRemapSourcePathPrefix` is disabled
 * `pnameSuffix` will be set to `"-fmt"`
 

--- a/lib/cargoFmt.nix
+++ b/lib/cargoFmt.nix
@@ -13,7 +13,6 @@ cargoBuild (args // {
   cargoArtifacts = null;
   cargoVendorDir = null;
   doCheck = false;
-  doInstallCargoArtifacts = false;
   doRemapSourcePathPrefix = false;
   pnameSuffix = "-fmt";
 
@@ -21,4 +20,9 @@ cargoBuild (args // {
   cargoExtraArgs = "${cargoExtraArgs} -- --check ${rustFmtExtraArgs}";
 
   nativeBuildInputs = (args.nativeBuildInputs or [ ]) ++ [ rustfmt ];
+
+  preInstallPhases = [ "ensureTargetDir" ] ++ (args.preInstallPhases or [ ]);
+  ensureTargetDir = ''
+    mkdir -p ''${CARGO_TARGET_DIR:-target}
+  '';
 })


### PR DESCRIPTION
* This allows potentially chaining `cargoFmt` invocations with other
  derivations

Fixes #6 