### PR TITLE
`cargoClippy` and `cargoTarpaulin`: change behavior to install cargo artifacts by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+* `cargoClippy` and `cargoTarpaulin` will install cargo artifacts by default (or
+  install an empty `target` directory if there are none). This allows for more
+  easily chaining derivations if doing so is desired.
+  - This can be disabled by setting `doInstallCargoArtifacts = false;` in the
+    derivation
+
 ## [0.3.0] - 2022-02-11
 
 ### Added

--- a/checks/default.nix
+++ b/checks/default.nix
@@ -20,6 +20,15 @@ onlyDrvs (lib.makeScope myLib.newScope (self:
     };
 
     # https://github.com/ipetkov/crane/issues/6
+    cargoClippyThenBuild = myLib.buildPackage {
+      src = ./simple;
+      cargoArtifacts = myLib.cargoClippy {
+        cargoArtifacts = null;
+        src = ./simple;
+      };
+    };
+
+    # https://github.com/ipetkov/crane/issues/6
     cargoFmtThenClippy = myLib.cargoClippy {
       src = ./simple;
       cargoArtifacts = self.cargoFmt;

--- a/docs/API.md
+++ b/docs/API.md
@@ -255,9 +255,6 @@ Except where noted below, all derivation attributes are delegated to
 * `cargoExtraArgs`: additional flags to be passed in the cargo invocation (e.g.
   enabling specific features)
   - Default value: `""`
-* `doInstallCargoArtifacts`: controls whether cargo's `target` directory should
-  be copied as an output
-  - Default value: `false`
 
 #### Native build dependencies
 The `clippy` package is automatically appended as a native build input to any

--- a/lib/cargoClippy.nix
+++ b/lib/cargoClippy.nix
@@ -20,9 +20,4 @@ cargoBuild (args // {
   nativeBuildInputs = (args.nativeBuildInputs or [ ]) ++ [ clippy ];
 
   doCheck = false; # We don't need to run tests to benefit from `cargo check`
-
-  # The existence of the build completing without error is enough to ensure
-  # the checks have passed, so we do not strictly need to install the cargo artifacts.
-  # However, we allow the caller to retain them if needed.
-  doInstallCargoArtifacts = args.doInstallCargoArtifacts or false;
 })

--- a/lib/cargoTarpaulin.nix
+++ b/lib/cargoTarpaulin.nix
@@ -16,7 +16,6 @@ cargoBuild (args // {
   cargoExtraArgs = "${cargoExtraArgs} ${cargoTarpaulinExtraArgs}";
 
   doCheck = false;
-  doInstallCargoArtifacts = args.doInstallCargoArtifacts or false;
   pnameSuffix = "-tarpaulin";
 
   nativeBuildInputs = (args.nativeBuildInputs or [ ]) ++ [ cargo-tarpaulin ];


### PR DESCRIPTION
* This allows potentially chaining invocations with other derivations more easily

Fixes #6 