### PR TITLE
Form paths by concatenating a string suffix not a path

### DIFF
--- a/lib/buildDepsOnly.nix
+++ b/lib/buildDepsOnly.nix
@@ -27,8 +27,8 @@ let
   '';
 
   path = args.src or throwMsg;
-  cargoToml = path + /Cargo.toml;
-  cargoLock = path + /Cargo.lock;
+  cargoToml = path + "/Cargo.toml";
+  cargoLock = path + "/Cargo.lock";
   dummySrc =
     if builtins.pathExists cargoToml && builtins.pathExists cargoLock
     then mkDummySrc args

--- a/lib/mkDummySrc.nix
+++ b/lib/mkDummySrc.nix
@@ -7,7 +7,7 @@
 }:
 
 { src
-, cargoLock ? src + /Cargo.lock
+, cargoLock ? src + "/Cargo.lock"
 , ...
 }:
 let


### PR DESCRIPTION
* Seems like Nix can get unhappy if a path fragment is evaluated too
  eagerly, giving errors like
  `error: access to absolute path '/Cargo.toml' is forbidden in pure eval mode (use '--impure' to override)`
* Changing to using string manipulation seems to resolve the issue

Refs #10 