### PR TITLE
Add compatibility fallback for builtins.groupBy 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,13 +12,19 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
+            # Latest and greatest release of Nix
+            install_url: https://nixos.org/nix/install
           - os: ubuntu-latest
+            # The 21.11 branch ships with Nix 2.3 but flakes support laneded in 2.4
+            install_url: https://releases.nixos.org/nix/nix-2.4/install
             nixpkgs-override: "--override-input nixpkgs github:NixOS/nixpkgs/release-21.11"
 
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2.4.0
     - uses: cachix/install-nix-action@v16
+      with:
+        install_url: ${{ matrix.install_url }}
     - uses: cachix/cachix-action@v10
       with:
         name: crane

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Fixed
+* Use `lib.groupBy` if `builtins.groupBy` isn't available (i.e. if a Nix version
+  earlier than 2.5 is used)
+
 ## [0.3.2] - 2022-02-18
 
 ### Fixed

--- a/lib/findCargoFiles.nix
+++ b/lib/findCargoFiles.nix
@@ -9,6 +9,9 @@ let
     mapAttrs
     mapAttrsToList;
 
+  # compat(2.5): fallback to lib.groupBy if the builtin version isn't available
+  groupBy = builtins.groupBy or lib.groupBy;
+
   # A specialized form of lib.listFilesRecursive except it will only look
   # for Cargo.toml and config.toml files to keep the intermediate results lean
   listFilesRecursive = parentIsDotCargo: dir: flatten (mapAttrsToList
@@ -29,7 +32,7 @@ let
     (builtins.readDir dir));
 
   foundFiles = listFilesRecursive false src;
-  grouped = builtins.groupBy (x: x.type) foundFiles;
+  grouped = groupBy (x: x.type) foundFiles;
   cleaned = mapAttrs (_: map (y: y.path)) grouped;
 
   # Ensure we have a well typed result

--- a/lib/vendorCargoRegistries.nix
+++ b/lib/vendorCargoRegistries.nix
@@ -12,7 +12,6 @@ let
     attrNames
     concatStringsSep
     filter
-    groupBy
     hasAttr
     hashString
     head
@@ -30,6 +29,9 @@ let
     mapAttrs'
     mapAttrsToList
     nameValuePair;
+
+  # compat(2.5): fallback to lib.groupBy if the builtin version isn't available
+  groupBy = builtins.groupBy or lib.groupBy;
 
   hash = hashString "sha256";
 

--- a/lib/vendorGitDeps.nix
+++ b/lib/vendorGitDeps.nix
@@ -11,7 +11,6 @@ let
     any
     attrNames
     filter
-    groupBy
     hashString
     head
     isString
@@ -29,6 +28,9 @@ let
     mapAttrsToList
     nameValuePair
     removePrefix;
+
+  # compat(2.5): fallback to lib.groupBy if the builtin version isn't available
+  groupBy = builtins.groupBy or lib.groupBy;
 
   knownGitParams = [ "branch" "rev" "tag" ];
   parseGitUrl = lockUrl:


### PR DESCRIPTION
* `builtins.groupBy` was added in Nix 2.5
* If it's not available (i.e. evaluating with an earlier version of Nix), we will then use the `lib.groupBy` implementation instead

Fixes #15 