### PR TITLE
fix(lib/buildDepsOnly): don't check for Cargo.lock if user configures lock path

### DIFF
--- a/lib/buildDepsOnly.nix
+++ b/lib/buildDepsOnly.nix
@@ -28,7 +28,7 @@ let
 
   path = args.src or throwMsg;
   cargoToml = path + "/Cargo.toml";
-  cargoLock = path + "/Cargo.lock";
+  cargoLock = args.cargoLock or (path + "/Cargo.lock");
   dummySrc =
     if builtins.pathExists cargoToml && builtins.pathExists cargoLock
     then mkDummySrc args


### PR DESCRIPTION
This should allow using buildDepsOnly with a custom lockfile path.
