### PR TITLE
buildDepsOnly: add `--all-targets` to default cargoCheckCommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Changed
+* `buildDepsOnly` now adds `--all-targets` to the default `cargo
+  check` invocation. This allows caching all artifacts (including from
+  dev-dependencies) such that tools like clippy don't have to generate them
+  every time they run.
+
 ## [0.3.3] - 2022-02-24
 
 ### Fixed

--- a/docs/API.md
+++ b/docs/API.md
@@ -83,7 +83,7 @@ to influence its behavior.
   - Default value: `"${cargoCheckCommand} ${cargoExtraArgs}\n${cargoBuildCommand} ${cargoExtraArgs}"`
 * `cargoBuildCommand`: A cargo (build) invocation to run during the derivation's build
   phase
-  - Default value: `"cargo build --workspace --release"`
+  - Default value: `"cargo build --workspace --release --all-targets"`
 * `cargoCheckCommand`: A cargo (check) invocation to run during the derivation's build
   phase (in order to cache additional artifacts)
   - Default value: `"cargo build --workspace --release"`

--- a/lib/buildDepsOnly.nix
+++ b/lib/buildDepsOnly.nix
@@ -5,7 +5,7 @@
 }:
 
 { cargoBuildCommand ? "cargo build --workspace --release"
-, cargoCheckCommand ? "cargo check --workspace --release"
+, cargoCheckCommand ? "cargo check --workspace --release --all-targets"
 , cargoExtraArgs ? ""
 , cargoTestCommand ? "cargo test --workspace --release"
 , ...

--- a/lib/cargoClippy.nix
+++ b/lib/cargoClippy.nix
@@ -19,5 +19,5 @@ cargoBuild (args // {
 
   nativeBuildInputs = (args.nativeBuildInputs or [ ]) ++ [ clippy ];
 
-  doCheck = false; # We don't need to run tests to benefit from `cargo check`
+  doCheck = false; # We don't need to run tests to benefit from `cargo clippy`
 })


### PR DESCRIPTION
This allows caching all artifacts (including from dev-dependencies) such
that tools like clippy don't have to generate them every time they run.