### PR TITLE
fix(nix-relative-paths): quote relative paths to allow for external sources

### DIFF
--- a/checks/cleanCargoTomlTests/default.nix
+++ b/checks/cleanCargoTomlTests/default.nix
@@ -8,10 +8,10 @@ let
   cmpCleanCargoToml = name: path:
     let
       cleaned = cleanCargoToml {
-        cargoToml = path + /Cargo.toml;
+        cargoToml = path + "/Cargo.toml";
       };
       cleanedToml = writeTOML "cleaned.toml" cleaned;
-      expected = path + /expected.toml;
+      expected = path + "/expected.toml";
     in
     runCommand "compare-${name}" { } ''
       diff ${expected} ${cleanedToml}

--- a/checks/mkDummySrcTests/default.nix
+++ b/checks/mkDummySrcTests/default.nix
@@ -7,7 +7,7 @@ let
   cmpDummySrc = name: path:
     let
       dummySrc = mkDummySrc {
-        src = path + /input;
+        src = path + "/input";
       };
     in
     runCommand "compare-${name}" { } ''

--- a/lib/crateNameFromCargoToml.nix
+++ b/lib/crateNameFromCargoToml.nix
@@ -7,7 +7,7 @@ let
     contains a valid Cargo.toml file, or consider setting a derivation name explicitly
   '');
 
-  cargoToml = args.cargoToml or (args.src + /Cargo.toml);
+  cargoToml = args.cargoToml or (args.src + "/Cargo.toml");
   cargoTomlContents = args.cargoTomlContents or (builtins.readFile cargoToml);
 
   toml = fromTOML cargoTomlContents;

--- a/lib/vendorCargoDeps.nix
+++ b/lib/vendorCargoDeps.nix
@@ -24,7 +24,7 @@ let
     - set `cargoVendorDir = null` to skip vendoring altogether
   '');
 
-  cargoLock = args.cargoLock or (src + /Cargo.lock);
+  cargoLock = args.cargoLock or (src + "/Cargo.lock");
   cargoLockContents = args.cargoLockContents or (
     if pathExists cargoLock
     then readFile cargoLock


### PR DESCRIPTION
when trying to use crane with a non local src (eg, not `./.`) we get the error
```
$ nix flake show
<...>
error: access to absolute path '/Cargo.toml' is forbidden in pure eval mode (use '--impure' to override)
(use '--show-trace' to show detailed location information)
```

To fix this, we quote the relative paths so to properly append them to the base path.

https://nixos.wiki/wiki/Nix_Expression_Language#Coercing_a_relative_path_with_interpolated_variables_to_an_absolute_path_.28for_imports.29

## Reproduction flake
```nix
{
  description = "Build a cargo project without extra checks";

  inputs = {
    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";

    crane = {
      url = "github:ipetkov/crane";
      inputs.nixpkgs.follows = "nixpkgs";
    };

    external-crate-source = {
      # should work with any crate source, not specifically this repo
      url = "github:ray-kast/empress";
      flake = false;
    };

    flake-utils.url = "github:numtide/flake-utils";
  };

  outputs = { self, nixpkgs, crane, flake-utils, external-crate-source, ... }:
    flake-utils.lib.eachDefaultSystem (system:
      let
        pkgs = nixpkgs.legacyPackages.${system};

        test-crate = crane.lib.${system}.buildPackage {
          src = external-crate-source.outPath;
        };
      in
      {
        packages.default = test-crate;
      });
}
```

---

Hi! Let me know if there's anything in here you'd like changes on or think should be approached differently. I just found that this change was needed for my use case where I don't want to fork upstream but instead just pull in revisions using `flake.lock`.