### PR TITLE
Make crane possible to use without flakes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   * Crane's default overlay is now available at `.overlays.default` (previously
     `.overlay`)
   * All templates now use `{app,devShells,packages}.default` as well
+* **Breaking**: `lib.fromTOML` and `lib.toTOML` have been removed in favor of
+  `builtins.fromTOML`
+* Improved support for consuming `crane` without using flakes
+* The `nix-std` dependency has been dropped
 
 ## [0.4.1] - 2022-05-29
 

--- a/checks/cleanCargoTomlTests/complex/expected.toml
+++ b/checks/cleanCargoTomlTests/complex/expected.toml
@@ -1,83 +1,4 @@
 cargo-features = ["some unstable features"]
-
-[build-dependencies]
-[build-dependencies.corge]
-version = "6"
-
-[dependencies]
-foo = "1"
-
-[dependencies.bar]
-features = ["bar-feature", "bar-another-feature"]
-version = "2"
-
-[dependencies.baz]
-features = ["baz-feature", "baz-feature2"]
-version = "3"
-
-[dev-dependencies]
-qux = "4"
-
-[dev-dependencies.zuul]
-version = "5"
-
-[features]
-barfeature = ["foofeature"]
-foofeature = []
-
-[lib]
-crate-type = ["lib", "rlib"]
-edition = "2021"
-name = "foo"
-path = "src/lib.rs"
-
-[package]
-edition = "2021"
-name = "some name"
-version = "1.2.3"
-workspace = "some/path/to/workspace"
-
-[patch]
-[patch.crates-io]
-[patch.crates-io.bar]
-path = "my/local/bar"
-
-[patch.crates-io.foo]
-git = "https://github.com/example/foo"
-
-[profile]
-[profile.dev]
-opt-level = 1
-overflow-checks = false
-
-[profile.release]
-opt-level = 2
-overflow-checks = true
-
-[replace]
-[replace."bar3:1.0.2"]
-path = "my/local/bar3"
-
-[replace."foo2:0.1.0"]
-git = "https://github.com/example/foo2"
-
-[some-unrecognized-object]
-some-unrecognized-field = "some value"
-
-[target]
-[target."cfg(target_arch = \"x86\")"]
-[target."cfg(target_arch = \"x86\")".dependencies]
-garply = "8"
-
-[target."cfg(unix)"]
-[target."cfg(unix)".dependencies]
-grault = "7"
-
-[workspace]
-default-members = ["path/to/member2", "path/to/member3/foo"]
-exclude = ["crates/foo", "path/to/other"]
-members = ["member1", "path/to/member2", "crates/*"]
-
 [[bench]]
 edition = "2015"
 name = "bench1"
@@ -118,3 +39,77 @@ path = "src/test1.rs"
 edition = "2018"
 name = "test2"
 path = "src/test2.rs"
+
+[build-dependencies.corge]
+version = "6"
+
+[dependencies]
+foo = "1"
+
+[dependencies.bar]
+features = ["bar-feature", "bar-another-feature"]
+version = "2"
+
+[dependencies.baz]
+features = ["baz-feature", "baz-feature2"]
+version = "3"
+
+[dev-dependencies]
+qux = "4"
+
+[dev-dependencies.zuul]
+version = "5"
+
+[features]
+barfeature = ["foofeature"]
+foofeature = []
+
+[lib]
+crate-type = ["lib", "rlib"]
+edition = "2021"
+name = "foo"
+path = "src/lib.rs"
+
+[package]
+edition = "2021"
+name = "some name"
+version = "1.2.3"
+workspace = "some/path/to/workspace"
+
+[patch.crates-io]
+[patch.crates-io.bar]
+path = "my/local/bar"
+
+[patch.crates-io.foo]
+git = "https://github.com/example/foo"
+
+[profile]
+[profile.dev]
+opt-level = 1
+overflow-checks = false
+
+[profile.release]
+opt-level = 2
+overflow-checks = true
+
+[replace]
+[replace."bar3:1.0.2"]
+path = "my/local/bar3"
+
+[replace."foo2:0.1.0"]
+git = "https://github.com/example/foo2"
+
+[some-unrecognized-object]
+some-unrecognized-field = "some value"
+
+[target]
+[target."cfg(target_arch = \"x86\")".dependencies]
+garply = "8"
+
+[target."cfg(unix)".dependencies]
+grault = "7"
+
+[workspace]
+default-members = ["path/to/member2", "path/to/member3/foo"]
+exclude = ["crates/foo", "path/to/other"]
+members = ["member1", "path/to/member2", "crates/*"]

--- a/checks/default.nix
+++ b/checks/default.nix
@@ -113,6 +113,12 @@ onlyDrvs (lib.makeScope myLib.newScope (self:
       src = ./simple-git;
     };
 
+    simple-nonflake = (import ../default.nix {
+      inherit pkgs;
+    }).buildPackage {
+      src = ./simple;
+    };
+
     remapPathPrefixWorks = pkgs.runCommand "remapPathPrefixWorks" { } ''
       if ${pkgs.binutils-unwrapped}/bin/strings ${self.ripgrep}/bin/rg | \
         grep -v glibc | \

--- a/checks/mkDummySrcTests/single/expected/Cargo.toml
+++ b/checks/mkDummySrcTests/single/expected/Cargo.toml
@@ -1,11 +1,3 @@
-[lib]
-name = "foo"
-
-[package]
-edition = "2021"
-name = "mkDummySrcSimple"
-version = "0.1.0"
-
 [[bench]]
 name = "bench1"
 
@@ -33,3 +25,11 @@ name = "test1"
 [[test]]
 name = "test2"
 path = "tests/custom.rs"
+
+[lib]
+name = "foo"
+
+[package]
+edition = "2021"
+name = "mkDummySrcSimple"
+version = "0.1.0"

--- a/checks/mkDummySrcTests/workspace/expected/member/foo/bar/baz/Cargo.toml
+++ b/checks/mkDummySrcTests/workspace/expected/member/foo/bar/baz/Cargo.toml
@@ -1,11 +1,3 @@
-[lib]
-name = "foo"
-
-[package]
-edition = "2021"
-name = "bar"
-version = "0.1.0"
-
 [[bench]]
 name = "bench1"
 
@@ -33,3 +25,11 @@ name = "test1"
 [[test]]
 name = "test2"
 path = "tests/custom.rs"
+
+[lib]
+name = "foo"
+
+[package]
+edition = "2021"
+name = "bar"
+version = "0.1.0"

--- a/checks/mkDummySrcTests/workspace/expected/member/qux/Cargo.toml
+++ b/checks/mkDummySrcTests/workspace/expected/member/qux/Cargo.toml
@@ -1,15 +1,3 @@
-[dependencies]
-[dependencies.bar]
-path = "../foo/bar/baz"
-
-[lib]
-name = "foo"
-
-[package]
-edition = "2021"
-name = "qux"
-version = "0.1.0"
-
 [[bench]]
 name = "bench1"
 
@@ -37,3 +25,14 @@ name = "test1"
 [[test]]
 name = "test2"
 path = "tests/custom.rs"
+
+[dependencies.bar]
+path = "../foo/bar/baz"
+
+[lib]
+name = "foo"
+
+[package]
+edition = "2021"
+name = "qux"
+version = "0.1.0"

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,6 @@
+{ pkgs ? import <nixpkgs> { } }:
+
+import ./lib {
+  inherit (pkgs) lib newScope;
+  mkMyPkgs = callPackage: import ./pkgs callPackage;
+}

--- a/docs/API.md
+++ b/docs/API.md
@@ -633,17 +633,6 @@ lib.registryFromGitIndex {
 # { "registry+https://github.com/Hirevo/alexandrie-index" = "https://crates.polomack.eu/api/v1/crates/{crate}/{version}/download"; }
 ```
 
-### `lib.toTOML`
-
-`toTOML :: set -> String`
-
-Convert an attribute set to a TOML string.
-
-```nix
-lib.toTOML { foo.bar = "baz"; }
-# "[foo]\nbar = \"baz\""
-```
-
 ### `lib.urlForCargoPackage`
 
 `urlForCargoPackage :: set -> String`

--- a/docs/API.md
+++ b/docs/API.md
@@ -449,17 +449,6 @@ lib.findCargoFiles ./src
 # { cargoTomls = [ "..." ]; cargoConfigs = [ "..." ]; }
 ```
 
-### `lib.fromTOML`
-
-`fromTOML :: String -> set`
-
-Convert a TOML string to a Nix attribute set.
-
-```nix
-lib.fromTOML (builtins.readFile ./Cargo.toml)
-# { package = { edition = "2021"; name = "simple"; version = "0.1.0"; }; }
-```
-
 ### `lib.mkCargoDerivation`
 
 `mkCargoDerivation :: set -> drv`
@@ -679,7 +668,7 @@ cargo can use for subsequent builds without needing network access.
 * `cargoConfigs`: a list of paths to all `.cargo/config.toml` files which may
   appear in the project
 * `lockPackages`: a list of all `[[package]]` entries found in the project's
-  `Cargo.lock` file (parsed via `fromTOML`)
+  `Cargo.lock` file (parsed via `builtins.fromTOML`)
 
 #### Output attributes
 * `config`: the configuration entires needed to point cargo to the vendored
@@ -698,7 +687,7 @@ access.
 
 #### Input attributes
 * `lockPackages`: a list of all `[[package]]` entries found in the project's
-  `Cargo.lock` file (parsed via `fromTOML`)
+  `Cargo.lock` file (parsed via `builtins.fromTOML`)
 
 #### Output attributes
 * `config`: the configuration entires needed to point cargo to the vendored

--- a/flake.lock
+++ b/flake.lock
@@ -31,21 +31,6 @@
         "type": "github"
       }
     },
-    "nix-std": {
-      "locked": {
-        "lastModified": 1652574713,
-        "narHash": "sha256-HQw5VtHI4uYvWfwXtDwupP8SV/efZa3Vot5VNbH0RRU=",
-        "owner": "chessai",
-        "repo": "nix-std",
-        "rev": "082f38023b68f93cd3a6e3a8ddda54d3f5487c52",
-        "type": "github"
-      },
-      "original": {
-        "owner": "chessai",
-        "repo": "nix-std",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1654007547,
@@ -66,7 +51,6 @@
       "inputs": {
         "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
-        "nix-std": "nix-std",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,7 @@
       myPkgsFor = pkgs: mkMyPkgs pkgs.callPackage;
 
       mkLib = pkgs: import ./lib {
-        inherit (nix-std.lib.serde) fromTOML toTOML;
+        fromTOML = builtins.fromTOML;
         inherit (pkgs) lib newScope;
         inherit mkMyPkgs;
       };

--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,6 @@
       myPkgsFor = pkgs: mkMyPkgs pkgs.callPackage;
 
       mkLib = pkgs: import ./lib {
-        fromTOML = builtins.fromTOML;
         inherit (pkgs) lib newScope;
         inherit mkMyPkgs;
       };

--- a/flake.nix
+++ b/flake.nix
@@ -8,10 +8,9 @@
     };
 
     flake-utils.url = "github:numtide/flake-utils";
-    nix-std.url = "github:chessai/nix-std";
   };
 
-  outputs = inputs@{ self, nixpkgs, nix-std, flake-utils, ... }:
+  outputs = inputs@{ self, nixpkgs, flake-utils, ... }:
     let
       mkMyPkgs = callPackage: import ./pkgs callPackage;
       myPkgsFor = pkgs: mkMyPkgs pkgs.callPackage;

--- a/lib/cleanCargoToml.nix
+++ b/lib/cleanCargoToml.nix
@@ -1,5 +1,4 @@
-{ fromTOML
-}:
+{}:
 
 let
   # https://doc.rust-lang.org/cargo/reference/manifest.html#the-package-section
@@ -103,4 +102,4 @@ in
 { cargoToml ? throw "either cargoToml or cargoTomlContents must be specified"
 , cargoTomlContents ? builtins.readFile cargoToml
 }:
-cleanCargoToml (fromTOML cargoTomlContents)
+cleanCargoToml (builtins.fromTOML cargoTomlContents)

--- a/lib/crateNameFromCargoToml.nix
+++ b/lib/crateNameFromCargoToml.nix
@@ -1,4 +1,4 @@
-{ fromTOML }:
+{}:
 
 args:
 let
@@ -10,7 +10,7 @@ let
   cargoToml = args.cargoToml or (args.src + "/Cargo.toml");
   cargoTomlContents = args.cargoTomlContents or (builtins.readFile cargoToml);
 
-  toml = fromTOML cargoTomlContents;
+  toml = builtins.fromTOML cargoTomlContents;
 in
 {
   pname = toml.package.name or "cargo-package";

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -1,5 +1,4 @@
-{ fromTOML
-, lib
+{ lib
 , mkMyPkgs
 , newScope
 }:
@@ -9,8 +8,6 @@ lib.makeScope newScope (self:
     inherit (self) callPackage;
   in
   (mkMyPkgs callPackage) // {
-    inherit fromTOML;
-
     appendCrateRegistries = input: self.overrideScope' (final: prev: {
       crateRegistries = prev.crateRegistries // (lib.foldl (a: b: a // b) { } input);
     });

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -2,7 +2,6 @@
 , lib
 , mkMyPkgs
 , newScope
-, toTOML
 }:
 
 lib.makeScope newScope (self:
@@ -10,7 +9,7 @@ lib.makeScope newScope (self:
     inherit (self) callPackage;
   in
   (mkMyPkgs callPackage) // {
-    inherit fromTOML toTOML;
+    inherit fromTOML;
 
     appendCrateRegistries = input: self.overrideScope' (final: prev: {
       crateRegistries = prev.crateRegistries // (lib.foldl (a: b: a // b) { } input);

--- a/lib/vendorCargoDeps.nix
+++ b/lib/vendorCargoDeps.nix
@@ -1,5 +1,4 @@
 { findCargoFiles
-, fromTOML
 , lib
 , runCommandLocal
 , vendorCargoRegistries
@@ -44,7 +43,7 @@ let
     '')
     (attrNames sources);
 
-  lock = fromTOML cargoLockContents;
+  lock = builtins.fromTOML cargoLockContents;
   lockPackages = lock.package or (throw "Cargo.lock missing [[package]] definitions");
 
   vendoredRegistries = vendorCargoRegistries {

--- a/lib/vendorCargoRegistries.nix
+++ b/lib/vendorCargoRegistries.nix
@@ -1,5 +1,4 @@
 { downloadCargoPackage
-, fromTOML
 , lib
 , runCommandLocal
 }:
@@ -47,7 +46,7 @@ let
     '') packages}
   '';
 
-  parsedCargoTomls = map (p: fromTOML (readFile p)) cargoConfigs;
+  parsedCargoTomls = map (p: builtins.fromTOML (readFile p)) cargoConfigs;
   allCargoRegistries = flatten (map (c: c.registries or [ ]) parsedCargoTomls);
   allCargoRegistryPairs = flatten (map (mapAttrsToList (name: value: { inherit name value; })) allCargoRegistries);
   allCargoRegistryPairsWithIndex = filter (r: r ? value.index) allCargoRegistryPairs;

--- a/lib/vendorGitDeps.nix
+++ b/lib/vendorGitDeps.nix
@@ -1,7 +1,6 @@
 { downloadCargoPackageFromGit
 , lib
 , runCommandLocal
-, toTOML
 }:
 
 { lockPackages

--- a/lib/writeTOML.nix
+++ b/lib/writeTOML.nix
@@ -1,7 +1,7 @@
-{ writeText
-, remarshal
+# NB: ideally this should just be `remarshal` but it appears to cause an infinite loop when building
+# against the release-22.05 branch, so using this as a workaround for now
+{ pkgsBuildBuild
 , runCommand
-, pkgsBuildBuild
 }:
 
 name: contents: runCommand name

--- a/lib/writeTOML.nix
+++ b/lib/writeTOML.nix
@@ -1,5 +1,14 @@
-{ toTOML
-, writeText
+{ writeText
+, remarshal
+, runCommand
+, pkgsBuildBuild
 }:
 
-name: contents: writeText name ((toTOML contents) + "\n")
+name: contents: runCommand name
+{
+  contents = builtins.toJSON contents;
+  passAsFile = [ "contents" ];
+  nativeBuildInputs = [ pkgsBuildBuild.remarshal ];
+} ''
+  remarshal -i $contentsPath -if json -of toml -o $out
+''

--- a/shell.nix
+++ b/shell.nix
@@ -8,4 +8,4 @@ let
 
   flake = import compat { src = ./.; };
 in
-flake.defaultNix
+flake.shellNix


### PR DESCRIPTION
I'd like to use Crane but I have no interest in starting to use Flakes.

With this change it's possible to use Crane without flakes like:
``` nix
{ lib ? pkgs.lib
, pkgs ? import <nixpkgs> { }
}:

let
  craneLib = import ../crane { inherit pkgs; };

  src = lib.cleanSource ./.;

  cargoArtifacts = craneLib.buildDepsOnly {
    inherit src;
  };

in craneLib.buildPackage {
  inherit cargoArtifacts src;
}
```