### PR TITLE
ci: bump stable Nix to use 22.05 release

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,9 +16,9 @@ jobs:
             # Latest and greatest release of Nix
             install_url: https://nixos.org/nix/install
           - os: ubuntu-latest
-            # The 21.11 branch ships with Nix 2.3 but flakes support landed in 2.4
-            install_url: https://releases.nixos.org/nix/nix-2.4/install
-            nixpkgs-override: "--override-input nixpkgs github:NixOS/nixpkgs/release-21.11"
+            # The 22.05 branch ships with Nix 2.8.1
+            install_url: https://releases.nixos.org/nix/nix-2.8.1/install
+            nixpkgs-override: "--override-input nixpkgs github:NixOS/nixpkgs/release-22.05"
 
     runs-on: ${{ matrix.os }}
     steps:
@@ -31,7 +31,7 @@ jobs:
         name: crane
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
     - name: flake checks
-      run: nix flake check --print-build-logs ${{ matrix.nixpkgs-override }}
+      run: nix flake check --keep-going --print-build-logs ${{ matrix.nixpkgs-override }}
     - name: extra tests
       run: nix develop ${{ matrix.nixpkgs-override }} --command ./extra-tests/test.sh
     - name: validate examples
@@ -40,7 +40,6 @@ jobs:
           pushd "${f}"
           echo "validating ${f}"
           nix flake check --print-build-logs --override-input crane ../.. ${{ matrix.nixpkgs-override }}
-          # Explicitly run .#default so it continues to work with nix versions < 2.8
-          nix run .#default --override-input crane ../.. ${{ matrix.nixpkgs-override }}
+          nix run --override-input crane ../.. ${{ matrix.nixpkgs-override }}
           popd
         done

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+# Changed
+* **Breaking**: dropped compatibility for Nix versions below 2.8.1
+
 ## [0.4.1] - 2022-05-29
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 # Changed
 * **Breaking**: dropped compatibility for Nix versions below 2.8.1
+* **Breaking**: updated all flake attributes to follow the new `.default`
+  guidance as per Nix's warnings. Specifically:
+  * Crane's default overlay is now available at `.overlays.default` (previously
+    `.overlay`)
+  * All templates now use `{app,devShells,packages}.default` as well
 
 ## [0.4.1] - 2022-05-29
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ following contents at the root of your cargo workspace:
 
   outputs = { self, nixpkgs, crane, flake-utils, ... }:
     flake-utils.lib.eachDefaultSystem (system: {
-      defaultPackage = crane.lib.${system}.buildPackage {
+      packages.default = crane.lib.${system}.buildPackage {
         src = ./.;
 
         # Add extra inputs here or any other derivation settings
@@ -179,7 +179,7 @@ Here's how we can set up our flake to achieve our goals:
         });
       in
       {
-        defaultPackage = myCrate;
+        packages.default = myCrate;
         checks = {
          inherit
            # Build the crate as part of `nix flake check` for convenience
@@ -275,7 +275,7 @@ build.
         });
       in
       {
-        defaultPackage = myCrate;
+        packages.default = myCrate;
         checks = {
          inherit
            # Build the crate as part of `nix flake check` for convenience

--- a/checks/default.nix
+++ b/checks/default.nix
@@ -7,6 +7,7 @@ in
 onlyDrvs (lib.makeScope myLib.newScope (self:
   let
     callPackage = self.newScope { };
+    x64Linux = pkgs.hostPlatform.system == "x86_64-linux";
   in
   myPkgs // {
     checkNixpkgsFmt = callPackage ./nixpkgs-fmt.nix { };
@@ -34,9 +35,9 @@ onlyDrvs (lib.makeScope myLib.newScope (self:
       cargoArtifacts = self.cargoFmt;
     };
 
-    cargoTarpaulin = myLib.cargoTarpaulin {
+    cargoTarpaulin = lib.optionalAttrs x64Linux (myLib.cargoTarpaulin {
       src = ./simple;
-    };
+    });
 
     compilesFresh = callPackage ./compilesFresh.nix { };
     compilesFreshSimple = self.compilesFresh ./simple "simple" { };

--- a/examples/alt-registry/flake.nix
+++ b/examples/alt-registry/flake.nix
@@ -67,7 +67,7 @@
           drv = my-crate;
         };
 
-        devShell = pkgs.mkShell {
+        devShells.default = pkgs.mkShell {
           inputsFrom = builtins.attrValues self.checks;
 
           # Extra inputs can be added here

--- a/examples/custom-toolchain/flake.nix
+++ b/examples/custom-toolchain/flake.nix
@@ -65,7 +65,7 @@
           '';
         };
 
-        devShell = pkgs.mkShell {
+        devShells.default = pkgs.mkShell {
           inputsFrom = builtins.attrValues self.checks;
 
           # Extra inputs can be added here

--- a/examples/quick-start-simple/flake.nix
+++ b/examples/quick-start-simple/flake.nix
@@ -34,7 +34,7 @@
           drv = my-crate;
         };
 
-        devShell = pkgs.mkShell {
+        devShells.default = pkgs.mkShell {
           inputsFrom = builtins.attrValues self.checks;
 
           # Extra inputs can be added here

--- a/examples/quick-start/flake.nix
+++ b/examples/quick-start/flake.nix
@@ -70,7 +70,7 @@
           drv = my-crate;
         };
 
-        devShell = pkgs.mkShell {
+        devShells.default = pkgs.mkShell {
           inputsFrom = builtins.attrValues self.checks;
 
           # Extra inputs can be added here

--- a/flake.lock
+++ b/flake.lock
@@ -18,11 +18,11 @@
     },
     "flake-utils": {
       "locked": {
-        "lastModified": 1649676176,
-        "narHash": "sha256-OWKJratjt2RW151VUlJPRALb7OU2S5s+f0vLj4o1bHM=",
+        "lastModified": 1653893745,
+        "narHash": "sha256-0jntwV3Z8//YwuOjzhV2sgJJPt+HY6KhU7VZUL0fKZQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "a4b154ebbdc88c8498a5c7b01589addc9e9cb678",
+        "rev": "1ed9fb1935d260de5fe1c2f7ee0ebaae17ed2fa1",
         "type": "github"
       },
       "original": {
@@ -33,11 +33,11 @@
     },
     "nix-std": {
       "locked": {
-        "lastModified": 1647625366,
-        "narHash": "sha256-jR4tpiQDs4GNJC6MzfrNyOFIhVH3o203qR+YNB++GYo=",
+        "lastModified": 1652574713,
+        "narHash": "sha256-HQw5VtHI4uYvWfwXtDwupP8SV/efZa3Vot5VNbH0RRU=",
         "owner": "chessai",
         "repo": "nix-std",
-        "rev": "8b8d32582e298da2c15b4c13ca48ba7994ef96df",
+        "rev": "082f38023b68f93cd3a6e3a8ddda54d3f5487c52",
         "type": "github"
       },
       "original": {
@@ -48,11 +48,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1651058742,
-        "narHash": "sha256-oH4vje8RnJVwHD5lon3dTL4LmRKEwONQFOH74oxkta4=",
+        "lastModified": 1654007547,
+        "narHash": "sha256-G812EeXZeGeGjkAvbTleGwcKFCGxdLOQb9aViOWASPc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d146577610c17d7674a2d3e285fc637c520ad344",
+        "rev": "5643714dea562f0161529ab23058562afeff46d0",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -25,10 +25,9 @@
     {
       inherit mkLib;
 
-      overlay = final: prev: myPkgsFor final;
+      overlays.default = final: prev: myPkgsFor final;
 
-      defaultTemplate = self.templates.quick-start;
-      templates = {
+      templates = rec {
         alt-registry = {
           description = "Build a cargo project with alternative crate registries";
           path = ./examples/alt-registry;
@@ -49,6 +48,7 @@
           path = ./examples/custom-toolchain;
         };
 
+        default = quick-start;
         quick-start = {
           description = "Build a cargo project";
           path = ./examples/quick-start;
@@ -79,7 +79,7 @@
 
         packages = myPkgs;
 
-        devShell = pkgs.mkShell {
+        devShells.default = pkgs.mkShell {
           nativeBuildInputs = with pkgs; [
             jq
             nixpkgs-fmt

--- a/lib/findCargoFiles.nix
+++ b/lib/findCargoFiles.nix
@@ -5,12 +5,10 @@ src:
 let
   inherit (lib)
     flatten
+    groupBy
     lists
     mapAttrs
     mapAttrsToList;
-
-  # compat(2.5): fallback to lib.groupBy if the builtin version isn't available
-  groupBy = builtins.groupBy or lib.groupBy;
 
   # A specialized form of lib.listFilesRecursive except it will only look
   # for Cargo.toml and config.toml files to keep the intermediate results lean

--- a/lib/vendorCargoRegistries.nix
+++ b/lib/vendorCargoRegistries.nix
@@ -12,12 +12,13 @@ let
     attrNames
     concatStringsSep
     filter
+    groupBy
     hasAttr
     hashString
     head
     length
-    placeholder
     mapAttrs
+    placeholder
     readFile;
 
   inherit (lib)
@@ -29,9 +30,6 @@ let
     mapAttrs'
     mapAttrsToList
     nameValuePair;
-
-  # compat(2.5): fallback to lib.groupBy if the builtin version isn't available
-  groupBy = builtins.groupBy or lib.groupBy;
 
   hash = hashString "sha256";
 

--- a/lib/vendorGitDeps.nix
+++ b/lib/vendorGitDeps.nix
@@ -11,6 +11,7 @@ let
     any
     attrNames
     filter
+    groupBy
     hashString
     head
     isString
@@ -28,9 +29,6 @@ let
     mapAttrsToList
     nameValuePair
     removePrefix;
-
-  # compat(2.5): fallback to lib.groupBy if the builtin version isn't available
-  groupBy = builtins.groupBy or lib.groupBy;
 
   knownGitParams = [ "branch" "rev" "tag" ];
   parseGitUrl = lockUrl:


### PR DESCRIPTION
This drops compatibility for Nix versions below 2.8.1