### PR TITLE
buildDepsOnly: remove (now unnecessary) cargoLock check

### DIFF
--- a/lib/buildDepsOnly.nix
+++ b/lib/buildDepsOnly.nix
@@ -28,9 +28,8 @@ let
 
   path = args.src or throwMsg;
   cargoToml = path + "/Cargo.toml";
-  cargoLock = path + "/Cargo.lock";
   dummySrc =
-    if builtins.pathExists cargoToml && builtins.pathExists cargoLock
+    if builtins.pathExists cargoToml
     then mkDummySrc args
     else throwMsg;
 in


### PR DESCRIPTION
* Previously we would manually copy over any Cargo.lock file from the
  source to the dummified source
* Now, `mkDummySrc` will implicitly copy the file if it is present, or
  ignore it if missing, so this check is a bit overzealous now
* Loosening this check also allows callers to sneak in their own
  Cargo.lock file (e.g. through a patch phase) while still avoiding IFD

Related to #18 #32 