### PR TITLE
Import groupBy from lib not builtins

### DIFF
--- a/lib/vendorCargoRegistries.nix
+++ b/lib/vendorCargoRegistries.nix
@@ -11,7 +11,6 @@ let
     attrNames
     concatStringsSep
     filter
-    groupBy
     hasAttr
     hashString
     head
@@ -25,6 +24,7 @@ let
     concatStrings
     escapeShellArg
     flatten
+    groupBy
     hasPrefix
     mapAttrs'
     mapAttrsToList

--- a/lib/vendorGitDeps.nix
+++ b/lib/vendorGitDeps.nix
@@ -10,7 +10,6 @@ let
     any
     attrNames
     filter
-    groupBy
     hashString
     head
     isString
@@ -22,6 +21,7 @@ let
     concatMapStrings
     concatStrings
     escapeShellArg
+    groupBy
     hasPrefix
     last
     mapAttrs'


### PR DESCRIPTION
* lib.groupBy will default to builtins.groupBy if available, so it is
  safer to use

Fixes #41 