### PR TITLE
Add .overrideToolchain convenience method

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   tests:
     strategy:
+      # Allow other jobs to finish building and cache properly before bailing
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Added
+* Added `.overrideToolchain` as a convenience for using a custom rust toolchain
+
 ## [0.5.0] - 2022-06-12
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -327,12 +327,16 @@ crane.mkLib (import nixpkgs { system = "armv7l-linux"; })
 
 Specific inputs can be overridden for the entire library via the
 `overrideScope'` API as follows. For more information, see the [API docs] for
-`mkLib` or checkout the [custom-toolchain] example.
+`mkLib`/`overrideToolchain`, or checkout the [custom-toolchain] example.
 
 ```nix
 crane.lib.${system}.overrideScope' (final: prev: {
-  cargo = myCustomCargoVersion;
+  cargo-tarpaulin = myCustomCargoTarpaulinVersion;
 })
+```
+
+```nix
+crane.lib.${system}.overrideToolchain myCustomToolchain
 ```
 
 ### My custom rust flags are getting ignored

--- a/docs/API.md
+++ b/docs/API.md
@@ -17,9 +17,12 @@ it across all of nixpkgs, consider using `overrideScope'`:
 
 ```nix
 (mkLib pkgs).overrideScope' (final: prev: {
-  cargo = myCustomCargoVersion;
+  cargo-tarpaulin = myCustomCargoTarpaulinVersion;
 })
 ```
+
+To overlay an entire rust toolchain (e.g. `cargo`, `rustc`, `clippy`, `rustfmt`,
+etc.) consider using `overrideToolchain`.
 
 ## `lib`
 
@@ -562,6 +565,19 @@ build caches. More specifically:
 #### Optional attributes
 * `cargoLock`: a path to a Cargo.lock file
   - Default value: `src + /Cargo.lock`
+
+### `lib.overrideToolchain`
+
+`overrideToolchain :: drv -> set`
+
+A convenience method to override and use tools (like `cargo`, `clippy`,
+`rustfmt`, `rustc`, etc.) from one specific toolchain. The input should be a
+single derivation which contains all the tools as binaries. For example, this
+can be the output of `oxalica/rust-overlay`.
+
+```nix
+crane.lib.${system}.overrideToolchain myCustomToolchain
+```
 
 ### `lib.registryFromDownloadUrl`
 

--- a/examples/cross-musl/flake.nix
+++ b/examples/cross-musl/flake.nix
@@ -32,12 +32,7 @@
           targets = [ "x86_64-unknown-linux-musl" ];
         };
 
-        craneLib = (crane.mkLib pkgs).overrideScope' (final: prev: {
-          cargo = rustToolchain;
-          clippy = rustToolchain;
-          rustc = rustToolchain;
-          rustfmt = rustToolchain;
-        });
+        craneLib = (crane.mkLib pkgs).overrideToolchain rustToolchain;
 
         my-crate = craneLib.buildPackage {
           src = ./.;

--- a/examples/cross-rust-overlay/flake.nix
+++ b/examples/cross-rust-overlay/flake.nix
@@ -35,12 +35,7 @@
           targets = [ "aarch64-unknown-linux-gnu" ];
         };
 
-        craneLib = (crane.mkLib pkgs).overrideScope' (final: prev: {
-          cargo = rustToolchain;
-          clippy = rustToolchain;
-          rustc = rustToolchain;
-          rustfmt = rustToolchain;
-        });
+        craneLib = (crane.mkLib pkgs).overrideToolchain rustToolchain;
 
         # Note: we have to use the `callPackage` approach here so that Nix
         # can "splice" the packages in such a way that dependencies are

--- a/examples/cross-rust-overlay/flake.nix
+++ b/examples/cross-rust-overlay/flake.nix
@@ -21,7 +21,8 @@
   };
 
   outputs = { self, nixpkgs, crane, flake-utils, rust-overlay, ... }:
-    flake-utils.lib.eachDefaultSystem (localSystem:
+    # NB: temporarily skip aarch64-darwin since QEMU can't build there on nixpkgs-unstable
+    flake-utils.lib.eachSystem [ "aarch64-linux" "i686-linux" "x86_64-darwin" "x86_64-linux" ] (localSystem:
       let
         # Replace with the system you want to build for
         crossSystem = "aarch64-linux";

--- a/examples/custom-toolchain/flake.nix
+++ b/examples/custom-toolchain/flake.nix
@@ -36,11 +36,7 @@
         # pkgs (which would require rebuidling anything else which uses rust).
         # Instead, we just want to update the scope that crane will use by appending
         # our specific toolchain there.
-        craneLib = (crane.mkLib pkgs).overrideScope' (final: prev: {
-          rustc = rustWithWasiTarget;
-          cargo = rustWithWasiTarget;
-          rustfmt = rustWithWasiTarget;
-        });
+        craneLib = (crane.mkLib pkgs).overrideToolchain rustWithWasiTarget;
 
         my-crate = craneLib.buildPackage {
           src = ./.;

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -31,6 +31,14 @@ lib.makeScope newScope (self:
     findCargoFiles = callPackage ./findCargoFiles.nix { };
     mkCargoDerivation = callPackage ./mkCargoDerivation.nix { };
     mkDummySrc = callPackage ./mkDummySrc.nix { };
+
+    overrideToolchain = toolchain: self.overrideScope' (final: prev: {
+      cargo = toolchain;
+      clippy = toolchain;
+      rustc = toolchain;
+      rustfmt = toolchain;
+    });
+
     registryFromDownloadUrl = callPackage ./registryFromDownloadUrl.nix { };
     registryFromGitIndex = callPackage ./registryFromGitIndex.nix { };
     urlForCargoPackage = callPackage ./urlForCargoPackage.nix { };


### PR DESCRIPTION
This should make it simpler to use a custom rust toolchain without having to remember to override each specific tool.

Fixes #43 