### PR TITLE
Correct docs on disabling CARGO_PROFILE from being used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * **Breaking**: the `$CARGO_PROFILE` environment variable can be used to specify
   which cargo-profile all invocations use (by default `release` will be used).
   Technically breaking if the default command was overridden for any derivation;
-  set `CARGO_PROFILE = null;` to avoid telling cargo to use a release build.
+  set `CARGO_PROFILE = "";` to avoid telling cargo to use a release build.
 * **Breaking**: `cargoTarpaulin` will use the release profile by default
 * All cargo invocations made during the build are automatically logged
 

--- a/checks/default.nix
+++ b/checks/default.nix
@@ -110,6 +110,14 @@ myPkgs // {
   simpleGit = myLib.buildPackage {
     src = ./simple-git;
   };
+  simpleCustomProfile = myLib.buildPackage {
+    src = ./simple;
+    CARGO_PROFILE = "test";
+  };
+  simpleNoProfile = myLib.buildPackage {
+    src = ./simple;
+    CARGO_PROFILE = "";
+  };
 
   simple-nonflake = (import ../default.nix {
     inherit pkgs;

--- a/docs/API.md
+++ b/docs/API.md
@@ -88,13 +88,13 @@ to influence its behavior.
   phase
   - Default value: `"cargo build --profile release --all-targets"`
     * `CARGO_PROFILE` can be set on the derivation to alter which cargo profile
-      is selected; setting it to `null` will omit specifying a profile
+      is selected; setting it to `""` will omit specifying a profile
       altogether.
 * `cargoCheckCommand`: A cargo (check) invocation to run during the derivation's build
   phase (in order to cache additional artifacts)
   - Default value: `"cargo build --profile release"`
     * `CARGO_PROFILE` can be set on the derivation to alter which cargo profile
-      is selected; setting it to `null` will omit specifying a profile
+      is selected; setting it to `""` will omit specifying a profile
       altogether.
 * `cargoExtraArgs`: additional flags to be passed in the cargo invocation (e.g.
   enabling specific features)
@@ -102,7 +102,7 @@ to influence its behavior.
   phase
   - Default value: `"cargo test --profile release"`
     * `CARGO_PROFILE` can be set on the derivation to alter which cargo profile
-      is selected; setting it to `null` will omit specifying a profile
+      is selected; setting it to `""` will omit specifying a profile
       altogether.
 * `cargoVendorDir`: A path (or derivation) of vendored cargo sources which can
   be consumed without network access. Directory structure should basically
@@ -159,7 +159,7 @@ log.
   phase
   - Default value: `"cargo build --profile release"`
     * `CARGO_PROFILE` can be set on the derivation to alter which cargo profile
-      is selected; setting it to `null` will omit specifying a profile
+      is selected; setting it to `""` will omit specifying a profile
       altogether.
 * `cargoExtraArgs`: additional flags to be passed in the cargo invocation (e.g.
   enabling specific features)
@@ -209,7 +209,7 @@ its behavior.
   phase
   - Default value: `"cargo build --profile release"`
     * `CARGO_PROFILE` can be set on the derivation to alter which cargo profile
-      is selected; setting it to `null` will omit specifying a profile
+      is selected; setting it to `""` will omit specifying a profile
       altogether.
 * `cargoExtraArgs`: additional flags to be passed in the cargo invocation (e.g.
   enabling specific features)
@@ -218,7 +218,7 @@ its behavior.
   phase
   - Default value: `"cargo test --profile release"`
     * `CARGO_PROFILE` can be set on the derivation to alter which cargo profile
-      is selected; setting it to `null` will omit specifying a profile
+      is selected; setting it to `""` will omit specifying a profile
       altogether.
 * `cargoVendorDir`: A path (or derivation) of vendored cargo sources which can
   be consumed without network access. Directory structure should basically
@@ -257,7 +257,7 @@ Except where noted below, all derivation attributes are delegated to
 * `cargoBuildCommand` will be set to run `cargo clippy --profile release
   --all-targets` for the workspace.
   - `CARGO_PROFILE` can be set on the derivation to alter which cargo profile
-    is selected; setting it to `null` will omit specifying a profile
+    is selected; setting it to `""` will omit specifying a profile
     altogether.
 * `cargoExtraArgs` will have `cargoClippyExtraArgs` appended to it
   - Default value: `""`
@@ -340,7 +340,7 @@ Except where noted below, all derivation attributes are delegated to
 * `cargoBuildCommand` will be set to run `cargo tarpaulin --profile release` in
   the workspace.
   - `CARGO_PROFILE` can be set on the derivation to alter which cargo profile is
-    selected; setting it to `null` will omit specifying a profile altogether.
+    selected; setting it to `""` will omit specifying a profile altogether.
 * `cargoExtraArgs` will have `cargoTarpaulinExtraArgs` appended to it
   - Default value: `""`
 * `doCheck` is disabled
@@ -765,7 +765,7 @@ worth documenting them just in case:
   - Note: a default value of `$CARGO_PROFILE` is set via
     `configureCargoCommonVarsHook`. You can set `CARGO_PROFILE = "something"` in
     your derivation to change which profile is used, or set `CARGO_PROFILE =
-    null;` to omit it altogether.
+    "";` to omit it altogether.
 
 ### `configureCargoCommonVarsHook`
 

--- a/pkgs/configureCargoCommonVarsHook.sh
+++ b/pkgs/configureCargoCommonVarsHook.sh
@@ -16,7 +16,7 @@ configureCargoCommonVars() {
 
   # Used by `cargoWithProfile` to specify a cargo profile to use.
   # Not exported since it is not natively understood by cargo.
-  CARGO_PROFILE=${CARGO_PROFILE:-release}
+  CARGO_PROFILE=${CARGO_PROFILE-release}
 }
 
 # NB: run after patching, but before other configure hooks so that we can set


### PR DESCRIPTION
Fixes a few issues with using `CARGO_PROFILE`

* Correct the docs that the environment variable needs to be set to an empty string (not null) to actually be disabled
  - Nix appears to skip setting null environment variables which makes it look like the variable wasn't set to begin with
* Also correct the behavior of setting `CARGO_PROFILE` by default, specifically only set the default value if the variable is unset (but if it is set and empty, leave it as is)