### PR TITLE
Add support for cargo audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Unreleased
 
 ### Added
+* Added `cargoAudit` for running [cargo-audit](https://crates.io/crates/cargo-audit)
+  with a provided advisory database instance.
+
+### Added
 * Added `cargoNextest` for running tests via [cargo-nextest](https://nexte.st/)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Unreleased
 
 ### Added
+* Added `cargoNextest` for running tests via [cargo-nextest](https://nexte.st/)
 * Added `cargoAudit` for running [cargo-audit](https://crates.io/crates/cargo-audit)
   with a provided advisory database instance.
-
-### Added
-* Added `cargoNextest` for running tests via [cargo-nextest](https://nexte.st/)
 
 ### Changed
 * **Breaking**: the `--workspace` flag is no longer set for all cargo commands

--- a/checks/default.nix
+++ b/checks/default.nix
@@ -35,9 +35,6 @@ myPkgs // {
 
   cargoAudit = myLib.cargoAudit {
     src = ./simple;
-    cargoArtifacts = myLib.buildDepsOnly {
-      src = ./simple;
-    };
     advisory-db = pkgs.fetchFromGitHub {
       owner = "rustsec";
       repo = "advisory-db";

--- a/checks/default.nix
+++ b/checks/default.nix
@@ -35,8 +35,10 @@ myPkgs // {
 
   cargoAudit = myLib.cargoAudit {
     src = ./simple;
+    cargoArtifacts = myLib.buildDepsOnly {
+      src = ./simple;
+    };
     advisory-db = pkgs.fetchFromGitHub {
-#      url = "github:rustsec/advisory-db";
       owner = "rustsec";
       repo = "advisory-db";
       rev = "36df8a4efc6f2da4ccc7ced0d431136f473b2001";

--- a/checks/default.nix
+++ b/checks/default.nix
@@ -33,6 +33,17 @@ myPkgs // {
     cargoArtifacts = self.cargoFmt;
   };
 
+  cargoAudit = myLib.cargoAudit {
+    src = ./simple;
+    advisory-db = pkgs.fetchFromGitHub {
+#      url = "github:rustsec/advisory-db";
+      owner = "rustsec";
+      repo = "advisory-db";
+      rev = "36df8a4efc6f2da4ccc7ced0d431136f473b2001";
+      sha256 = "sha256-9eSrCrsSNyl79JMH7LrlCpn9a8lYJ01daZNxUDBKMEo=";
+    };
+  };
+
   cargoTarpaulin = lib.optionalAttrs x64Linux (myLib.cargoTarpaulin {
     src = ./simple;
   });

--- a/docs/API.md
+++ b/docs/API.md
@@ -184,6 +184,8 @@ workspace.
 
 Except where noted below, all derivation attributes are delegated to
 `cargoBuild`, and can be used to influence its behavior.
+* `cargoVendorDir` will be instantiated via `vendorCargoDeps` if not specified
+  - `cargoAuditExtraArgs` will be removed before delegating to `vendorCargoDeps`
 * `advisory-db` will be passed to the call cargo-audit as the advisory database
   (a git repo).
 * `cargoBuildCommand` will be set to run `cargo audit -n -d ${advisory-db}` in
@@ -191,6 +193,7 @@ Except where noted below, all derivation attributes are delegated to
 * `cargoExtraArgs` will have `cargoAuditExtraArgs` appended to it
   - Default value: `""`
 * `doCheck` is disabled
+* `doInstallCargoArtifacts` is disabled
 * `pnameSuffix` will be set to `"-audit"`
 
 #### Optional attributes

--- a/docs/API.md
+++ b/docs/API.md
@@ -176,6 +176,40 @@ log.
 The following hooks are automatically added as native build inputs:
 * `installFromCargoBuildLogHook`
 
+### `lib.cargoAudit`
+`cargoAudi :: set -> drv`
+
+Create a derivation which will run a `cargo audit` invocation in a cargo
+workspace.
+
+Except where noted below, all derivation attributes are delegated to
+`cargoBuild`, and can be used to influence its behavior.
+* `cargoBuildCommand` will be set to run `cargo audit -n -d ${advisory-db}` in
+  the workspace.
+* `cargoExtraArgs` will have `cargoAuditExtraArgs` appended to it
+  - Default value: `""`
+* `doCheck` is disabled
+* `pnameSuffix` will be set to `"-audit"`
+* `advisory-db` will be passed to the call cargo-audit as the advisory database
+  (a git repo).
+
+#### Optional attributes
+* `cargoAuditExtraArgs`: additional flags to be passed in the cargo-audit invocation
+  - Default value: `""`
+* `cargoExtraArgs`: additional flags to be passed in the cargo invocation
+  - Default value: `""`
+
+#### Native build dependencies
+The `cargo-audit` package is automatically appended as a native build input to any
+other `nativeBuildInputs` specified by the caller.
+
+#### Remove attributes
+The following attributes will be removed before being lowered to
+`cargoBuild`. If you absolutely need these attributes present as
+environment variables during the build, you can bring them back via
+`.overrideAttrs`.
+* `cargoAuditExtraArgs`
+
 ### `lib.cargoBuild`
 
 `cargoBuild :: set -> drv`

--- a/docs/API.md
+++ b/docs/API.md
@@ -177,21 +177,21 @@ The following hooks are automatically added as native build inputs:
 * `installFromCargoBuildLogHook`
 
 ### `lib.cargoAudit`
-`cargoAudi :: set -> drv`
+`cargoAudit :: set -> drv`
 
 Create a derivation which will run a `cargo audit` invocation in a cargo
 workspace.
 
 Except where noted below, all derivation attributes are delegated to
 `cargoBuild`, and can be used to influence its behavior.
+* `advisory-db` will be passed to the call cargo-audit as the advisory database
+  (a git repo).
 * `cargoBuildCommand` will be set to run `cargo audit -n -d ${advisory-db}` in
   the workspace.
 * `cargoExtraArgs` will have `cargoAuditExtraArgs` appended to it
   - Default value: `""`
 * `doCheck` is disabled
 * `pnameSuffix` will be set to `"-audit"`
-* `advisory-db` will be passed to the call cargo-audit as the advisory database
-  (a git repo).
 
 #### Optional attributes
 * `cargoAuditExtraArgs`: additional flags to be passed in the cargo-audit invocation

--- a/docs/API.md
+++ b/docs/API.md
@@ -184,8 +184,6 @@ workspace.
 
 Except where noted below, all derivation attributes are delegated to
 `cargoBuild`, and can be used to influence its behavior.
-* `cargoVendorDir` will be instantiated via `vendorCargoDeps` if not specified
-  - `cargoAuditExtraArgs` will be removed before delegating to `vendorCargoDeps`
 * `advisory-db` will be passed to the call cargo-audit as the advisory database
   (a git repo).
 * `cargoBuildCommand` will be set to run `cargo audit -n -d ${advisory-db}` in

--- a/examples/quick-start/flake.nix
+++ b/examples/quick-start/flake.nix
@@ -65,7 +65,7 @@
 
           # Audit dependencies
           my-crate-audit = craneLib.cargoAudit {
-            inherit src cargoArtifacts advisory-db;
+            inherit src advisory-db;
           };
 
           # Run tests with cargo-nextest

--- a/examples/quick-start/flake.nix
+++ b/examples/quick-start/flake.nix
@@ -65,7 +65,7 @@
 
           # Audit dependencies
           my-crate-audit = craneLib.cargoAudit {
-            inherit src, cargoArtifacts, advisory-db;
+            inherit src cargoArtifacts advisory-db;
           };
 
           # Run tests with cargo-nextest

--- a/examples/quick-start/flake.nix
+++ b/examples/quick-start/flake.nix
@@ -10,9 +10,14 @@
     };
 
     flake-utils.url = "github:numtide/flake-utils";
+
+    advisory-db = {
+      url = "github:rustsec/advisory-db";
+      flake = false;
+    };
   };
 
-  outputs = { self, nixpkgs, crane, flake-utils, ... }:
+  outputs = { self, nixpkgs, crane, flake-utils, advisory-db, ... }:
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = import nixpkgs {
@@ -55,6 +60,12 @@
           # Check formatting
           my-crate-fmt = craneLib.cargoFmt {
             inherit src;
+          };
+
+
+          # Audit dependencies
+          my-crate-audit = craneLib.cargoAudit {
+            inherit src, cargoArtifacts, advisory-db;
           };
 
           # Run tests with cargo-nextest

--- a/flake.lock
+++ b/flake.lock
@@ -33,11 +33,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1658644204,
-        "narHash": "sha256-MWyfCH9K3eVTXJUxBi67OQSAh9jJAnvWklM6qm4j8w8=",
+        "lastModified": 1658311025,
+        "narHash": "sha256-GqagY5YmaZB3YaO41kKcQhe5RcpS83wnsW8iCu5Znqo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2f0c3be57c348f4cfd8820f2d189e29a685d9c41",
+        "rev": "cd8d1784506a7c7eb0796772b73437e0b82fad57",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -33,11 +33,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1658311025,
-        "narHash": "sha256-GqagY5YmaZB3YaO41kKcQhe5RcpS83wnsW8iCu5Znqo=",
+        "lastModified": 1658644204,
+        "narHash": "sha256-MWyfCH9K3eVTXJUxBi67OQSAh9jJAnvWklM6qm4j8w8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "cd8d1784506a7c7eb0796772b73437e0b82fad57",
+        "rev": "2f0c3be57c348f4cfd8820f2d189e29a685d9c41",
         "type": "github"
       },
       "original": {

--- a/lib/cargoAudit.nix
+++ b/lib/cargoAudit.nix
@@ -1,6 +1,5 @@
 { cargoBuild
 , cargo-audit
-, vendorCargoDeps
 ,
 }: { cargoAuditExtraArgs ? ""
    , cargoExtraArgs ? ""
@@ -11,8 +10,6 @@ let
   args = builtins.removeAttrs origArgs [ "cargoAuditExtraArgs" ];
 in
 cargoBuild (args // {
-  cargoVendorDir = args.cargoVendorDir or (vendorCargoDeps args);
-
   cargoArtifacts = null;
   cargoBuildCommand = "cargo audit -n -d ${advisory-db}";
   cargoExtraArgs = "${cargoExtraArgs} ${cargoAuditExtraArgs}";

--- a/lib/cargoAudit.nix
+++ b/lib/cargoAudit.nix
@@ -1,7 +1,8 @@
 { cargoBuild
 , cargo-audit
 ,
-}: { cargoAuditExtraArgs ? ""
+}: { cargoArtifacts
+   , cargoAuditExtraArgs ? ""
    , cargoExtraArgs ? ""
    , advisory-db
    , ...
@@ -11,7 +12,7 @@ let
 in
 cargoBuild (args
   // {
-  cargoArtifacts = null;
+  inherit cargoArtifacts;
   cargoBuildCommand = "cargo audit -n -d ${advisory-db}";
   cargoExtraArgs = "${cargoExtraArgs} ${cargoAuditExtraArgs}";
 

--- a/lib/cargoAudit.nix
+++ b/lib/cargoAudit.nix
@@ -1,5 +1,5 @@
 { cargoBuild
-, audit
+, cargo-audit
 }:
 
 { cargoArtifacts
@@ -12,12 +12,11 @@ let
 in
 cargoBuild (args // {
   inherit cargoArtifacts;
-  pnameSuffix = "-audit";
-
   cargoBuildCommand = "cargo audit";
   cargoExtraArgs = "${cargoExtraArgs} ${cargoAuditExtraArgs}";
 
-  nativeBuildInputs = (args.nativeBuildInputs or [ ]) ++ [ audit ];
-
   doCheck = false; # We don't need to run tests to benefit from `cargo audit`
+  pnameSuffix = "-audit";
+
+  nativeBuildInputs = (args.nativeBuildInputs or [ ]) ++ [ cargo-audit ];
 })

--- a/lib/cargoAudit.nix
+++ b/lib/cargoAudit.nix
@@ -1,0 +1,23 @@
+{ cargoBuild
+, audit
+}:
+
+{ cargoArtifacts
+, cargoAuditExtraArgs ? ""
+, cargoExtraArgs ? ""
+, ...
+}@origArgs:
+let
+  args = builtins.removeAttrs origArgs [ "cargoAuditExtraArgs" ];
+in
+cargoBuild (args // {
+  inherit cargoArtifacts;
+  pnameSuffix = "-audit";
+
+  cargoBuildCommand = "cargo audit";
+  cargoExtraArgs = "${cargoExtraArgs} ${cargoAuditExtraArgs}";
+
+  nativeBuildInputs = (args.nativeBuildInputs or [ ]) ++ [ audit ];
+
+  doCheck = false; # We don't need to run tests to benefit from `cargo audit`
+})

--- a/lib/cargoAudit.nix
+++ b/lib/cargoAudit.nix
@@ -1,7 +1,7 @@
 { cargoBuild
 , cargo-audit
 ,
-}: { cargoArtifacts
+}: { cargoVendorDir
    , cargoAuditExtraArgs ? ""
    , cargoExtraArgs ? ""
    , advisory-db
@@ -12,11 +12,13 @@ let
 in
 cargoBuild (args
   // {
-  inherit cargoArtifacts;
+  inherit cargoVendorDir;
+  cargoArtifacts = null;
   cargoBuildCommand = "cargo audit -n -d ${advisory-db}";
   cargoExtraArgs = "${cargoExtraArgs} ${cargoAuditExtraArgs}";
 
   doCheck = false; # We don't need to run tests to benefit from `cargo audit`
+  doInstallCargoArtifacts = false; # We don't expect to/need to install artifacts
   pnameSuffix = "-audit";
 
   nativeBuildInputs = (args.nativeBuildInputs or [ ]) ++ [ cargo-audit ];

--- a/lib/cargoAudit.nix
+++ b/lib/cargoAudit.nix
@@ -1,8 +1,7 @@
 { cargoBuild
 , cargo-audit
 ,
-}: { cargoArtifacts
-   , cargoAuditExtraArgs ? ""
+}: { cargoAuditExtraArgs ? ""
    , cargoExtraArgs ? ""
    , advisory-db
    , ...
@@ -12,7 +11,7 @@ let
 in
 cargoBuild (args
   // {
-  inherit cargoArtifacts;
+  cargoArtifacts = null;
   cargoBuildCommand = "cargo audit -n -d ${advisory-db}";
   cargoExtraArgs = "${cargoExtraArgs} ${cargoAuditExtraArgs}";
 

--- a/lib/cargoAudit.nix
+++ b/lib/cargoAudit.nix
@@ -1,18 +1,19 @@
 { cargoBuild
 , cargo-audit
-}:
-
-{ cargoArtifacts
-, cargoAuditExtraArgs ? ""
-, cargoExtraArgs ? ""
-, ...
-}@origArgs:
+,
+}: { cargoArtifacts
+   , cargoAuditExtraArgs ? ""
+   , cargoExtraArgs ? ""
+   , advisory-db
+   , ...
+   } @ origArgs:
 let
   args = builtins.removeAttrs origArgs [ "cargoAuditExtraArgs" ];
 in
-cargoBuild (args // {
+cargoBuild (args
+  // {
   inherit cargoArtifacts;
-  cargoBuildCommand = "cargo audit";
+  cargoBuildCommand = "cargo audit -n -d ${advisory-db}";
   cargoExtraArgs = "${cargoExtraArgs} ${cargoAuditExtraArgs}";
 
   doCheck = false; # We don't need to run tests to benefit from `cargo audit`

--- a/lib/cargoAudit.nix
+++ b/lib/cargoAudit.nix
@@ -1,8 +1,8 @@
 { cargoBuild
 , cargo-audit
+, vendorCargoDeps
 ,
-}: { cargoVendorDir
-   , cargoAuditExtraArgs ? ""
+}: { cargoAuditExtraArgs ? ""
    , cargoExtraArgs ? ""
    , advisory-db
    , ...
@@ -10,9 +10,9 @@
 let
   args = builtins.removeAttrs origArgs [ "cargoAuditExtraArgs" ];
 in
-cargoBuild (args
-  // {
-  inherit cargoVendorDir;
+cargoBuild (args // {
+  cargoVendorDir = args.cargoVendorDir or (vendorCargoDeps args);
+
   cargoArtifacts = null;
   cargoBuildCommand = "cargo audit -n -d ${advisory-db}";
   cargoExtraArgs = "${cargoExtraArgs} ${cargoAuditExtraArgs}";

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -16,6 +16,7 @@ in
   buildPackage = callPackage ./buildPackage.nix { };
   cargoBuild = callPackage ./cargoBuild.nix { };
   cargoClippy = callPackage ./cargoClippy.nix { };
+  cargoAudit = callPackage ./cargoAudit.nix { };
   cargoFmt = callPackage ./cargoFmt.nix { };
   cargoNextest = callPackage ./cargoNextest.nix { };
   cargoTarpaulin = callPackage ./cargoTarpaulin.nix { };

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -14,9 +14,9 @@ in
 
   buildDepsOnly = callPackage ./buildDepsOnly.nix { };
   buildPackage = callPackage ./buildPackage.nix { };
+  cargoAudit = callPackage ./cargoAudit.nix { };
   cargoBuild = callPackage ./cargoBuild.nix { };
   cargoClippy = callPackage ./cargoClippy.nix { };
-  cargoAudit = callPackage ./cargoAudit.nix { };
   cargoFmt = callPackage ./cargoFmt.nix { };
   cargoNextest = callPackage ./cargoNextest.nix { };
   cargoTarpaulin = callPackage ./cargoTarpaulin.nix { };


### PR DESCRIPTION
This adds support for cargo-audit as a possible check when using crane. Cargo-audit uses a local clone of a repository of security advisories- this must be provided, but doing so means that crane doesn't need to be updated with repository updates.

Example usage:
```
{
  inputs = {
  ...
    crane = {
      url = "github:ipetkov/crane";
      inputs.nixpkgs.follows = "nixpkgs";
    };
    advisory-db = {
      url = "github:rustsec/advisory-db";
      flake = false;
    };
   ...
  };  
  outputs = {
    self,
    nixpkgs,
    crane,
    advisory-db,
    ...
  }:
    flake-utils.lib.eachDefaultSystem (system: let
      pkgs = import nixpkgs {inherit system overlays;};
      craneLib = (crane.mkLib pkgs).overrideToolchain rust;
      src = ./.;
      ...

    in rec {
      ...
      
      checks =
        {
          # Check formatting
          app-fmt = craneLib.cargoFmt {
            inherit src;
          };
         app-audit = craneLib.cargoAudit {
            inherit src;
            inherit advisory-db;
          }; 
          ...
        }
        ...
    });
}
```

I'm happy to consider alternatives, if there's something that seems to fit better/is more idiomatic.

[EDIT: updated example]