### PR TITLE
cargoAudit: filter source to only include Cargo.lock files

### DIFF
--- a/checks/cargoAudit.nix
+++ b/checks/cargoAudit.nix
@@ -1,0 +1,29 @@
+{ cargoAudit
+, fetchFromGitHub
+, lib
+, linkFarmFromDrvs
+}:
+
+let
+  auditWith = pname: src: cargoAudit {
+    inherit src pname;
+    advisory-db = fetchFromGitHub {
+      owner = "rustsec";
+      repo = "advisory-db";
+      rev = "36df8a4efc6f2da4ccc7ced0d431136f473b2001";
+      sha256 = "sha256-9eSrCrsSNyl79JMH7LrlCpn9a8lYJ01daZNxUDBKMEo=";
+    };
+  };
+in
+linkFarmFromDrvs "cleanCargoToml" [
+  # Check against all different kinds of workspace types to make sure it works
+  (auditWith "simple" ./simple)
+  (auditWith "simple-git" ./simple-git)
+
+  (auditWith "gitRevNoRef" ./gitRevNoRef)
+  (auditWith "git-overlapping" ./git-overlapping)
+
+  (auditWith "workspace" ./workspace)
+  (auditWith "workspace-git" ./workspace-git)
+  (auditWith "workspace-root" ./workspace-root)
+]

--- a/checks/default.nix
+++ b/checks/default.nix
@@ -33,15 +33,7 @@ myPkgs // {
     cargoArtifacts = self.cargoFmt;
   };
 
-  cargoAudit = myLib.cargoAudit {
-    src = ./simple;
-    advisory-db = pkgs.fetchFromGitHub {
-      owner = "rustsec";
-      repo = "advisory-db";
-      rev = "36df8a4efc6f2da4ccc7ced0d431136f473b2001";
-      sha256 = "sha256-9eSrCrsSNyl79JMH7LrlCpn9a8lYJ01daZNxUDBKMEo=";
-    };
-  };
+  cargoAuditTests = callPackage ./cargoAudit.nix { };
 
   cargoTarpaulin = lib.optionalAttrs x64Linux (myLib.cargoTarpaulin {
     src = ./simple;

--- a/docs/API.md
+++ b/docs/API.md
@@ -184,21 +184,37 @@ workspace.
 
 Except where noted below, all derivation attributes are delegated to
 `cargoBuild`, and can be used to influence its behavior.
-* `advisory-db` will be passed to the call cargo-audit as the advisory database
-  (a git repo).
+* `cargoArtifacts` will be set to `null` as they are not needed
 * `cargoBuildCommand` will be set to run `cargo audit -n -d ${advisory-db}` in
   the workspace.
 * `cargoExtraArgs` will have `cargoAuditExtraArgs` appended to it
   - Default value: `""`
+* `cargoVendorDir` will be set to `null` as it is not needed
 * `doCheck` is disabled
 * `doInstallCargoArtifacts` is disabled
 * `pnameSuffix` will be set to `"-audit"`
+* `src` will be filtered to only keep `Cargo.lock` files
+
+#### Required attributes
+* `advisory-db`: A path (or derivation) which contains the advisory database
+  - It is possible to track the advisory database as a flake input and avoid
+    having to manually update hashes or specific revisions to check out
+* `src`: The project source to audit, it must contain a `Cargo.lock` file
+  - Note that the source will internally be filtered to omit any files besides
+    `Cargo.lock`. This avoids having to audit the project again until either the
+    advisory database or the dependencies change.
 
 #### Optional attributes
 * `cargoAuditExtraArgs`: additional flags to be passed in the cargo-audit invocation
   - Default value: `""`
 * `cargoExtraArgs`: additional flags to be passed in the cargo invocation
   - Default value: `""`
+* `pname`: the name of the derivation, will _not_ be introspected from a
+  `Cargo.toml` file
+  - Default value: `"cargo"` (to give a final name of `"cargo-audit"`)
+* `version`: the version of the derivation, will _not_ be introspected from a
+  `Cargo.toml` file
+  - Default value: `"0.0.0"`
 
 #### Native build dependencies
 The `cargo-audit` package is automatically appended as a native build input to any

--- a/docs/API.md
+++ b/docs/API.md
@@ -209,9 +209,9 @@ Except where noted below, all derivation attributes are delegated to
   - Default value: `""`
 * `cargoExtraArgs`: additional flags to be passed in the cargo invocation
   - Default value: `""`
-* `pname`: the name of the derivation, will _not_ be introspected from a
+* `pname`: the name of the derivation; will _not_ be introspected from a
   `Cargo.toml` file
-  - Default value: `"cargo"` (to give a final name of `"cargo-audit"`)
+  - Default value: `"crate"`
 * `version`: the version of the derivation, will _not_ be introspected from a
   `Cargo.toml` file
   - Default value: `"0.0.0"`

--- a/lib/cargoAudit.nix
+++ b/lib/cargoAudit.nix
@@ -1,22 +1,39 @@
-{ cargoBuild
-, cargo-audit
-,
-}: { cargoAuditExtraArgs ? ""
-   , cargoExtraArgs ? ""
-   , advisory-db
-   , ...
-   } @ origArgs:
+{ cargo-audit
+, cargoBuild
+, lib
+}:
+
+{ advisory-db
+, cargoAuditExtraArgs ? ""
+, cargoExtraArgs ? ""
+, src
+, ...
+}@origArgs:
 let
   args = builtins.removeAttrs origArgs [ "cargoAuditExtraArgs" ];
 in
 cargoBuild (args // {
-  cargoArtifacts = null;
   cargoBuildCommand = "cargo audit -n -d ${advisory-db}";
   cargoExtraArgs = "${cargoExtraArgs} ${cargoAuditExtraArgs}";
 
+  src = lib.cleanSourceWith {
+    inherit src;
+    # Keep all Cargo.lock files in the source in case the caller wants to
+    # pass a flag to audit a specific one.
+    filter = path: type: type == "directory" || lib.hasSuffix "Cargo.lock" path;
+  };
+
+  cargoArtifacts = null; # Don't need artifacts, just Cargo.lock
+  cargoVendorDir = null; # Don't need dependencies either
   doCheck = false; # We don't need to run tests to benefit from `cargo audit`
   doInstallCargoArtifacts = false; # We don't expect to/need to install artifacts
   pnameSuffix = "-audit";
+
+  # Avoid trying to introspect the Cargo.toml file as it won't exist in the
+  # filtered source (it also might not exist in the original source either).
+  # So just use some placeholders here in case the caller did not set them.
+  pname = args.pname or "cargo";
+  version = args.version or "0.0.0";
 
   nativeBuildInputs = (args.nativeBuildInputs or [ ]) ++ [ cargo-audit ];
 })

--- a/lib/cargoAudit.nix
+++ b/lib/cargoAudit.nix
@@ -32,7 +32,7 @@ cargoBuild (args // {
   # Avoid trying to introspect the Cargo.toml file as it won't exist in the
   # filtered source (it also might not exist in the original source either).
   # So just use some placeholders here in case the caller did not set them.
-  pname = args.pname or "cargo";
+  pname = args.pname or "crate";
   version = args.version or "0.0.0";
 
   nativeBuildInputs = (args.nativeBuildInputs or [ ]) ++ [ cargo-audit ];


### PR DESCRIPTION
## Motivation
Seems like cargo-audit only needs a `Cargo.lock` file and an advisory
  database to run, so we can filter the inputs down even further to
  avoid rebuilds and file copying into the Nix sandbox

## Checklist
- [x] added tests to verify new behavior
- [x] added an example template or updated an existing one
- [x] updated `docs/API.md` with changes
- [x] updated `CHANGELOG.md`

cc @ngerstle-cognite 