### PR TITLE
vendorGitDeps: throw descriptive error if locked revision is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   set `CARGO_PROFILE = "";` to avoid telling cargo to use a release build.
 * **Breaking**: `cargoTarpaulin` will use the release profile by default
 * All cargo invocations made during the build are automatically logged
+* Vendoring git dependencies will throw a descriptive error message if a locked
+  revision is missing from `Cargo.lock` and a hint towards resolution
 
 ## [0.5.1] - 2022-07-20
 


### PR DESCRIPTION
## Motivation
If the `Cargo.lock` file is missing a locked revision for a git dependency we should throw a descriptive error (with a suggestion for resolving it) instead of failing with a weird error.

Fixes #57 

## Checklist
- [ ] added tests to verify new behavior
  * Can't add a good test for this, nix has `builtins.tryEval` but you cannot access the error itself so probably wouldn't be a good test
- [ ] added an example template or updated an existing one
  * Not relevant
- [ ] updated `docs/API.md` with changes
  * Not relevant
- [x] updated `CHANGELOG.md`
