### PR TITLE
cargoClippy: add --all-targets to default cargoClippyExtraArgs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   Technically breaking if the default command was overridden for any derivation;
   set `CARGO_PROFILE = "";` to avoid telling cargo to use a release build.
 * **Breaking**: `cargoTarpaulin` will use the release profile by default
+* **Breaking**: `cargoClippy`'s `cargoClippyExtraArgs` now default to
+  `"--all-targets"` instead of being specified as the cargo command itself. If
+  you have set `cargoClippyExtraArgs` to an explicit value and wish to retain
+  the previous behavior you should prepend `"--all-targets"` to it.
 * All cargo invocations made during the build are automatically logged
 * Vendoring git dependencies will throw a descriptive error message if a locked
   revision is missing from `Cargo.lock` and a hint towards resolution

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Here's how we can set up our flake to achieve our goals:
           # Again we apply some extra arguments only to this derivation
           # and not every where else. In this case we add some clippy flags
           inherit cargoArtifacts;
-          cargoClippyExtraArgs = "-- --deny warnings";
+          cargoClippyExtraArgs = "--all-targets -- --deny warnings";
         });
 
         # Build the actual crate itself, reusing the dependency
@@ -260,7 +260,7 @@ build.
           # Again we apply some extra arguments only to this derivation
           # and not every where else. In this case we add some clippy flags
           inherit cargoArtifacts;
-          cargoClippyExtraArgs = "-- --deny warnings";
+          cargoClippyExtraArgs = "--all-targets -- --deny warnings";
         });
 
         # Next, we want to run the tests and collect code-coverage, _but only if

--- a/checks/clippy/default.nix
+++ b/checks/clippy/default.nix
@@ -18,7 +18,7 @@ linkFarmFromDrvs "clippy-tests" (builtins.attrValues {
     inherit cargoArtifacts src;
     pname = "checkWarnings";
 
-    cargoClippyExtraArgs = "2>clippy.log";
+    cargoClippyExtraArgs = "--all-targets 2>clippy.log";
     installPhaseCommand = ''
       grep 'warning: use of `println!`' <clippy.log
       mkdir -p $out
@@ -30,7 +30,7 @@ linkFarmFromDrvs "clippy-tests" (builtins.attrValues {
     pname = "denyWarnings";
 
     cargoClippyExtraArgs = ''
-      -- --deny warnings 2>clippy.log || [ "0" != "$?" ]
+      --all-targets -- --deny warnings 2>clippy.log || [ "0" != "$?" ]
     '';
     installPhaseCommand = ''
       grep 'error: use of `println!`' <clippy.log

--- a/docs/API.md
+++ b/docs/API.md
@@ -305,13 +305,13 @@ workspace.
 
 Except where noted below, all derivation attributes are delegated to
 `cargoBuild`, and can be used to influence its behavior.
-* `cargoBuildCommand` will be set to run `cargo clippy --profile release
-  --all-targets` for the workspace.
+* `cargoBuildCommand` will be set to run `cargo clippy --profile release` for
+  the workspace.
   - `CARGO_PROFILE` can be set on the derivation to alter which cargo profile
     is selected; setting it to `""` will omit specifying a profile
     altogether.
 * `cargoExtraArgs` will have `cargoClippyExtraArgs` appended to it
-  - Default value: `""`
+  - Default value: `"--all-targets"`
 * `doCheck` is disabled
 * `pnameSuffix` will be set to `"-clippy"`
 
@@ -326,7 +326,7 @@ Except where noted below, all derivation attributes are delegated to
 #### Optional attributes
 * `cargoClippyExtraArgs`: additional flags to be passed in the clippy invocation (e.g.
   deny specific lints)
-  - Default value: `""`
+  - Default value: `"--all-targets"`
 * `cargoExtraArgs`: additional flags to be passed in the cargo invocation (e.g.
   enabling specific features)
   - Default value: `""`

--- a/examples/quick-start/flake.nix
+++ b/examples/quick-start/flake.nix
@@ -54,7 +54,7 @@
           # prevent downstream consumers from building our crate by itself.
           my-crate-clippy = craneLib.cargoClippy {
             inherit cargoArtifacts src;
-            cargoClippyExtraArgs = "-- --deny warnings";
+            cargoClippyExtraArgs = "--all-targets -- --deny warnings";
           };
 
           # Check formatting

--- a/lib/cargoClippy.nix
+++ b/lib/cargoClippy.nix
@@ -3,7 +3,7 @@
 }:
 
 { cargoArtifacts
-, cargoClippyExtraArgs ? ""
+, cargoClippyExtraArgs ? "--all-targets"
 , cargoExtraArgs ? ""
 , ...
 }@origArgs:
@@ -14,7 +14,7 @@ cargoBuild (args // {
   inherit cargoArtifacts;
   pnameSuffix = "-clippy";
 
-  cargoBuildCommand = "cargoWithProfile clippy --all-targets";
+  cargoBuildCommand = "cargoWithProfile clippy";
   cargoExtraArgs = "${cargoExtraArgs} ${cargoClippyExtraArgs}";
 
   nativeBuildInputs = (args.nativeBuildInputs or [ ]) ++ [ clippy ];


### PR DESCRIPTION
## Motivation
This allows callers to opt-out of using `--all-targets` without having to override the entire cargo command itself

Fixes #64 

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [ ] added tests to verify new behavior
- [x] added an example template or updated an existing one
- [x] updated `docs/API.md` with changes
- [x] updated `CHANGELOG.md`
