### PR TITLE
docs: tweak `cargoBuild` docs to mention `doInstallCargoArtifacts`

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -281,6 +281,9 @@ its behavior.
   - Default value: `"${cargoTestCommand} ${cargoExtraArgs}"`
 * `doCheck`: whether the derivation's check phase should be run
   - Default value: `true`
+* `doInstallCargoArtifacts`: controls whether cargo's `target` directory should
+  be copied as an output
+  - Default value: `true`
 * `pname`: package name of the derivation
   - Default value: inherited from calling `crateNameFromCargoToml`
 * `version`: version of the derivation


### PR DESCRIPTION
## Motivation
Tweak `cargoBuild` docs to mention `doInstallCargoArtifacts` to be hopefully less confusing about when cargo artifacts are installed.

Fixes #74 

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [x] updated `docs/API.md` with changes
- [ ] updated `CHANGELOG.md`
