### PR TITLE
mkCargoDerivation: allow ergonomically overriding stdenv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## Changed
+* `mkCargoDerivation` (along with any of its callers like `cargoBuild`,
+  `buildPackage`, etc.) now accept a `stdenv` argument which will override the
+  default environment (coming from `pkgs.stdenv`) for that particular derivation
+
 ## Fixed
 * `cargoAudit` properly keeps any `audit.toml` files when cleaning the source
 

--- a/checks/default.nix
+++ b/checks/default.nix
@@ -142,6 +142,10 @@ myPkgs // {
   simpleOnlyTests = myLib.buildPackage {
     src = ./simple-only-tests;
   };
+  simpleAltStdenv = myLib.buildPackage {
+    src = ./simple;
+    stdenv = pkgs.gcc12Stdenv;
+  };
 
   simple-nonflake = (import ../default.nix {
     inherit pkgs;

--- a/docs/API.md
+++ b/docs/API.md
@@ -645,6 +645,8 @@ This is a fairly low-level abstraction, so consider using `buildPackage` or
     appropriate installation commands for the package being built.
 * `pnameSuffix`: a suffix appended to `pname`
   - Default value: `""`
+* `stdenv`: the standard build environment to use for this derivation
+  - Default value: `pkgs.stdenv`
 
 #### Remove attributes
 The following attributes will be removed before being lowered to
@@ -656,6 +658,7 @@ environment variables during the build, you can bring them back via
 * `checkPhaseCargoCommand`
 * `installPhaseCommand`
 * `pnameSuffix`
+* `stdenv`
 
 #### Native build dependencies and included hooks
 The `cargo` package is automatically appended as a native build input to any

--- a/lib/mkCargoDerivation.nix
+++ b/lib/mkCargoDerivation.nix
@@ -27,14 +27,16 @@ args@{
 , ...
 }:
 let
+  chosenStdenv = args.stdenv or stdenv;
   cleanedArgs = builtins.removeAttrs args [
     "buildPhaseCargoCommand"
     "checkPhaseCargoCommand"
     "installPhaseCommand"
     "pnameSuffix"
+    "stdenv"
   ];
 in
-stdenv.mkDerivation (cleanedArgs // {
+chosenStdenv.mkDerivation (cleanedArgs // {
   pname = "${args.pname}${args.pnameSuffix or ""}";
 
   # Controls whether cargo's `target` directory should be copied as an output


### PR DESCRIPTION
## Motivation
Allow ergonomically overriding stdenv without having to override it for the entire library's scope

Refs #99 

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [x] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [x] updated `docs/API.md` with changes
- [x] updated `CHANGELOG.md`
