### PR TITLE
mkCargoDerivation: add default `configurePhase`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Unreleased
 
 ## Changed
+* **Breaking**: `mkCargoDerivation` now includes a default `configurePhase`
+  which does nothing but run the `preConfigure` and `postConfigure` hooks. This
+  is done to avoid breaking builds by including puts happen to have setup-hooks
+  which try to claim the configure phase (such as `cmake`). To get the old
+  behavior back, set `configurePhase = null;` in the derivation.
 * `mkCargoDerivation` (along with any of its callers like `cargoBuild`,
   `buildPackage`, etc.) now accept a `stdenv` argument which will override the
   default environment (coming from `pkgs.stdenv`) for that particular derivation

--- a/checks/default.nix
+++ b/checks/default.nix
@@ -146,6 +146,13 @@ myPkgs // {
     src = ./simple;
     stdenv = pkgs.gcc12Stdenv;
   };
+  # https://github.com/ipetkov/crane/issues/104
+  simpleWithCmake = myLib.buildPackage {
+    src = ./simple;
+    nativeBuildInputs = with pkgs; [
+      cmake
+    ];
+  };
 
   simple-nonflake = (import ../default.nix {
     inherit pkgs;

--- a/docs/API.md
+++ b/docs/API.md
@@ -631,6 +631,9 @@ This is a fairly low-level abstraction, so consider using `buildPackage` or
 * `checkPhase`: the commands used by the check phase of the derivation
   - Default value: the check phase will run `preCheck` hooks, log and evaluate
     `checkPhaseCargoCommand`, and run `postCheck` hooks
+* `configurePhase`: the commands used by the configure phase of the derivation
+  - Default value: the configure phase will run `preConfigureHooks` hooks, then
+    run `postConfigure` hooks
 * `doInstallCargoArtifacts`: controls whether cargo's `target` directory should
   be copied as an output
   - Default value: `true`

--- a/lib/buildPackage.nix
+++ b/lib/buildPackage.nix
@@ -52,6 +52,7 @@ in
 
   buildPhase = args.buildPhase or ''
     runHook preBuild
+    cargo --version
     ${buildPhaseCargoCommand}
     runHook postBuild
   '';

--- a/lib/mkCargoDerivation.nix
+++ b/lib/mkCargoDerivation.nix
@@ -64,6 +64,12 @@ chosenStdenv.mkDerivation (cleanedArgs // {
     runHook postCheck
   '';
 
+  configurePhase = args.configurePhase or ''
+    runHook preConfigure
+    echo default configurePhase, nothing to do
+    runHook postConfigure
+  '';
+
   installPhase = args.installPhase or ''
     runHook preInstall
     ${installPhaseCommand}


### PR DESCRIPTION
## Motivation
This is done to avoid breaking builds by including puts happen to have setup-hooks which try to claim the configure phase (such as `cmake`).

The old behavior can be brought back by setting `configurePhase = null;` on the derivation.

Fixes #104 

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [x] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [x] updated `docs/API.md` with changes
- [x] updated `CHANGELOG.md`
