### PR TITLE
Add cleanCargoSource and filterCargoSources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Added
 * `cargoDoc` can now be used for building the documentation of a workspace
+* `cleanCargoSource` can now be used to filter sources to only include cargo and
+  Rust files (and avoid rebuilds when irrelevant files change).
+  `filterCargoSources` is the underlying filter implementation and can be
+  composed with other filters
 
 ## Changed
 * **Breaking**: `mkCargoDerivation` now includes a default `configurePhase`

--- a/checks/default.nix
+++ b/checks/default.nix
@@ -142,10 +142,10 @@ myPkgs // {
   nextest = callPackage ./nextest.nix { };
 
   simple = myLib.buildPackage {
-    src = ./simple;
+    src = myLib.cleanCargoSource ./simple;
   };
   simpleGit = myLib.buildPackage {
-    src = ./simple-git;
+    src = myLib.cleanCargoSource ./simple-git;
   };
   simpleCustomProfile = myLib.buildPackage {
     src = ./simple;
@@ -156,7 +156,7 @@ myPkgs // {
     CARGO_PROFILE = "";
   };
   simpleOnlyTests = myLib.buildPackage {
-    src = ./simple-only-tests;
+    src = myLib.cleanCargoSource ./simple-only-tests;
   };
   simpleAltStdenv = myLib.buildPackage {
     src = ./simple;
@@ -230,17 +230,17 @@ myPkgs // {
   vendorGitSubset = callPackage ./vendorGitSubset.nix { };
 
   workspace = myLib.buildPackage {
-    src = ./workspace;
+    src = myLib.cleanCargoSource ./workspace;
     pname = "workspace";
   };
 
   workspaceRoot = myLib.buildPackage {
-    src = ./workspace-root;
+    src = myLib.cleanCargoSource ./workspace-root;
     pname = "workspace-root";
   };
 
   workspaceGit = myLib.buildPackage {
-    src = ./workspace-git;
+    src = myLib.cleanCargoSource ./workspace-git;
     pname = "workspace-git";
   };
 })

--- a/examples/alt-registry/flake.nix
+++ b/examples/alt-registry/flake.nix
@@ -46,7 +46,7 @@
         ];
 
         my-crate = craneLib.buildPackage {
-          src = ./.;
+          src = craneLib.cleanCargoSource ./.;
 
           # Specific to our example, but not always necessary in the general case.
           nativeBuildInputs = with pkgs; [

--- a/examples/cross-musl/flake.nix
+++ b/examples/cross-musl/flake.nix
@@ -35,7 +35,7 @@
         craneLib = (crane.mkLib pkgs).overrideToolchain rustToolchain;
 
         my-crate = craneLib.buildPackage {
-          src = ./.;
+          src = craneLib.cleanCargoSource ./.;
 
           CARGO_BUILD_TARGET = "x86_64-unknown-linux-musl";
           CARGO_BUILD_RUSTFLAGS = "-C target-feature=+crt-static";

--- a/examples/cross-rust-overlay/flake.nix
+++ b/examples/cross-rust-overlay/flake.nix
@@ -55,7 +55,7 @@
           , stdenv
           }:
           craneLib.buildPackage {
-            src = ./.;
+            src = craneLib.cleanCargoSource ./.;
 
             # Build-time tools which are target agnostic. build = host = target = your-machine.
             # Emulators should essentially also go `nativeBuildInputs`. But with some packaging issue,

--- a/examples/custom-toolchain/flake.nix
+++ b/examples/custom-toolchain/flake.nix
@@ -39,7 +39,7 @@
         craneLib = (crane.mkLib pkgs).overrideToolchain rustWithWasiTarget;
 
         my-crate = craneLib.buildPackage {
-          src = ./.;
+          src = craneLib.cleanCargoSource ./.;
 
           cargoExtraArgs = "--target wasm32-wasi";
 

--- a/examples/quick-start-simple/flake.nix
+++ b/examples/quick-start-simple/flake.nix
@@ -19,8 +19,9 @@
           inherit system;
         };
 
-        my-crate = crane.lib.${system}.buildPackage {
-          src = ./.;
+        craneLib = crane.lib.${system};
+        my-crate = craneLib.buildPackage {
+          src = craneLib.cleanCargoSource ./.;
         };
       in
       {

--- a/examples/quick-start/flake.nix
+++ b/examples/quick-start/flake.nix
@@ -27,7 +27,7 @@
         inherit (pkgs) lib;
 
         craneLib = crane.lib.${system};
-        src = ./.;
+        src = craneLib.cleanCargoSource ./.;
 
         # Build *just* the cargo dependencies, so we can reuse
         # all of that work (e.g. via cachix) when running in CI

--- a/lib/cleanCargoSource.nix
+++ b/lib/cleanCargoSource.nix
@@ -1,0 +1,11 @@
+{ filterCargoSources
+, lib
+}:
+
+src: lib.cleanSourceWith {
+  # Apply the default source cleaning from nixpkgs
+  src = lib.cleanSource src;
+
+  # Then add our own filter on top
+  filter = filterCargoSources;
+}

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -21,6 +21,7 @@ in
   cargoFmt = callPackage ./cargoFmt.nix { };
   cargoNextest = callPackage ./cargoNextest.nix { };
   cargoTarpaulin = callPackage ./cargoTarpaulin.nix { };
+  cleanCargoSource = callPackage ./cleanCargoSource.nix { };
   cleanCargoToml = callPackage ./cleanCargoToml.nix { };
   crateNameFromCargoToml = callPackage ./crateNameFromCargoToml.nix { };
 
@@ -32,6 +33,7 @@ in
   downloadCargoPackage = callPackage ./downloadCargoPackage.nix { };
   downloadCargoPackageFromGit = callPackage ./downloadCargoPackageFromGit.nix { };
   findCargoFiles = callPackage ./findCargoFiles.nix { };
+  filterCargoSources = callPackage ./filterCargoSources.nix { };
   mkCargoDerivation = callPackage ./mkCargoDerivation.nix { };
   mkDummySrc = callPackage ./mkDummySrc.nix { };
 

--- a/lib/filterCargoSources.nix
+++ b/lib/filterCargoSources.nix
@@ -1,0 +1,24 @@
+{ lib
+}:
+
+orig_path: type:
+let
+  path = (toString orig_path);
+  base = baseNameOf path;
+  parentDir = baseNameOf (dirOf path);
+
+  matchesSuffix = lib.any (suffix: lib.hasSuffix suffix base) [
+    # Keep rust sources
+    ".rs"
+    # Keep all toml files as they are commonly used to configure other
+    # cargo-based tools
+    ".toml"
+  ];
+
+  # Cargo.toml already captured above
+  isCargoFile = base == "Cargo.lock";
+
+  # .cargo/config.toml already captured above
+  isCargoConfig = parentDir == ".cargo" && base == "config";
+in
+type == "directory" || matchesSuffix || isCargoFile || isCargoConfig


### PR DESCRIPTION
## Motivation
Add `cleanCargoSource` and `filterCargoSources` for easy source filtering. Examples have also been updated to highlight using `cleanCargoSource`, though it is not required.

Fixes #79 

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [x] added tests to verify new behavior
- [x] added an example template or updated an existing one
- [x] updated `docs/API.md` with changes
- [x] updated `CHANGELOG.md`
