### PR TITLE
Copy all files from `./config`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * `mkCargoDerivation` (along with any of its callers like `cargoBuild`,
   `buildPackage`, etc.) now accept a `stdenv` argument which will override the
   default environment (coming from `pkgs.stdenv`) for that particular derivation
+* `mkDummySrc` will now copy all files from `./.cargo/` directory
 
 ## Fixed
 * `cargoAudit` properly keeps any `audit.toml` files when cleaning the source

--- a/docs/API.md
+++ b/docs/API.md
@@ -781,8 +781,7 @@ empty programs, such that changes to the source files does not invalidate any
 build caches. More specifically:
 * The Cargo.lock file is kept as-is
   - Any changes to it will invalidate the build cache
-* Any cargo configuration files (i.e. files name `config` or `config.toml` whose
-  parent directory is named `.cargo`) are kept as-is.
+* Any cargo configuration files (i.e. files under `.cargo` directory) are kept as-is.
   - Any changes to these files will invalidate the build cache
 * Any files named `Cargo.toml` are reduced via `cleanCargoToml` and the result
   is kept. Only the following changes will result in invalidating the build

--- a/lib/findCargoFiles.nix
+++ b/lib/findCargoFiles.nix
@@ -11,12 +11,13 @@ let
     mapAttrsToList;
 
   # A specialized form of lib.listFilesRecursive except it will only look
-  # for Cargo.toml and config.toml files to keep the intermediate results lean
+  # for Cargo.toml and files in `.cargo/` to keep the intermediate results lean
   listFilesRecursive = parentIsDotCargo: dir: flatten (mapAttrsToList
     (name: type:
       let
         cur = dir + "/${name}";
         isConfig = parentIsDotCargo && (name == "config" || name == "config.toml");
+        isOther = !isConfig && parentIsDotCargo;
         isCargoToml = name == "Cargo.toml";
       in
       if type == "directory"
@@ -25,6 +26,8 @@ let
       then [{ path = cur; type = "cargoTomls"; }]
       else if isConfig
       then [{ path = cur; type = "cargoConfigs"; }]
+      else if isOther
+      then [{ path = cur; type = "other"; }]
       else [ ]
     )
     (builtins.readDir dir));
@@ -37,6 +40,7 @@ let
   default = {
     cargoTomls = [ ];
     cargoConfigs = [ ];
+    other = [ ];
   };
 in
 default // cleaned

--- a/lib/mkDummySrc.nix
+++ b/lib/mkDummySrc.nix
@@ -29,7 +29,7 @@ let
   # We want to build a dummy version of the project source. The only things that
   # we want to keep are:
   # 1. the Cargo.lock file
-  # 2. any .cargo/config.toml files (unaltered)
+  # 2. any files under .cargo/ (unaltered)
   # 3. any Cargo.toml files stripped down only the attributes that would affect
   # caching dependencies
   #
@@ -101,7 +101,7 @@ let
         (p: removePrefix uncleanSrcBasePath (toString p))
         # Allow the default `Cargo.lock` location to be picked up here
         # (if it exists) so it automattically appears in the cleaned source
-        (uncleanFiles.cargoConfigs ++ [ "Cargo.lock" ]);
+        (uncleanFiles.cargoConfigs ++ uncleanFiles.other ++ [ "Cargo.lock" ]);
     in
     lib.cleanSourceWith {
       inherit src;


### PR DESCRIPTION
Typically `./.cargo/` would contain only `config.toml`, but if there are any other files in there, it's highly likely they are wrappers used by the config itself that should be included in the dependency-only build anyway.

Re: https://github.com/ipetkov/crane/issues/111

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [x] updated `docs/API.md` with changes
- [x] updated `CHANGELOG.md`
