### PR TITLE
hooks: do not use substitutions for needed tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Changed
+* **Breaking** (technically): build hooks now expect helper tools (like `cargo`,
+  `jq`, `zstd`, etc.) to be present on the path instead of substituting a
+  reference to a (possibly different) executable in the store.
+
+### Fixed
+* Installing binaries now uses the same version of cargo as was used to build
+  the package (instead of using whatever version is present in nixpkgs)
+
 ## [0.7.0] - 2022-09-28
 
 ## Added

--- a/docs/API.md
+++ b/docs/API.md
@@ -179,6 +179,8 @@ log.
 #### Native build dependencies and included hooks
 The following hooks are automatically added as native build inputs:
 * `installFromCargoBuildLogHook`
+* `jq`
+* `removeReferencesTo`
 * `removeReferencesToVendoredSourcesHook`
 
 ### `lib.cargoAudit`
@@ -765,6 +767,7 @@ hooks:
 * `configureCargoVendoredDepsHook`
 * `inheritCargoArtifactsHook`
 * `installCargoArtifactsHook`
+* `zstd`
 
 ### `lib.mkDummySrc`
 
@@ -1068,6 +1071,8 @@ directory using a previous derivation. It takes two positional arguments:
 `inheritCargoArtifacts "$cargoArtifacts" "$CARGO_TARGET_DIR"` will be run as a
 post patch hook.
 
+**Required nativeBuildInputs**: assumes `zstd` is available on the `$PATH`
+
 ### `installCargoArtifactsHook`
 
 Defines `prepareAndInstallCargoArtifactsDir()` which handles installing cargo's
@@ -1086,6 +1091,8 @@ arguments:
 **Automatic behavior:** if `doInstallCargoArtifacts` is set to `1`, then
 `prepareAndInstallCargoArtifactsDir "$out" "$CARGO_TARGET_DIR"` will be run as a
 post install hook.
+
+**Required nativeBuildInputs**: assumes `zstd` is available on the `$PATH`
 
 ### `installFromCargoBuildLogHook`
 
@@ -1107,6 +1114,8 @@ takes two positional arguments:
 
 **Automatic behavior:** none
 
+**Required nativeBuildInputs**: assumes `cargo` and `jq` are available on the `$PATH`
+
 ### `removeReferencesToVendoredSourcesHook`
 
 Defines `removeReferencesToVendoredSources()` which handles removing all
@@ -1126,3 +1135,5 @@ sources themselves. It takes two positional arguments:
 `doNotRemoveReferencesToVendorDir` is not set, then
 `removeReferencesToVendoredSources "$out" "$cargoVendorDir"` will be run as a
 post install hook.
+
+**Required nativeBuildInputs**: assumes `remove-references-to` is available on the `$PATH`

--- a/lib/buildPackage.nix
+++ b/lib/buildPackage.nix
@@ -1,6 +1,8 @@
 { cargoBuild
 , installFromCargoBuildLogHook
+, jq
 , lib
+, removeReferencesTo
 , removeReferencesToVendoredSourcesHook
 }:
 
@@ -59,6 +61,8 @@ in
 
   nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [
     installFromCargoBuildLogHook
+    jq
+    removeReferencesTo
     removeReferencesToVendoredSourcesHook
   ];
 })

--- a/lib/mkCargoDerivation.nix
+++ b/lib/mkCargoDerivation.nix
@@ -6,6 +6,7 @@
 , installCargoArtifactsHook
 , lib
 , stdenv
+, zstd
 }:
 
 args@{
@@ -49,6 +50,7 @@ chosenStdenv.mkDerivation (cleanedArgs // {
     configureCargoVendoredDepsHook
     inheritCargoArtifactsHook
     installCargoArtifactsHook
+    zstd
   ];
 
   buildPhase = args.buildPhase or ''

--- a/pkgs/inheritCargoArtifacts.nix
+++ b/pkgs/inheritCargoArtifacts.nix
@@ -1,12 +1,8 @@
 { makeSetupHook
-, pkgsBuildBuild
 }:
 
 makeSetupHook
 {
   name = "inheritCargoArtifactsHook";
-  substitutions = {
-    zstd = "${pkgsBuildBuild.zstd}/bin/zstd";
-  };
 } ./inheritCargoArtifactsHook.sh
 

--- a/pkgs/inheritCargoArtifactsHook.sh
+++ b/pkgs/inheritCargoArtifactsHook.sh
@@ -12,7 +12,7 @@ inheritCargoArtifacts() {
     mkdir -p "${cargoTargetDir}"
     echo "copying cargo artifacts from ${preparedArtifacts} to ${cargoTargetDir}"
   
-    @zstd@ -d "${preparedArtifacts}" --stdout | \
+    zstd -d "${preparedArtifacts}" --stdout | \
       tar -x -C "${cargoTargetDir}" --strip-components=1
   else
     echo unable to copy cargo artifacts, \"${preparedArtifacts}\" looks invalid

--- a/pkgs/installCargoArtifacts.nix
+++ b/pkgs/installCargoArtifacts.nix
@@ -1,11 +1,7 @@
 { makeSetupHook
-, pkgsBuildBuild
 }:
 
 makeSetupHook
 {
   name = "installCargoArtifactsHook";
-  substitutions = {
-    zstd = "${pkgsBuildBuild.zstd}/bin/zstd";
-  };
 } ./installCargoArtifactsHook.sh

--- a/pkgs/installCargoArtifactsHook.sh
+++ b/pkgs/installCargoArtifactsHook.sh
@@ -17,7 +17,7 @@ prepareAndInstallCargoArtifactsDir() {
     --group=0 \
     --numeric-owner \
     --pax-option=exthdr.name=%d/PaxHeaders/%f,delete=atime,delete=ctime \
-    -c "${cargoTargetDir}" | @zstd@ -o "${dest}"
+    -c "${cargoTargetDir}" | zstd -o "${dest}"
 }
 
 if [ "1" = "${doInstallCargoArtifacts-}" ]; then

--- a/pkgs/installFromCargoBuildLog.nix
+++ b/pkgs/installFromCargoBuildLog.nix
@@ -1,12 +1,7 @@
 { makeSetupHook
-, pkgsBuildBuild
 }:
 
 makeSetupHook
 {
   name = "installFromCargoBuildLogHook";
-  substitutions = {
-    cargo = "${pkgsBuildBuild.cargo}/bin/cargo";
-    jq = "${pkgsBuildBuild.jq}/bin/jq";
-  };
 } ./installFromCargoBuildLogHook.sh

--- a/pkgs/installFromCargoBuildLogHook.sh
+++ b/pkgs/installFromCargoBuildLogHook.sh
@@ -29,12 +29,12 @@ function installFromCargoBuildLog() (
     rmdir --ignore-fail-on-non-empty "${loc}"
   }
 
-  @jq@ -r <"${log}" "${select_bins}" | installArtifacts "${dest}/bin"
+  jq -r <"${log}" "${select_bins}" | installArtifacts "${dest}/bin"
 
-  @cargo@ metadata --format-version 1 | @jq@ '.workspace_members[]' | (
+  command cargo metadata --format-version 1 | jq '.workspace_members[]' | (
     while IFS= read -r ws_member; do
       local select_member_libs="select(.package_id == ${ws_member}) | ${select_lib_files}"
-      @jq@ -r <"${log}" "${select_member_libs}" | installArtifacts "${dest}/lib"
+      jq -r <"${log}" "${select_member_libs}" | installArtifacts "${dest}/lib"
     done
   )
 

--- a/pkgs/removeReferencesToVendoredSources.nix
+++ b/pkgs/removeReferencesToVendoredSources.nix
@@ -1,5 +1,4 @@
 { makeSetupHook
-, pkgsBuildBuild
 }:
 
 makeSetupHook
@@ -8,7 +7,4 @@ makeSetupHook
   substitutions = {
     storeDir = builtins.storeDir;
   };
-  deps = with pkgsBuildBuild; [
-    removeReferencesTo
-  ];
 } ./removeReferencesToVendoredSourcesHook.sh


### PR DESCRIPTION
## Motivation
* Using substitutions for build hooks is a great way to ensure the necessary utility is present without making the caller supply it to the builder, except it makes things confusing when applying overrides
* For example, the `installFromCargoBuildLog` hook was inadvertently ignoring any `cargo` overrides applied to the entire `lib` instantiation
* By removing all explicit substations we also side step the issue of trying to select the correct build/host/target version of the tool and use whatever is present in the build environment

Fixes #125

## Checklist
- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [x] updated `docs/API.md` with changes
- [x] updated `CHANGELOG.md`
