### PR TITLE
Refactor internal usage of `cargoBuild`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * **Breaking** (technically): build hooks now expect helper tools (like `cargo`,
   `jq`, `zstd`, etc.) to be present on the path instead of substituting a
   reference to a (possibly different) executable in the store.
+* `mkCargoDerivation` now automatically vendors dependencies if `cargoVendorDir`
+  is not defined
 
 ### Fixed
 * Installing binaries now uses the same version of cargo as was used to build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   `crateNameFromCargoToml`) if they are not specified
 * `mkCargoDerivation` now defaults to an empty `checkPhaseCargoCommand` if not
   specified
+* `cargoFmt` now delegates to `mkCargoDerivation` instead of `cargoBuild`
 
 ### Fixed
 * Installing binaries now uses the same version of cargo as was used to build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * `cargoAudit` now delegates to `mkCargoDerivation` instead of `cargoBuild`
 * `cargoDoc` now delegates to `mkCargoDerivation` instead of `cargoBuild`
 * `cargoFmt` now delegates to `mkCargoDerivation` instead of `cargoBuild`
+* `cargoTarpaulin` now delegates to `mkCargoDerivation` instead of `cargoBuild`
 
 ### Fixed
 * Installing binaries now uses the same version of cargo as was used to build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * `cargoClippy` now delegates to `mkCargoDerivation` instead of `cargoBuild`
 * `cargoDoc` now delegates to `mkCargoDerivation` instead of `cargoBuild`
 * `cargoFmt` now delegates to `mkCargoDerivation` instead of `cargoBuild`
+* `cargoNextest` now delegates to `mkCargoDerivation` instead of `cargoBuild`
 * `cargoTarpaulin` now delegates to `mkCargoDerivation` instead of `cargoBuild`
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   is not defined
 * `mkCargoDerivation` now automatically populates `pname` and `version` (via
   `crateNameFromCargoToml`) if they are not specified
+* `mkCargoDerivation` now defaults to an empty `checkPhaseCargoCommand` if not
+  specified
 
 ### Fixed
 * Installing binaries now uses the same version of cargo as was used to build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   `crateNameFromCargoToml`) if they are not specified
 * `mkCargoDerivation` now defaults to an empty `checkPhaseCargoCommand` if not
   specified
+* `cargoAudit` now delegates to `mkCargoDerivation` instead of `cargoBuild`
 * `cargoDoc` now delegates to `mkCargoDerivation` instead of `cargoBuild`
 * `cargoFmt` now delegates to `mkCargoDerivation` instead of `cargoBuild`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   reference to a (possibly different) executable in the store.
 * `mkCargoDerivation` now automatically vendors dependencies if `cargoVendorDir`
   is not defined
+* `mkCargoDerivation` now automatically populates `pname` and `version` (via
+  `crateNameFromCargoToml`) if they are not specified
 
 ### Fixed
 * Installing binaries now uses the same version of cargo as was used to build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   `crateNameFromCargoToml`) if they are not specified
 * `mkCargoDerivation` now defaults to an empty `checkPhaseCargoCommand` if not
   specified
+* `cargoDoc` now delegates to `mkCargoDerivation` instead of `cargoBuild`
 * `cargoFmt` now delegates to `mkCargoDerivation` instead of `cargoBuild`
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * `mkCargoDerivation` now defaults to an empty `checkPhaseCargoCommand` if not
   specified
 * `cargoAudit` now delegates to `mkCargoDerivation` instead of `cargoBuild`
+* `cargoClippy` now delegates to `mkCargoDerivation` instead of `cargoBuild`
 * `cargoDoc` now delegates to `mkCargoDerivation` instead of `cargoBuild`
 * `cargoFmt` now delegates to `mkCargoDerivation` instead of `cargoBuild`
 * `cargoTarpaulin` now delegates to `mkCargoDerivation` instead of `cargoBuild`

--- a/docs/API.md
+++ b/docs/API.md
@@ -709,9 +709,6 @@ This is a fairly low-level abstraction, so consider using `buildPackage` or
   - This can be prepared via `buildDepsOnly`
   - Alternatively, any cargo-based derivation which was built with
     `doInstallCargoArtifacts = true` will work as well
-* `checkPhaseCargoCommand`: A command (likely a cargo invocation) to run during
-  the derivation's check phase. Pre and post check hooks will automatically be
-  run.
 
 #### Optional attributes
 * `buildPhase`: the commands used by the build phase of the derivation
@@ -726,6 +723,10 @@ This is a fairly low-level abstraction, so consider using `buildPackage` or
 * `checkPhase`: the commands used by the check phase of the derivation
   - Default value: the check phase will run `preCheck` hooks, log and evaluate
     `checkPhaseCargoCommand`, and run `postCheck` hooks
+* `checkPhaseCargoCommand`: A command (likely a cargo invocation) to run during
+  the derivation's check phase. Pre and post check hooks will automatically be
+  run.
+  - Default value: `""`
 * `configurePhase`: the commands used by the configure phase of the derivation
   - Default value: the configure phase will run `preConfigureHooks` hooks, then
     run `postConfigure` hooks

--- a/docs/API.md
+++ b/docs/API.md
@@ -190,14 +190,11 @@ Create a derivation which will run a `cargo audit` invocation in a cargo
 workspace.
 
 Except where noted below, all derivation attributes are delegated to
-`cargoBuild`, and can be used to influence its behavior.
-* `cargoArtifacts` will be set to `null` as they are not needed
-* `cargoBuildCommand` will be set to run `cargo audit -n -d ${advisory-db}` in
+`mkCargoDerivation`, and can be used to influence its behavior.
+* `buildPhaseCargoCommand` will be set to run `cargo audit -n -d ${advisory-db}` in
   the workspace.
-* `cargoExtraArgs` will have `cargoAuditExtraArgs` appended to it
-  - Default value: `""`
+* `cargoArtifacts` will be set to `null` as they are not needed
 * `cargoVendorDir` will be set to `null` as it is not needed
-* `doCheck` is disabled
 * `doInstallCargoArtifacts` is disabled
 * `pnameSuffix` will be set to `"-audit"`
 * `src` will be filtered to only keep `Cargo.lock` files
@@ -233,6 +230,7 @@ The following attributes will be removed before being lowered to
 environment variables during the build, you can bring them back via
 `.overrideAttrs`.
 * `cargoAuditExtraArgs`
+* `cargoExtraArgs`
 
 ### `lib.cargoBuild`
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -402,19 +402,17 @@ Create a derivation which will run a `cargo fmt` invocation in a cargo
 workspace.
 
 Except where noted below, all derivation attributes are delegated to
-`cargoBuild`, and can be used to influence its behavior.
+`mkCargoDerivation`, and can be used to influence its behavior.
+* `buildPhaseCargoCommand` will be set to run `cargo fmt` (in check mode) in the
+  workspace.
 * `cargoArtifacts` is disabled/cleared
-* `cargoBuildCommand` will be set to run `cargo fmt` in the workspace.
-* `cargoExtraArgs` will have `rustFmtExtraArgs` appended to it
-  - Default value: `""`
 * `cargoVendorDir` is disabled/cleared
-* `doCheck` is disabled
 * `pnameSuffix` will be set to `"-fmt"`
 
 #### Optional attributes
-* `rustFmtExtraArgs`: additional flags to be passed in the rustfmt invocation
-  - Default value: `""`
 * `cargoExtraArgs`: additional flags to be passed in the cargo invocation
+  - Default value: `""`
+* `rustFmtExtraArgs`: additional flags to be passed in the rustfmt invocation
   - Default value: `""`
 
 #### Native build dependencies
@@ -426,6 +424,7 @@ The following attributes will be removed before being lowered to
 `cargoBuild`. If you absolutely need these attributes present as
 environment variables during the build, you can bring them back via
 `.overrideAttrs`.
+* `cargoExtraArgs`
 * `rustFmtExtraArgs`
 
 ### `lib.cargoNextest`

--- a/docs/API.md
+++ b/docs/API.md
@@ -360,15 +360,12 @@ Create a derivation which will run a `cargo doc` invocation in a cargo
 workspace.
 
 Except where noted below, all derivation attributes are delegated to
-`cargoBuild`, and can be used to influence its behavior.
-* `cargoBuildCommand` will be set to run `cargo doc --profile release` for
+`mkCargoDerivation`, and can be used to influence its behavior.
+* `buildPhaseCargoCommand` will be set to run `cargo doc --profile release` for
   the workspace.
   - `CARGO_PROFILE` can be set on the derivation to alter which cargo profile
     is selected; setting it to `""` will omit specifying a profile
     altogether.
-* `cargoExtraArgs` will have `cargoDocExtraArgs` appended to it
-  - Default value: `"--no-deps"`
-* `doCheck` is disabled
 * `pnameSuffix` will be set to `"-doc"`
 
 #### Required attributes
@@ -393,6 +390,7 @@ The following attributes will be removed before being lowered to
 environment variables during the build, you can bring them back via
 `.overrideAttrs`.
 * `cargoDocExtraArgs`
+* `cargoExtraArgs`
 
 ### `lib.cargoFmt`
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -712,7 +712,6 @@ This is a fairly low-level abstraction, so consider using `buildPackage` or
 * `checkPhaseCargoCommand`: A command (likely a cargo invocation) to run during
   the derivation's check phase. Pre and post check hooks will automatically be
   run.
-* `pname`: the package name used for the derivation
 
 #### Optional attributes
 * `buildPhase`: the commands used by the build phase of the derivation
@@ -742,10 +741,14 @@ This is a fairly low-level abstraction, so consider using `buildPackage` or
   - By default an output directory is created such that any other `postInstall`
     hooks can successfully run. Consider overriding this value with an
     appropriate installation commands for the package being built.
+* `pname`: the name of the derivation
+  - Default value: the package name listed in `Cargo.toml`
 * `pnameSuffix`: a suffix appended to `pname`
   - Default value: `""`
 * `stdenv`: the standard build environment to use for this derivation
   - Default value: `pkgs.stdenv`
+* `version`: the version of the derivation
+  - Default value: the version listed in `Cargo.toml`
 
 #### Remove attributes
 The following attributes will be removed before being lowered to

--- a/docs/API.md
+++ b/docs/API.md
@@ -312,15 +312,12 @@ Create a derivation which will run a `cargo clippy` invocation in a cargo
 workspace.
 
 Except where noted below, all derivation attributes are delegated to
-`cargoBuild`, and can be used to influence its behavior.
-* `cargoBuildCommand` will be set to run `cargo clippy --profile release` for
+`mkCargoDerivation`, and can be used to influence its behavior.
+* `buildPhaseCargoCommand` will be set to run `cargo clippy --profile release` for
   the workspace.
   - `CARGO_PROFILE` can be set on the derivation to alter which cargo profile
     is selected; setting it to `""` will omit specifying a profile
     altogether.
-* `cargoExtraArgs` will have `cargoClippyExtraArgs` appended to it
-  - Default value: `"--all-targets"`
-* `doCheck` is disabled
 * `pnameSuffix` will be set to `"-clippy"`
 
 #### Required attributes
@@ -349,6 +346,7 @@ The following attributes will be removed before being lowered to
 environment variables during the build, you can bring them back via
 `.overrideAttrs`.
 * `cargoClippyExtraArgs`
+* `cargoExtraArgs`
 
 ### `lib.cargoDoc`
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -429,15 +429,12 @@ Create a derivation which will run a `cargo nextest` invocation in a cargo
 workspace.
 
 Except where noted below, all derivation attributes are delegated to
-`cargoBuild`, and can be used to influence its behavior.
-* `cargoTestCommand` will be set to run `cargo nextest run --profile release`
+`mkCargoDerivation`, and can be used to influence its behavior.
+* `checkPhaseCargoCommand` will be set to run `cargo nextest run --profile release`
   for the workspace.
   - `CARGO_PROFILE` can be set on the derivation to alter which cargo profile
     is selected; setting it to `""` will omit specifying a profile
     altogether.
-* `cargoExtraArgs` will have `cargoNextestExtraArgs` appended to it, along with
-  any additional flags needed for handling multiple partitions
-  - Default value: `""`
 * `pnameSuffix` will be set to `"-nextest"` and may include partition numbers
 
 #### Required attributes
@@ -473,6 +470,7 @@ The following attributes will be removed before being lowered to
 `cargoBuild`. If you absolutely need these attributes present as
 environment variables during the build, you can bring them back via
 `.overrideAttrs`.
+* `cargoExtraArgs`
 * `cargoNextestExtraArgs`
 * `partitions`
 * `partitionType`

--- a/docs/API.md
+++ b/docs/API.md
@@ -487,16 +487,13 @@ Create a derivation which will run a `cargo tarpaulin` invocation in a cargo
 workspace.
 
 Except where noted below, all derivation attributes are delegated to
-`cargoBuild`, and can be used to influence its behavior.
+`mkCargoDerivation`, and can be used to influence its behavior.
 * `cargoArtifacts` will be instantiated via `buildDepsOnly` if not specified
   - `cargoTarpaulinExtraArgs` will be removed before delegating to `buildDepsOnly`
-* `cargoBuildCommand` will be set to run `cargo tarpaulin --profile release` in
+* `buildPhaseCargoCommand` will be set to run `cargo tarpaulin --profile release` in
   the workspace.
   - `CARGO_PROFILE` can be set on the derivation to alter which cargo profile is
     selected; setting it to `""` will omit specifying a profile altogether.
-* `cargoExtraArgs` will have `cargoTarpaulinExtraArgs` appended to it
-  - Default value: `""`
-* `doCheck` is disabled
 * `pnameSuffix` will be set to `"-tarpaulin"`
 
 #### Optional attributes
@@ -515,6 +512,7 @@ The following attributes will be removed before being lowered to
 `cargoBuild`. If you absolutely need these attributes present as
 environment variables during the build, you can bring them back via
 `.overrideAttrs`.
+* `cargoExtraArgs`
 * `cargoTarpaulinExtraArgs`
 
 ### `lib.cleanCargoSource`

--- a/docs/API.md
+++ b/docs/API.md
@@ -709,10 +709,6 @@ This is a fairly low-level abstraction, so consider using `buildPackage` or
   - This can be prepared via `buildDepsOnly`
   - Alternatively, any cargo-based derivation which was built with
     `doInstallCargoArtifacts = true` will work as well
-* `cargoVendorDir`: A path (or derivation) of vendored cargo sources which can
-  be consumed without network access. Directory structure should basically
-  follow the output of `cargo vendor`.
-  - This can be prepared via `vendorCargoDeps`
 * `checkPhaseCargoCommand`: A command (likely a cargo invocation) to run during
   the derivation's check phase. Pre and post check hooks will automatically be
   run.
@@ -723,6 +719,11 @@ This is a fairly low-level abstraction, so consider using `buildPackage` or
   - Default value: the build phase will run `preBuild` hooks, print the cargo
     version, log and evaluate `buildPhaseCargoCommand`, and run `postBuild`
     hooks
+* `cargoVendorDir`: A path (or derivation) of vendored cargo sources which can
+  be consumed without network access. Directory structure should basically
+  follow the output of `cargo vendor`.
+  - Default value: the result of `vendorCargoDeps` after applying the arguments
+    set (with the respective default values)
 * `checkPhase`: the commands used by the check phase of the derivation
   - Default value: the check phase will run `preCheck` hooks, log and evaluate
     `checkPhaseCargoCommand`, and run `postCheck` hooks

--- a/lib/cargoAudit.nix
+++ b/lib/cargoAudit.nix
@@ -1,6 +1,6 @@
 { cargo-audit
-, cargoBuild
 , lib
+, mkCargoDerivation
 }:
 
 { advisory-db
@@ -10,11 +10,13 @@
 , ...
 }@origArgs:
 let
-  args = builtins.removeAttrs origArgs [ "cargoAuditExtraArgs" ];
+  args = builtins.removeAttrs origArgs [
+    "cargoAuditExtraArgs"
+    "cargoExtraArgs"
+  ];
 in
-cargoBuild (args // {
-  cargoBuildCommand = "cargo audit -n -d ${advisory-db}";
-  cargoExtraArgs = "${cargoExtraArgs} ${cargoAuditExtraArgs}";
+mkCargoDerivation (args // {
+  buildPhaseCargoCommand = "cargo audit ${cargoExtraArgs} -n -d ${advisory-db} ${cargoAuditExtraArgs}";
 
   src = lib.cleanSourceWith {
     inherit src;
@@ -27,7 +29,6 @@ cargoBuild (args // {
 
   cargoArtifacts = null; # Don't need artifacts, just Cargo.lock
   cargoVendorDir = null; # Don't need dependencies either
-  doCheck = false; # We don't need to run tests to benefit from `cargo audit`
   doInstallCargoArtifacts = false; # We don't expect to/need to install artifacts
   pnameSuffix = "-audit";
 

--- a/lib/cargoClippy.nix
+++ b/lib/cargoClippy.nix
@@ -1,5 +1,5 @@
-{ cargoBuild
-, clippy
+{ clippy
+, mkCargoDerivation
 }:
 
 { cargoArtifacts
@@ -8,16 +8,16 @@
 , ...
 }@origArgs:
 let
-  args = builtins.removeAttrs origArgs [ "cargoClippyExtraArgs" ];
+  args = builtins.removeAttrs origArgs [
+    "cargoClippyExtraArgs"
+    "cargoExtraArgs"
+  ];
 in
-cargoBuild (args // {
+mkCargoDerivation (args // {
   inherit cargoArtifacts;
   pnameSuffix = "-clippy";
 
-  cargoBuildCommand = "cargoWithProfile clippy";
-  cargoExtraArgs = "${cargoExtraArgs} ${cargoClippyExtraArgs}";
+  buildPhaseCargoCommand = "cargoWithProfile clippy ${cargoExtraArgs} ${cargoClippyExtraArgs}";
 
   nativeBuildInputs = (args.nativeBuildInputs or [ ]) ++ [ clippy ];
-
-  doCheck = false; # We don't need to run tests to benefit from `cargo clippy`
 })

--- a/lib/cargoDoc.nix
+++ b/lib/cargoDoc.nix
@@ -1,4 +1,4 @@
-{ cargoBuild
+{ mkCargoDerivation
 }:
 
 { cargoArtifacts
@@ -7,13 +7,13 @@
 , ...
 }@origArgs:
 let
-  args = (builtins.removeAttrs origArgs [ "cargoDocExtraArgs" ]);
+  args = (builtins.removeAttrs origArgs [
+    "cargoDocExtraArgs"
+    "cargoExtraArgs"
+  ]);
 in
-cargoBuild (args // {
+mkCargoDerivation (args // {
   pnameSuffix = "-doc";
 
-  cargoBuildCommand = "cargoWithProfile doc";
-  cargoExtraArgs = "${cargoExtraArgs} ${cargoDocExtraArgs}";
-
-  doCheck = false; # We don't need to run tests to build docs
+  buildPhaseCargoCommand = "cargoWithProfile doc ${cargoExtraArgs} ${cargoDocExtraArgs}";
 })

--- a/lib/cargoFmt.nix
+++ b/lib/cargoFmt.nix
@@ -1,4 +1,4 @@
-{ cargoBuild
+{ mkCargoDerivation
 , rustfmt
 }:
 
@@ -7,16 +7,17 @@
 , ...
 }@origArgs:
 let
-  args = builtins.removeAttrs origArgs [ "rustFmtExtraArgs" ];
+  args = builtins.removeAttrs origArgs [
+    "cargoExtraArgs"
+    "rustFmtExtraArgs"
+  ];
 in
-cargoBuild (args // {
+mkCargoDerivation (args // {
   cargoArtifacts = null;
   cargoVendorDir = null;
-  doCheck = false;
   pnameSuffix = "-fmt";
 
-  cargoBuildCommand = "cargo fmt";
-  cargoExtraArgs = "${cargoExtraArgs} -- --check ${rustFmtExtraArgs}";
+  buildPhaseCargoCommand = "cargo fmt ${cargoExtraArgs} -- --check ${rustFmtExtraArgs}";
 
   nativeBuildInputs = (args.nativeBuildInputs or [ ]) ++ [ rustfmt ];
 

--- a/lib/cargoTarpaulin.nix
+++ b/lib/cargoTarpaulin.nix
@@ -1,5 +1,5 @@
 { buildDepsOnly
-, cargoBuild
+, mkCargoDerivation
 , cargo-tarpaulin
 }:
 
@@ -8,14 +8,15 @@
 , ...
 }@origArgs:
 let
-  args = builtins.removeAttrs origArgs [ "cargoTarpaulinExtraArgs" ];
+  args = builtins.removeAttrs origArgs [
+    "cargoExtraArgs"
+    "cargoTarpaulinExtraArgs"
+  ];
 in
-cargoBuild (args // {
+mkCargoDerivation (args // {
   cargoArtifacts = args.cargoArtifacts or (buildDepsOnly args);
-  cargoBuildCommand = "cargoWithProfile tarpaulin";
-  cargoExtraArgs = "${cargoExtraArgs} ${cargoTarpaulinExtraArgs}";
+  buildPhaseCargoCommand = "cargoWithProfile tarpaulin ${cargoExtraArgs} ${cargoTarpaulinExtraArgs}";
 
-  doCheck = false;
   pnameSuffix = "-tarpaulin";
 
   nativeBuildInputs = (args.nativeBuildInputs or [ ]) ++ [ cargo-tarpaulin ];

--- a/lib/mkCargoDerivation.nix
+++ b/lib/mkCargoDerivation.nix
@@ -20,7 +20,7 @@ args@{
 , buildPhaseCargoCommand
   # A command (likely a cargo invocation) to run during the derivation's check
   # phase. Pre and post check hooks will automatically be run.
-, checkPhaseCargoCommand
+, checkPhaseCargoCommand ? ""
   # A command  to run during the derivation's install
   # phase. Pre and post install hooks will automatically be run.
 , installPhaseCommand ? "mkdir -p $out"

--- a/lib/mkCargoDerivation.nix
+++ b/lib/mkCargoDerivation.nix
@@ -2,6 +2,7 @@
 , cargoHelperFunctionsHook
 , configureCargoCommonVarsHook
 , configureCargoVendoredDepsHook
+, crateNameFromCargoToml
 , inheritCargoArtifactsHook
 , installCargoArtifactsHook
 , lib
@@ -26,6 +27,7 @@ args@{
 , ...
 }:
 let
+  crateName = crateNameFromCargoToml args;
   chosenStdenv = args.stdenv or stdenv;
   cleanedArgs = builtins.removeAttrs args [
     "buildPhaseCargoCommand"
@@ -36,7 +38,8 @@ let
   ];
 in
 chosenStdenv.mkDerivation (cleanedArgs // {
-  pname = "${args.pname}${args.pnameSuffix or ""}";
+  pname = "${args.pname or crateName.pname}${args.pnameSuffix or ""}";
+  version = args.version or crateName.version;
 
   # Controls whether cargo's `target` directory should be copied as an output
   doInstallCargoArtifacts = args.doInstallCargoArtifacts or true;

--- a/lib/mkCargoDerivation.nix
+++ b/lib/mkCargoDerivation.nix
@@ -6,6 +6,7 @@
 , installCargoArtifactsHook
 , lib
 , stdenv
+, vendorCargoDeps
 , zstd
 }:
 
@@ -13,9 +14,6 @@ args@{
   # A directory to an existing cargo `target` directory, which will be reused
   # at the start of the derivation. Useful for caching incremental cargo builds.
   cargoArtifacts
-  # A directory of vendored cargo sources which can be consumed without network
-  # access. Directory structure should basically follow the output of `cargo vendor`.
-, cargoVendorDir
   # A command (likely a cargo invocation) to run during the derivation's build
   # phase. Pre and post build hooks will automatically be run.
 , buildPhaseCargoCommand
@@ -42,6 +40,10 @@ chosenStdenv.mkDerivation (cleanedArgs // {
 
   # Controls whether cargo's `target` directory should be copied as an output
   doInstallCargoArtifacts = args.doInstallCargoArtifacts or true;
+
+  # A directory of vendored cargo sources which can be consumed without network
+  # access. Directory structure should basically follow the output of `cargo vendor`.
+  cargoVendorDir = args.cargoVendorDir or (vendorCargoDeps args);
 
   nativeBuildInputs = (args.nativeBuildInputs or [ ]) ++ [
     cargo


### PR DESCRIPTION
## Motivation
`cargoBuild` originally started out the central place for preparing a derivation for running cargo (e.g. vendoring dependencies, building only dependnecies, setting the derivation's `pname` and `version`) and was meant to be a foundation for defining additional commands (e.g. running `clippy`, or `cargo audit`, etc.).

In reality it [ended up doing a bit too much and causing friction for customization](https://github.com/ipetkov/crane/issues/89#issuecomment-1229261734). Keeping up with the pattern of having a `cargoFoo` command (which only runs the "foo" procedure) `cargoBuild` should only build (and not run tests).

In preparation for changing the behavior of `cargoBuild` (to come in a future change), all internal usage of `cargoBuild` has been replaced with using `mkCargoDerivation` directly. This means that `mkCargoDerivation` does a few extra things it did not before:
* a check phase command is no longer required, by default nothing will be done unless the caller specifies it
* dependencies will automatically be vendored instead of requiring the caller to do it (callers can turn it off if they wish)
* the derivation's `pname` and `version` attributes will automatically be populated using the `Cargo.toml` definition, if they are not already present

## Checklist
- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [x] updated `docs/API.md` with changes
- [x] updated `CHANGELOG.md`
