### PR TITLE
Cleanup deprecated bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Changed
+* **Breaking**: all setup hooks have been removed from the `packages` flake
+  output. They can still be accessed via the `lib` flake output.
+
 ## [0.8.0] - 2022-10-09
 
 ### Added

--- a/checks/default.nix
+++ b/checks/default.nix
@@ -54,6 +54,9 @@ myPkgs // {
 
   cargoTarpaulin = lib.optionalAttrs x64Linux (myLib.cargoTarpaulin {
     src = ./simple;
+    cargoArtifacts = myLib.buildDepsOnly {
+      src = ./simple;
+    };
   });
 
   compilesFresh = callPackage ./compilesFresh.nix { };

--- a/docs/API.md
+++ b/docs/API.md
@@ -484,13 +484,19 @@ workspace.
 
 Except where noted below, all derivation attributes are delegated to
 `mkCargoDerivation`, and can be used to influence its behavior.
-* `cargoArtifacts` will be instantiated via `buildDepsOnly` if not specified
-  - `cargoTarpaulinExtraArgs` will be removed before delegating to `buildDepsOnly`
 * `buildPhaseCargoCommand` will be set to run `cargo tarpaulin --profile release` in
   the workspace.
   - `CARGO_PROFILE` can be set on the derivation to alter which cargo profile is
     selected; setting it to `""` will omit specifying a profile altogether.
 * `pnameSuffix` will be set to `"-tarpaulin"`
+
+#### Required attributes
+* `cargoArtifacts`: A path (or derivation) which contains an existing cargo
+  `target` directory, which will be reused at the start of the derivation.
+  Useful for caching incremental cargo builds.
+  - This can be prepared via `buildDepsOnly`
+  - Alternatively, any cargo-based derivation which was built with
+    `doInstallCargoArtifacts = true` will work as well
 
 #### Optional attributes
 * `cargoExtraArgs`: additional flags to be passed in the cargo invocation

--- a/flake.nix
+++ b/flake.nix
@@ -16,12 +16,17 @@
         inherit (pkgs) lib newScope;
       };
 
-      myPkgsFor = pkgs: import ./pkgs (mkLib pkgs);
+      myPkgsFor = { pkgs, myLib }: import ./pkgs {
+        inherit pkgs myLib;
+      };
     in
     {
       inherit mkLib;
 
-      overlays.default = final: prev: myPkgsFor final;
+      overlays.default = final: prev: myPkgsFor {
+        pkgs = final;
+        myLib = mkLib final;
+      };
 
       templates = rec {
         alt-registry = {
@@ -63,7 +68,10 @@
 
         # To override do: lib.overrideScope' (self: super: { ... });
         lib = mkLib pkgs;
-        myPkgs = myPkgsFor pkgs;
+        myPkgs = myPkgsFor {
+          inherit pkgs;
+          myLib = lib;
+        };
 
         checks = pkgs.callPackages ./checks {
           inherit pkgs myPkgs;

--- a/lib/cargoTarpaulin.nix
+++ b/lib/cargoTarpaulin.nix
@@ -3,7 +3,8 @@
 , cargo-tarpaulin
 }:
 
-{ cargoExtraArgs ? ""
+{ cargoArtifacts
+, cargoExtraArgs ? ""
 , cargoTarpaulinExtraArgs ? "--skip-clean --out Xml --output-dir $out"
 , ...
 }@origArgs:
@@ -14,7 +15,6 @@ let
   ];
 in
 mkCargoDerivation (args // {
-  cargoArtifacts = args.cargoArtifacts or (buildDepsOnly args);
   buildPhaseCargoCommand = "cargoWithProfile tarpaulin ${cargoExtraArgs} ${cargoTarpaulinExtraArgs}";
 
   pnameSuffix = "-tarpaulin";

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -1,15 +1,6 @@
-myLib:
-let
-  mkDeprecated = name:
-    builtins.trace "packages.${name} is deprecated, please use craneLib.${name} instead"
-      myLib.${name};
-in
+{ myLib
+, pkgs
+}:
+
 {
-  cargoHelperFunctionsHook = mkDeprecated "cargoHelperFunctionsHook";
-  configureCargoCommonVarsHook = mkDeprecated "configureCargoCommonVarsHook";
-  configureCargoVendoredDepsHook = mkDeprecated "configureCargoVendoredDepsHook";
-  inheritCargoArtifactsHook = mkDeprecated "inheritCargoArtifactsHook";
-  installCargoArtifactsHook = mkDeprecated "installCargoArtifactsHook";
-  installFromCargoBuildLogHook = mkDeprecated "installFromCargoBuildLogHook";
-  removeReferencesToVendoredSourcesHook = mkDeprecated "removeReferencesToVendoredSourcesHook";
 }


### PR DESCRIPTION
## Motivation
Cleanup deprecated bindings to the `packages` flake output

## Checklist
- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [ ] updated `docs/API.md` with changes
- [x] updated `CHANGELOG.md`
