### PR TITLE
Refactor `cargoBuild` so it only builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 * **Breaking**: all setup hooks have been removed from the `packages` flake
   output. They can still be accessed via the `lib` flake output.
+* `buildPackage` now delegates to `mkCargoDerivation` instead of `cargoBuild`
 
 ## [0.8.0] - 2022-10-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 * **Breaking**: all setup hooks have been removed from the `packages` flake
   output. They can still be accessed via the `lib` flake output.
+* **Breaking**: `cargoBuild` now only runs `cargo build` in a workspace, tests
+  are no longer run
 * **Breaking**: `buildDepsOnly` does not automatically imply the `--all-targets`
   flag when invoking `cargo check`. Use `cargoCheckExtraArgs` to control this
 * `buildDepsOnly` now accepts `cargoCheckExtraArgs` for passing additional

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 * **Breaking**: all setup hooks have been removed from the `packages` flake
   output. They can still be accessed via the `lib` flake output.
+* **Breaking**: `buildDepsOnly` does not automatically imply the `--all-targets`
+  flag when invoking `cargo check`. Use `cargoCheckExtraArgs` to control this
+* `buildDepsOnly` now accepts `cargoCheckExtraArgs` for passing additional
+  arguments just to the `cargo check` invocation. By default `--all-targets`
+  will be used
+* `buildDepsOnly` now accepts `cargoTestExtraArgs` for passing additional
+  arguments just to the `cargo test` invocation
 * `buildPackage` now delegates to `mkCargoDerivation` instead of `cargoBuild`
 
 ## [0.8.0] - 2022-10-09

--- a/checks/default.nix
+++ b/checks/default.nix
@@ -63,6 +63,9 @@ myPkgs // {
   compilesFreshSimple = self.compilesFresh "simple" (myLib.cargoBuild) {
     src = ./simple;
   };
+  compilesFreshSimpleBuildPackage = self.compilesFresh "simple" (myLib.buildPackage) {
+    src = ./simple;
+  };
   compilesFreshOverlappingTargets = self.compilesFresh
     (builtins.concatStringsSep "\n" [
       "bar"

--- a/docs/API.md
+++ b/docs/API.md
@@ -268,63 +268,31 @@ environment variables during the build, you can bring them back via
 
 `cargoBuild :: set -> drv`
 
-Create a derivation which will build and test a cargo workspace.
+Create a derivation which will run a `cargo build` invocation in a cargo
+workspace. Consider using `buildPackage` if all you need is to build the
+workspace and install the resulting application binaries.
 
-The exact cargo command being run (or the arguments passed into it) can be
-easily updated to suit your needs. If a project requires multiple cargo
-invocations, they can either be run one after the other (as you'd expect in a
-regular derivation), or they can be split out into separate derivations and
-chained together via `cargoArtifacts` which would allow for more incremental
-building and caching of the results.
+Except where noted below, all derivation attributes are delegated to
+`mkCargoDerivation`, and can be used to influence its behavior.
+* `buildPhaseCargoCommand` will be set to run `cargo build --profile release` for
+  the workspace.
+  - `CARGO_PROFILE` can be set on the derivation to alter which cargo profile
+    is selected; setting it to `""` will omit specifying a profile
+    altogether.
+* `pnameSuffix` will be set to `"-build"`
 
-Consider using `buildPackage` if all you need is to build the workspace and
-install the resulting application binaries.
-
-In addition to all default values being set as documented below, all derivation
-attributes are delegated to `mkCargoDerivation`, and can be used to influence
-its behavior.
-
-#### Optional attributes
-* `buildPhaseCargoCommand`: A command to run during the derivation's build
-  phase. Pre and post build hooks will automatically be run.
-  - Default value: `"${cargoBuildCommand} ${cargoExtraArgs}"`
+#### Required attributes
 * `cargoArtifacts`: A path (or derivation) which contains an existing cargo
   `target` directory, which will be reused at the start of the derivation.
   Useful for caching incremental cargo builds.
-  - Default value: the result of `buildDepsOnly` after applying the arguments
-    set (with the respective default values)
-* `cargoBuildCommand`: A cargo invocation to run during the derivation's build
-  phase
-  - Default value: `"cargo build --profile release"`
-    * `CARGO_PROFILE` can be set on the derivation to alter which cargo profile
-      is selected; setting it to `""` will omit specifying a profile
-      altogether.
+  - This can be prepared via `buildDepsOnly`
+  - Alternatively, any cargo-based derivation which was built with
+    `doInstallCargoArtifacts = true` will work as well
+
+#### Optional attributes
 * `cargoExtraArgs`: additional flags to be passed in the cargo invocation (e.g.
   enabling specific features)
   - Default value: `""`
-* `cargoTestCommand`: A cargo invocation to run during the derivation's check
-  phase
-  - Default value: `"cargo test --profile release"`
-    * `CARGO_PROFILE` can be set on the derivation to alter which cargo profile
-      is selected; setting it to `""` will omit specifying a profile
-      altogether.
-* `cargoVendorDir`: A path (or derivation) of vendored cargo sources which can
-  be consumed without network access. Directory structure should basically
-  follow the output of `cargo vendor`.
-  - Default value: the result of `vendorCargoDeps` after applying the arguments
-    set (with the respective default values)
-* `checkPhaseCargoCommand`: A command to run during the derivation's check
-  phase. Pre and post check hooks will automatically be run.
-  - Default value: `"${cargoTestCommand} ${cargoExtraArgs}"`
-* `doCheck`: whether the derivation's check phase should be run
-  - Default value: `true`
-* `doInstallCargoArtifacts`: controls whether cargo's `target` directory should
-  be copied as an output
-  - Default value: `true`
-* `pname`: package name of the derivation
-  - Default value: inherited from calling `crateNameFromCargoToml`
-* `version`: version of the derivation
-  - Default value: inherited from calling `crateNameFromCargoToml`
 
 #### Remove attributes
 The following attributes will be removed before being lowered to
@@ -332,9 +300,7 @@ The following attributes will be removed before being lowered to
 environment variables during the build, you can bring them back via
 `.overrideAttrs`.
 
-* `cargoBuildCommand`
 * `cargoExtraArgs`
-* `cargoTestCommand`
 
 ### `lib.cargoClippy`
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -96,14 +96,21 @@ to influence its behavior.
     * `CARGO_PROFILE` can be set on the derivation to alter which cargo profile
       is selected; setting it to `""` will omit specifying a profile
       altogether.
+* `cargoCheckExtraArgs`: additional flags to be passed in the `cargoCheckCommand`
+  invocation
+  - Default value: `"--all-targets"`
 * `cargoExtraArgs`: additional flags to be passed in the cargo invocation (e.g.
   enabling specific features)
+  - Default value: `""`
 * `cargoTestCommand`: A cargo invocation to run during the derivation's check
   phase
   - Default value: `"cargo test --profile release"`
     * `CARGO_PROFILE` can be set on the derivation to alter which cargo profile
       is selected; setting it to `""` will omit specifying a profile
       altogether.
+* `cargoTestExtraArgs`: additional flags to be passed in the `cargoTestCommand`
+  invocation (e.g. enabling specific tests)
+  - Default value: `""`
 * `cargoVendorDir`: A path (or derivation) of vendored cargo sources which can
   be consumed without network access. Directory structure should basically
   follow the output of `cargo vendor`.
@@ -130,8 +137,10 @@ environment variables during the build, you can bring them back via
 
 * `cargoBuildCommand`
 * `cargoCheckCommand`
+* `cargoCheckExtraArgs`
 * `cargoExtraArgs`
 * `cargoTestCommand`
+* `cargoTestExtraArgs`
 * `dummySrc`
 
 ### `lib.buildPackage`

--- a/lib/buildDepsOnly.nix
+++ b/lib/buildDepsOnly.nix
@@ -5,9 +5,11 @@
 }:
 
 { cargoBuildCommand ? "cargoWithProfile build"
-, cargoCheckCommand ? "cargoWithProfile check --all-targets"
+, cargoCheckCommand ? "cargoWithProfile check"
+, cargoCheckExtraArgs ? "--all-targets"
 , cargoExtraArgs ? ""
 , cargoTestCommand ? "cargoWithProfile test"
+, cargoTestExtraArgs ? ""
 , ...
 }@args:
 let
@@ -15,8 +17,10 @@ let
   cleanedArgs = builtins.removeAttrs args [
     "cargoBuildCommand"
     "cargoCheckCommand"
+    "cargoCheckExtraArgs"
     "cargoExtraArgs"
     "cargoTestCommand"
+    "cargoTestExtraArgs"
     "dummySrc"
   ];
 
@@ -46,12 +50,12 @@ mkCargoDerivation (cleanedArgs // {
   # First we run `cargo check` to cache cargo's internal artifacts, fingerprints, etc. for all deps.
   # Then we run `cargo build` to actually compile the deps and cache the results
   buildPhaseCargoCommand = args.buildPhaseCargoCommand or ''
-    ${cargoCheckCommand} ${cargoExtraArgs}
+    ${cargoCheckCommand} ${cargoExtraArgs} ${cargoCheckExtraArgs}
     ${cargoBuildCommand} ${cargoExtraArgs}
   '';
 
   checkPhaseCargoCommand = args.checkPhaseCargoCommand or ''
-    ${cargoTestCommand} ${cargoExtraArgs}
+    ${cargoTestCommand} ${cargoExtraArgs} ${cargoTestExtraArgs}
   '';
 
   # Run tests by default to ensure we cache any dev-dependencies

--- a/lib/cargoBuild.nix
+++ b/lib/cargoBuild.nix
@@ -1,47 +1,18 @@
-{ buildDepsOnly
-, crateNameFromCargoToml
-, mkCargoDerivation
-, vendorCargoDeps
+{ mkCargoDerivation
 }:
 
-{ cargoBuildCommand ? "cargoWithProfile build"
-, cargoTestCommand ? "cargoWithProfile test"
+{ cargoArtifacts
 , cargoExtraArgs ? ""
 , ...
-}@args:
+}@origArgs:
 let
-  crateName = crateNameFromCargoToml args;
-  cleanedArgs = builtins.removeAttrs args [
-    "cargoBuildCommand"
+  args = builtins.removeAttrs origArgs [
     "cargoExtraArgs"
-    "cargoTestCommand"
   ];
-
-  # Avoid recomputing values when passing args down
-  memoizedArgs = {
-    pname = args.pname or crateName.pname;
-    version = args.version or crateName.version;
-
-    # A directory of vendored cargo sources which can be consumed without network
-    # access. Directory structure should basically follow the output of `cargo vendor`.
-    # This can be inferred automatically if the `src` root has a Cargo.lock file.
-    cargoVendorDir = args.cargoVendorDir or (vendorCargoDeps args);
-  };
 in
-mkCargoDerivation (cleanedArgs // memoizedArgs // {
-  doCheck = args.doCheck or true;
+mkCargoDerivation (args // {
+  inherit cargoArtifacts;
 
-  # A directory to an existing cargo `target` directory, which will be reused
-  # at the start of the derivation. Useful for caching incremental cargo builds.
-  # This can be inferred automatically if the `src` root has both a Cargo.toml
-  # and Cargo.lock file.
-  cargoArtifacts = args.cargoArtifacts or (buildDepsOnly args // memoizedArgs);
-
-  buildPhaseCargoCommand = args.buildPhaseCargoCommand or ''
-    ${cargoBuildCommand} ${cargoExtraArgs}
-  '';
-
-  checkPhaseCargoCommand = args.checkPhaseCargoCommand or ''
-    ${cargoTestCommand} ${cargoExtraArgs}
-  '';
+  pnameSuffix = "-build";
+  buildPhaseCargoCommand = "cargoWithProfile build ${cargoExtraArgs}";
 })


### PR DESCRIPTION
## Motivation
Make `cargoBuild` focused on doing just one thing: building a workspace. Namely, _not_ running tests since we have `cargoTest` now.

`buildPackage` will continue to run tests if `doCheck = true;` is set

Fixes #134 

## Checklist
- [x] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [x] updated `docs/API.md` with changes
- [x] updated `CHANGELOG.md`
