### PR TITLE
crateNameFromCargoToml: handle workspace inheritance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   arguments just to the `cargo test` invocation
 * `buildPackage` now delegates to `mkCargoDerivation` instead of `cargoBuild`
 
+### Fixed
+* `crateNameFromCargoToml` now takes workspace inheritance into account. If a
+  crate does not specify `package.version` in its (root) Cargo.toml but does
+  specify `workspace.package.version` then the latter will be returned.
+
 ## [0.8.0] - 2022-10-09
 
 ### Added

--- a/docs/API.md
+++ b/docs/API.md
@@ -597,6 +597,16 @@ raised during evaluation.
 
 Extract a crate's name and version from its Cargo.toml file.
 
+The resulting `pname` attribute will be populated with the value of the
+Cargo.toml's `package.name` attribute, if present. Otherwise a placeholder value
+will be used.
+
+The resulting `version` attribute will be populated with the value of the
+Cargo.toml's (top-level) `package.version` attribute, if present and if the
+value is a string. Otherwise `workspace.package.version` will be used if it is
+present _and_ the value is a string. Otherwise a placeholder version field will
+be used.
+
 ```nix
 lib.crateNameFromCargoToml { cargoToml = ./Cargo.toml; }
 # { pname = "simple"; version = "0.1.0"; }

--- a/lib/crateNameFromCargoToml.nix
+++ b/lib/crateNameFromCargoToml.nix
@@ -1,4 +1,5 @@
-{}:
+{ lib
+}:
 
 args:
 let
@@ -14,5 +15,19 @@ let
 in
 {
   pname = toml.package.name or "cargo-package";
-  version = toml.package.version or "0.0.1";
+
+  # Now that cargo supports workspace inheritance we attempt to select a version
+  # string with the following priorities:
+  # - choose `[package.version]` if the value is present and a string
+  #   (i.e. it isn't `[package.version] = { workspace = "true" }`)
+  # - choose `[workspace.package.version]` if it is present (and a string for good measure)
+  # - otherwise, fall back to a placeholder
+  version =
+    let
+      packageVersion = toml.package.version or null;
+      workspacePackageVersion = toml.workspace.package.version or null;
+    in
+    if lib.isString packageVersion then packageVersion
+    else if lib.isString workspacePackageVersion then workspacePackageVersion
+    else "0.0.1";
 }


### PR DESCRIPTION
## Motivation
`crateNameFromCargoToml` now takes workspace inheritance into account. If a crate does not specify `package.version` in its (root) Cargo.toml but does specify `workspace.package.version` then the latter will be returned.

Refs #113 
Fixes #143 

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [x] updated `docs/API.md` with changes
- [x] updated `CHANGELOG.md`
