### PR TITLE
Change default cargo artifact installation to use symlinks where possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Added
+* A new installation mode has been defined which symlinks identical cargo
+  artifacts against previously generated ones. This allows for linear space
+  usage in the Nix store across many chained derivations (as opposed to using a
+  zstd compressed tarball which uses quadratic space across many chained
+  derivations).
+
+### Changed
+* **Breaking**: all cargo-based derivations will now default to using symlinking
+  their installed artifacts together instead of using zstd compressed tarballs.
+  To get the old behavior back, set `installCargoArtifactsMode = "use-zstd";` in
+  the derivation.
+  - Note that `buildPackage` will continue to use zstd compressed tarballs while
+    building dependencies (unless either of `cargoArtifacts` or
+    `installCargoArtifactsMode` is defined, in which case they will be honored)
+
 ## [0.9.0] - 2022-10-29
 
 ### Changed

--- a/ci/run-tests.sh
+++ b/ci/run-tests.sh
@@ -11,7 +11,10 @@ main() {
   runLocked="1"
 
   while [ $# -gt 0 ]; do
-    case "$1" in
+    local arg="$1";
+    shift
+
+    case "${arg}" in
       "--locked")
         runLocked="1"
         runStable=""
@@ -21,7 +24,7 @@ main() {
         runStable="1"
         ;;
       *)
-        echo "unrecognized option $1"
+        echo "unrecognized option ${arg}"
         exit 1
         ;;
     esac
@@ -58,4 +61,4 @@ runtests() {
   done
 }
 
-main
+main "$@"

--- a/lib/buildPackage.nix
+++ b/lib/buildPackage.nix
@@ -35,7 +35,9 @@ mkCargoDerivation (cleanedArgs // memoizedArgs // {
   doCheck = args.doCheck or true;
   doInstallCargoArtifacts = args.doInstallCargoArtifacts or false;
 
-  cargoArtifacts = args.cargoArtifacts or (buildDepsOnly args // memoizedArgs);
+  cargoArtifacts = args.cargoArtifacts or (buildDepsOnly (args // memoizedArgs // {
+    installCargoArtifactsMode = args.installCargoArtifactsMode or "use-zstd";
+  }));
 
   buildPhaseCargoCommand = args.buildPhaseCargoCommand or ''
     cargoBuildLog=$(mktemp cargoBuildLogXXXX.json)


### PR DESCRIPTION
## Motivation
* Define a new installation mode which symlinks identical artifacts
  against a directory of previously generated ones
* This allows for linear space usage in the Nix store across many
  chained derivations (as opposed to using a zstd compressed tarball
  which uses quadratic space across many chained derivations)
* This new installation mode is the new default for all cargo based
  builds. The previous behavior is still available by setting
  `installCargoArtifactsMode = "use-zstd";` on a derivation
* `buildPackage` will continue to use zstd compressed tarballs while
  building dependencies (unless either of `cargoArtifacts` or
  `installCargoArtifactsMode` is defined, in which case they will be
  honored)

Fixes #76 

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [x] updated `docs/API.md` with changes
- [x] updated `CHANGELOG.md`
