### PR TITLE
registryFromGitIndex: use shallow git checkouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   - Note that `buildPackage` will continue to use zstd compressed tarballs while
     building dependencies (unless either of `cargoArtifacts` or
     `installCargoArtifactsMode` is defined, in which case they will be honored)
+* `registryFromGitIndex` now uses shallow checkouts for better performance
 
 ## [0.9.0] - 2022-10-29
 

--- a/lib/registryFromGitIndex.nix
+++ b/lib/registryFromGitIndex.nix
@@ -9,6 +9,7 @@ let
   index = builtins.fetchGit {
     inherit rev;
     url = indexUrl;
+    shallow = true;
   };
 
   configPath = "${index}/config.json";


### PR DESCRIPTION
## Motivation
Registry repos can get quite large if they have a lot of publish traffic. `registryFromGitIndex` only needs to check out a particular commit and observe the `config.json` file, and since the history is not significant we can use a shallow clone to speed things up

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [ ] updated `docs/API.md` with changes
- [x] updated `CHANGELOG.md`
