### PR TITLE
Allow passing curlOptsList per registry, closes #159

### DIFF
--- a/lib/downloadCargoPackage.nix
+++ b/lib/downloadCargoPackage.nix
@@ -9,10 +9,12 @@
 , ...
 }@args:
 let
+  pkgInfo = urlForCargoPackage args;
   tarball = fetchurl {
     name = "${name}-${version}";
     sha256 = checksum;
-    url = urlForCargoPackage args;
+    url = pkgInfo.url;
+    curlOptsList = pkgInfo.curlOptsList;
   };
 in
 runCommandLocal "cargo-package-${name}-${version}" { } ''

--- a/lib/registryFromDownloadUrl.nix
+++ b/lib/registryFromDownloadUrl.nix
@@ -4,6 +4,7 @@
 # https://doc.rust-lang.org/cargo/reference/registries.html
 { dl
 , indexUrl
+, curlOptsList ? []
 }:
 let
   matches = m: builtins.match ".*${lib.escapeRegex m}.*" dl;
@@ -24,5 +25,8 @@ let
     else "${registryPrefix}${indexUrl}";
 in
 {
-  "${registryIndexUrl}" = fullDownloadUrl;
+  "${registryIndexUrl}" = {
+    downloadUrl = fullDownloadUrl;
+    curlOptsList = curlOptsList;
+  };
 }

--- a/lib/urlForCargoPackage.nix
+++ b/lib/urlForCargoPackage.nix
@@ -19,7 +19,7 @@ let
     else if nameLen == 3 then "3/${substr 0 1 name}"
     else "${substr 0 2 name}/${substr 2 4 name}";
 
-  dl = crateRegistries.${source} or (throw ''
+  registry = crateRegistries.${source} or (throw ''
     not sure how to download crates from ${source}.
     for example, this can be resolved with:
 
@@ -42,19 +42,22 @@ let
     }
   '');
 in
-builtins.replaceStrings
-  [
-    "{crate}"
-    "{version}"
-    "{prefix}"
-    "{lowerprefix}"
-    "{sha256-checksum}"
-  ]
-  [
-    name
-    version
-    prefix
-    (lib.toLower prefix)
-    checksum
-  ]
-  dl
+  {
+    url = builtins.replaceStrings
+      [
+        "{crate}"
+        "{version}"
+        "{prefix}"
+        "{lowerprefix}"
+        "{sha256-checksum}"
+      ]
+      [
+        name
+        version
+        prefix
+        (lib.toLower prefix)
+        checksum
+      ]
+      registry.downloadUrl;
+    curlOptsList = registry.curlOptsList;
+  }


### PR DESCRIPTION
## Motivation

So we don't want to merge this as-is, but this is just my POC for #159.

Most of the diff is noise because I have "nixfmt on save", I'll try and redo it without it maybe? but I'm not sure what the formatting rules for this repo are either so 🤷

Essentially:

  * `registryFromDownloadUrl` now takes an optional `curlOptsList` (defaults to `[]`)
  * the entries in `crateRegistries` are no longer strings, but a record with keys `downloadUrl` (what the value was before) and `curlOptsList`
  * `urlForCargoPackage` no longer returns a string, but a record with keys `url` (what the value was before) and `curlOptsList`
  * `downloadCargoPackage` has been changed to forward `curlOptsList` to `fetchurl` and use `(urlForCargoPackage args).url`

Apart from the formatting noise, open questions are:

  * should `urlForCargoPackage` be renamed? it no longer returns _just_ the URL
  * what happens if the user's `fetchurl` doesn't support `curlOptsList`?

Anyway this works for me for now, I'm happy to address feedback so this can land, or to wait till you make your own PR @ipetkov.

<!--
Thank you for your contribution! Please add a brief description below about the change and what is the motivation
behind it.
-->

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [ ] updated `docs/API.md` with changes
- [ ] updated `CHANGELOG.md`
