### PR TITLE
removeReferencesToVendoredSourcesHook: use a single sed invocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 * Unpacking a git repository now ignores duplicate crates to match cargo's
   behavior
+* Sped up stripping references to source files
 
 ## [0.9.0] - 2022-10-29
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -213,7 +213,6 @@ environment variables during the build, you can bring them back via
 The following hooks are automatically added as native build inputs:
 * `installFromCargoBuildLogHook`
 * `jq`
-* `removeReferencesTo`
 * `removeReferencesToVendoredSourcesHook`
 
 ### `lib.cargoAudit`
@@ -1218,5 +1217,3 @@ sources themselves. It takes two positional arguments:
 `doNotRemoveReferencesToVendorDir` is not set, then
 `removeReferencesToVendoredSources "$out" "$cargoVendorDir"` will be run as a
 post install hook.
-
-**Required nativeBuildInputs**: assumes `remove-references-to` is available on the `$PATH`

--- a/lib/buildPackage.nix
+++ b/lib/buildPackage.nix
@@ -4,7 +4,6 @@
 , jq
 , lib
 , mkCargoDerivation
-, removeReferencesTo
 , removeReferencesToVendoredSourcesHook
 , vendorCargoDeps
 }:
@@ -72,7 +71,6 @@ mkCargoDerivation (cleanedArgs // memoizedArgs // {
   nativeBuildInputs = (args.nativeBuildInputs or [ ]) ++ [
     installFromCargoBuildLogHook
     jq
-    removeReferencesTo
     removeReferencesToVendoredSourcesHook
   ];
 })


### PR DESCRIPTION
## Motivation
* Speed up the `removeReferencesToVendoredSourcesHook`
* Turns out it is much faster to build up one big regex of the references to remove and invoking `sed` just once than it is to invoke it once per reference

Fixes #161 

## Checklist
- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [x] updated `docs/API.md` with changes
- [x] updated `CHANGELOG.md`
