### PR TITLE
ci: test against 22.11 and stop testing 22.05

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,7 +59,7 @@ jobs:
             install_url: https://nixos.org/nix/install
           - os: ubuntu-latest
             # The 22.11 branch ships with Nix 2.11.0
-          - install_url: https://releases.nixos.org/nix/nix-2.11.0/install
+            install_url: https://releases.nixos.org/nix/nix-2.11.0/install
             nixpkgs-override: "--override-input nixpkgs github:NixOS/nixpkgs/release-22.11"
           - os: macos-12
             # Latest and greatest release of Nix

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,9 +30,9 @@ jobs:
         include:
             # Latest and greatest release of Nix
           - install_url: https://nixos.org/nix/install
-            # The 22.05 branch ships with Nix 2.8.1
-          - install_url: https://releases.nixos.org/nix/nix-2.8.1/install
-            nixpkgs-override: "--override-input nixpkgs github:NixOS/nixpkgs/release-22.05"
+            # The 22.11 branch ships with Nix 2.11.0
+          - install_url: https://releases.nixos.org/nix/nix-2.11.0/install
+            nixpkgs-override: "--override-input nixpkgs github:NixOS/nixpkgs/release-22.11"
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -58,13 +58,13 @@ jobs:
             # Latest and greatest release of Nix
             install_url: https://nixos.org/nix/install
           - os: ubuntu-latest
-            # The 22.05 branch ships with Nix 2.8.1
-            install_url: https://releases.nixos.org/nix/nix-2.8.1/install
-            nixpkgs-override: "--override-input nixpkgs github:NixOS/nixpkgs/release-22.05"
+            # The 22.11 branch ships with Nix 2.11.0
+          - install_url: https://releases.nixos.org/nix/nix-2.11.0/install
+            nixpkgs-override: "--override-input nixpkgs github:NixOS/nixpkgs/release-22.11"
           - os: macos-12
             # Latest and greatest release of Nix
             install_url: https://nixos.org/nix/install
-            nixpkgs-override: "--override-input nixpkgs github:NixOS/nixpkgs/nixpkgs-22.05-darwin"
+            nixpkgs-override: "--override-input nixpkgs github:NixOS/nixpkgs/nixpkgs-22.11-darwin"
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Changed
+* **Breaking**: dropped compatibility for Nix versions below 2.11.0
+* **Breaking**: dropped compatibility for nixpkgs-22.05. nixpkgs-22.11 and
+  nixpkgs-unstable are fully supported
+
 ## [0.10.0] - 2022-12-01
 
 ### Added

--- a/checks/default.nix
+++ b/checks/default.nix
@@ -335,10 +335,10 @@ in
     pname = "workspace-hack";
   };
 
-  workspaceInheritance = lib.optionalAttrs (lib.versionAtLeast pkgs.cargo.version "1.64.0") (myLib.buildPackage {
+  workspaceInheritance = myLib.buildPackage {
     src = myLib.cleanCargoSource ./workspace-inheritance;
     pname = "workspace-inheritance";
-  });
+  };
 
   workspaceRoot = myLib.buildPackage {
     src = myLib.cleanCargoSource ./workspace-root;

--- a/checks/nextest.nix
+++ b/checks/nextest.nix
@@ -1,15 +1,8 @@
-{ cargo-nextest
-, cargoNextest
-, lib
-, runCommand
+{ cargoNextest
+, linkFarmFromDrvs
 }:
 
 let
-  # cargo-nextest version in the stable-22.05 branch is too old
-  nextestSupportsArchives = lib.versionAtLeast
-    cargo-nextest.version
-    "0.9.15";
-
   nextestSimple = cargoNextest {
     src = ./simple;
     pname = "nextest-simple";
@@ -32,12 +25,8 @@ let
     cargoArtifacts = null;
   };
 in
-runCommand "nextestTests"
-{
-  buildInputs = [ nextestSimple ] ++ (lib.optionals nextestSupportsArchives [
-    nextestPartitionsCount
-    nextestPartitionsHash
-  ]);
-} ''
-  mkdir -p $out
-''
+linkFarmFromDrvs "nextestTests" [
+  nextestSimple
+  nextestPartitionsCount
+  nextestPartitionsHash
+]

--- a/checks/nextest.nix
+++ b/checks/nextest.nix
@@ -1,5 +1,5 @@
 { cargoNextest
-, linkFarmFromDrvs
+, runCommand
 }:
 
 let
@@ -25,8 +25,13 @@ let
     cargoArtifacts = null;
   };
 in
-linkFarmFromDrvs "nextestTests" [
-  nextestSimple
-  nextestPartitionsCount
-  nextestPartitionsHash
-]
+runCommand "nextestTests"
+{
+  buildInputs = [
+    nextestSimple
+    nextestPartitionsCount
+    nextestPartitionsHash
+  ];
+} ''
+  mkdir -p $out
+''


### PR DESCRIPTION
## Motivation
The 22.11 branch was released and 22.05 is now deprecated

## Checklist
- [x] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [ ] updated `docs/API.md` with changes
- [x] updated `CHANGELOG.md`
