### PR TITLE
zstd: use as many threads as we can when compressing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * **Breaking**: dropped compatibility for Nix versions below 2.11.0
 * **Breaking**: dropped compatibility for nixpkgs-22.05. nixpkgs-22.11 and
   nixpkgs-unstable are fully supported
+* Zstd compression of cargo artifacts now defaults to using as many cores as
+  `$NIX_BUILD_CORES` allows for (or all available cores if it isn't defined)
 
 ## [0.10.0] - 2022-12-01
 

--- a/lib/setupHooks/installCargoArtifactsHook.sh
+++ b/lib/setupHooks/installCargoArtifactsHook.sh
@@ -14,7 +14,7 @@ compressAndInstallCargoArtifactsDir() {
       --group=0 \
       --numeric-owner \
       --pax-option=exthdr.name=%d/PaxHeaders/%f,delete=atime,delete=ctime \
-      -c "${cargoTargetDir}" | zstd -o "${dest}"
+      -c "${cargoTargetDir}" | zstd "-T${NIX_BUILD_CORES:-0}" -o "${dest}"
   )
 }
 


### PR DESCRIPTION
## Motivation
zstd compression is supposed to be deterministic (even with multiple threads) so we might as well allow it to use as many cores as are available to the derivation

Fixes #182

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [ ] updated `docs/API.md` with changes
- [x] updated `CHANGELOG.md`
