### PR TITLE
Add buildInputs to quick-start doc

### DIFF
--- a/examples/quick-start/flake.nix
+++ b/examples/quick-start/flake.nix
@@ -65,7 +65,7 @@
           };
 
           my-crate-doc = craneLib.cargoDoc {
-            inherit cargoArtifacts src;
+            inherit cargoArtifacts src buildInputs;
           };
 
           # Check formatting


### PR DESCRIPTION
## Motivation

Upon further testing it looks like the crate-doc quick start also needs buildInputs when you add more involved doc tests on macos. Other platforms should remain unaffected.

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [ ] added tests to verify new behavior
- [x] added an example template or updated an existing one
- [ ] updated `docs/API.md` with changes
- [ ] updated `CHANGELOG.md`
