### PR TITLE
multi folder build support

### DIFF
--- a/lib/buildDepsOnly.nix
+++ b/lib/buildDepsOnly.nix
@@ -36,7 +36,7 @@ let
   cargoCheckExtraArgs = args.cargoCheckExtraArgs or (if doCheck then "--all-targets" else "");
 
   path = args.src or throwMsg;
-  cargoToml = path + "/Cargo.toml";
+  cargoToml = args.cargoToml or (path + "/Cargo.toml");
   dummySrc = args.dummySrc or
     (if builtins.pathExists cargoToml
     then mkDummySrc args


### PR DESCRIPTION
## Motivation

```
./a/b/Cargo.toml - simple package without workspace
./c/d/Cargo.lock
./c/d/Cargo.toml - workspace
./c/d/e/Cargo.toml - package from workspace referencing ./a/b/Cargo.toml 
```

So we can setup toml file from any folder to allow non root folder build.

Are there other options?

## Checklist

- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [ ] updated `docs/API.md` with changes
- [ ] updated `CHANGELOG.md`
