### PR TITLE
mkDummySource: fix build invalidation regression

### DIFF
--- a/lib/mkDummySrc.nix
+++ b/lib/mkDummySrc.nix
@@ -223,7 +223,8 @@ let
   # `/build/dummy-src/...`).
   sourceName =
     let
-      srcStorePath = removePrefix storeDir src;
+      # NB: we just want to get the source's name but not depend on it
+      srcStorePath = builtins.unsafeDiscardStringContext (removePrefix storeDir src);
       nameWithoutHash = match "/[a-z0-9]+-(.*)" srcStorePath;
     in
     if (nameWithoutHash == null)


### PR DESCRIPTION
## Motivation
* When checking the original source for its name, make sure we throw away the string context so we don't end up actually depending on the original source instead of the cleaned one

Fixes https://github.com/ipetkov/crane/issues/194

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [ ] updated `docs/API.md` with changes
- [ ] updated `CHANGELOG.md`
