### PR TITLE
Add `cargoMetadataExtraArgs`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Added
+* `buildPackage` now accepts `cargoManifestExtraArgs` for passing additional
+  arguments just to the `cargo manifest` invocation
+
 ### Fixed
 * Previously compiled build scripts now maintain their executable bit when
   inherited

--- a/docs/API.md
+++ b/docs/API.md
@@ -104,6 +104,9 @@ to influence its behavior.
 * `cargoExtraArgs`: additional flags to be passed in the cargo invocation (e.g.
   enabling specific features)
   - Default value: `""`
+* `cargoMetadataExtraArgs`: additional flags to be passed in the `cargo metadata`
+  invocation (e.g. specifying `--manifest-path`)
+  - Default value: `""`
 * `cargoTestCommand`: A cargo invocation to run during the derivation's check
   phase
   - Default value: `"cargo test --profile release"`

--- a/lib/buildPackage.nix
+++ b/lib/buildPackage.nix
@@ -10,6 +10,7 @@
 
 { cargoBuildCommand ? "cargoWithProfile build"
 , cargoExtraArgs ? ""
+, cargoMetadataExtraArgs ? ""
 , cargoTestCommand ? "cargoWithProfile test"
 , cargoTestExtraArgs ? ""
 , ...
@@ -19,6 +20,7 @@ let
   cleanedArgs = builtins.removeAttrs args [
     "cargoBuildCommand"
     "cargoExtraArgs"
+    "cargoMetadataExtraArgs"
     "cargoTestCommand"
     "cargoTestExtraArgs"
   ];
@@ -49,7 +51,7 @@ mkCargoDerivation (cleanedArgs // memoizedArgs // {
 
   installPhaseCommand = args.installPhaseCommand or ''
     if [ -n "$cargoBuildLog" -a -f "$cargoBuildLog" ]; then
-      installFromCargoBuildLog "$out" "$cargoBuildLog"
+      installFromCargoBuildLog "$out" "$cargoBuildLog" ${cargoMetadataExtraArgs}
     else
       echo ${lib.strings.escapeShellArg ''
         !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!

--- a/lib/setupHooks/installFromCargoBuildLogHook.sh
+++ b/lib/setupHooks/installFromCargoBuildLogHook.sh
@@ -31,7 +31,7 @@ function installFromCargoBuildLog() (
 
   jq -r <"${log}" "${select_bins}" | installArtifacts "${dest}/bin"
 
-  command cargo metadata --format-version 1 | jq '.workspace_members[]' | (
+  command cargo metadata --format-version 1 "${@:3}" | jq '.workspace_members[]' | (
     while IFS= read -r ws_member; do
       local select_member_libs="select(.package_id == ${ws_member}) | ${select_lib_files}"
       jq -r <"${log}" "${select_member_libs}" | installArtifacts "${dest}/lib"


### PR DESCRIPTION
## Motivation
<!--
Thank you for your contribution! Please add a brief description below about the change and what is the motivation
behind it.
-->
This adds `cargoMetadataExtraArgs` to support the use case described in https://github.com/ipetkov/crane/issues/209. In short, it enables building projects where `Cargo.toml` lives in a subdirectory of the root. 

This almost worked already:

```nix
{
  src = ./.;
  cargoToml = ./backend/Cargo.toml;
  cargoLock = ./backend/Cargo.lock;
  cargoExtraArgs = "--manifest-path ./backend/Cargo.toml";
}
```

but `cargoExtraArgs` wasn't being passed to `cargo manifest`.

I tried providing `cargoExtraArgs` there first, but some flags aren't supported by `cargo metadata` so it makes sense to have a separate option.

For example, I'm also providing `--package` in `cargoExtraArgs` and `cargo manifest` complains about that.

So, this pull request allows for this instead:

```nix
{
  src = ./.;
  cargoToml = ./backend/Cargo.toml;
  cargoLock = ./backend/Cargo.lock;
  cargoMetadataExtraArgs = "--manifest-path ./backend/Cargo.toml";
}
```

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [x] updated `docs/API.md` with changes
- [x] updated `CHANGELOG.md`
