### PR TITLE
ignore non-json lines in cargoBuildLog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Fixed
+* `buildPackage` is more tolerant of misbehaving proc macros which write to
+  stdout during the build
+
 ## [0.11.1] - 2023-01-21
 
 ### Changed

--- a/checks/default.nix
+++ b/checks/default.nix
@@ -126,6 +126,7 @@ in
       touch $out
     '';
 
+  # https://github.com/ipetkov/crane/pull/234
   nonJsonCargoBuildLog =
     let
       nonJson = ''

--- a/checks/default.nix
+++ b/checks/default.nix
@@ -126,6 +126,21 @@ in
       touch $out
     '';
 
+  nonJsonCargoBuildLog =
+    let
+      nonJson = ''
+        db_id attr "field_id" Attribute { pound_token: Pound, style: Outer, bracket_token: Bracket, path: Path { leading_colon: None, segments: [PathSegment { ident: Ident { ident: "db_id", span: #0 bytes(8250..8255) }, arguments: None }] }, tokens: TokenStream [] }
+      '';
+    in
+    myLib.buildPackage {
+      src = myLib.cleanCargoSource ./simple;
+      buildPhaseCargoCommand = ''
+        cargoBuildLog=$(mktemp cargoBuildLogXXXX.json)
+        cargoWithProfile build --message-format json-render-diagnostics >"$cargoBuildLog"
+        echo "${nonJson}" >>"$cargoBuildLog"
+      '';
+    };
+
   # https://github.com/ipetkov/crane/discussions/203
   dependencyBuildScriptPerms = myLib.cargoClippy {
     src = ./dependencyBuildScriptPerms;


### PR DESCRIPTION
Fix issues with non-JSON values in `cargoBuildLog` by ignoring non-json lines.

## Motivation
In some cases using cargo with `message-format=json` prints some non-json lines: https://github.com/rust-lang/cargo/issues/8179

When that's the case crane currently fails with:
```
searching for bins/libs to install from cargo build log at cargoBuildLogGbmv.json
parse error: Invalid numeric literal at line 390, column 6
```

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [x] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [ ] updated `docs/API.md` (or general documentation) with changes
- [ ] updated `CHANGELOG.md`
