### PR TITLE
crateNameFromCargoToml: warn when values can't be found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Changed
+* A warning will now be emitted if a derivation's `pname` or `version`
+  attributes are not set and the value cannot be loaded from the derivation's
+  root `Cargo.toml`. To resolve it consider setting `pname = "...";` or `version
+  = "...";` explicitly on the derivation.
+
 ## [0.11.2] - 2023-02-11
 
 ### Fixed

--- a/checks/default.nix
+++ b/checks/default.nix
@@ -380,11 +380,13 @@ in
   workspace = myLib.buildPackage {
     src = myLib.cleanCargoSource ./workspace;
     pname = "workspace";
+    version = "0.0.1";
   };
 
   workspaceHack = myLib.buildPackage {
     src = myLib.cleanCargoSource ./workspace-hack;
     pname = "workspace-hack";
+    version = "0.0.1";
   };
 
   workspaceInheritance = myLib.buildPackage {
@@ -394,6 +396,8 @@ in
 
   # https://github.com/ipetkov/crane/issues/209
   workspaceRootNotAtSourceRoot = myLib.buildPackage {
+    pname = "workspaceRootNotAtSourceRoot";
+    version = "0.0.1";
     src = myLib.cleanCargoSource ./workspace-not-at-root;
     postUnpack = ''
       cd $sourceRoot/workspace
@@ -411,6 +415,7 @@ in
   workspaceGit = myLib.buildPackage {
     src = myLib.cleanCargoSource ./workspace-git;
     pname = "workspace-git";
+    version = "0.0.1";
   };
 })
 )

--- a/docs/API.md
+++ b/docs/API.md
@@ -605,8 +605,10 @@ raised during evaluation.
 Extract a crate's name and version from its Cargo.toml file.
 
 The resulting `pname` attribute will be populated with the value of the
-Cargo.toml's `package.name` attribute, if present. Otherwise a placeholder value
-will be used.
+Cargo.toml's (top-level) `package.name` attribute, if present and if the
+value is a string. Otherwise `workspace.package.name` will be used if it is
+present _and_ the value is a string. Otherwise a placeholder version field will
+be used.
 
 The resulting `version` attribute will be populated with the value of the
 Cargo.toml's (top-level) `package.version` attribute, if present and if the

--- a/lib/mkCargoDerivation.nix
+++ b/lib/mkCargoDerivation.nix
@@ -5,6 +5,7 @@
 , crateNameFromCargoToml
 , inheritCargoArtifactsHook
 , installCargoArtifactsHook
+, lib
 , stdenv
 , vendorCargoDeps
 , zstd


### PR DESCRIPTION
## Motivation
Emit a warning whenever `crateNameFromCargoToml` fails to find an appropriate value for a package's `name` or `version` fields. This should make it a bit more obvious when this happens (i.e. so the caller can explicitly set an appropriate value and not have things like `nix run` break "inexplicably") but still allow the build to go through.

Fixes https://github.com/ipetkov/crane/issues/236

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [x] updated `docs/API.md` (or general documentation) with changes
- [x] updated `CHANGELOG.md`
