### PR TITLE
Add cargoBench

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Added
+* `cargoBench` can now be used to run cargo benchmarks
+
 ### Changed
 * A warning will now be emitted if a derivation's `pname` or `version`
   attributes are not set and the value cannot be loaded from the derivation's

--- a/lib/cargoBench.nix
+++ b/lib/cargoBench.nix
@@ -1,0 +1,18 @@
+{ mkCargoDerivation
+}:
+
+{ cargoExtraArgs ? ""
+, cargoBenchExtraArgs ? ""
+, ...
+}@origArgs:
+let
+  args = builtins.removeAttrs origArgs [
+    "cargoExtraArgs"
+    "cargoBenchExtraArgs"
+  ];
+in
+mkCargoDerivation (args // {
+  pnameSuffix = "-bench";
+
+  buildPhaseCargoCommand = "cargoWithProfile bench ${cargoExtraArgs} ${cargoBenchExtraArgs}";
+})

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -14,6 +14,7 @@ in
   buildDepsOnly = callPackage ./buildDepsOnly.nix { };
   buildPackage = callPackage ./buildPackage.nix { };
   cargoAudit = callPackage ./cargoAudit.nix { };
+  cargoBench = callPackage ./cargoBench.nix { };
   cargoBuild = callPackage ./cargoBuild.nix { };
   cargoClippy = callPackage ./cargoClippy.nix { };
   cargoDoc = callPackage ./cargoDoc.nix { };


### PR DESCRIPTION
Allows running cargo benchmarks easily via crane.

## Motivation

Noticed this was missing in a project I'm working on [using crane](https://github.com/tweag/nickel/pull/1119/files#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0R220).

Creating as a draft to gauge interest before sinking more time into this :)

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [ ] updated `docs/API.md` (or general documentation) with changes
- [x] updated `CHANGELOG.md`
