### PR TITLE
buildDepsOnly: warn if both `src` and `dummySrc` are set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   attributes are not set and the value cannot be loaded from the derivation's
   root `Cargo.toml`. To resolve it consider setting `pname = "...";` or `version
   = "...";` explicitly on the derivation.
+* A warning will now be emitted if `src` and `dummySrc` are passed to
+  `buildDepsOnly` as `dummySrc` will take priority
 
 ## [0.11.2] - 2023-02-11
 

--- a/lib/buildDepsOnly.nix
+++ b/lib/buildDepsOnly.nix
@@ -1,4 +1,5 @@
 { crateNameFromCargoToml
+, lib
 , mkCargoDerivation
 , mkDummySrc
 , vendorCargoDeps
@@ -28,7 +29,14 @@ let
 
   cargoCheckExtraArgs = args.cargoCheckExtraArgs or (if doCheck then "--all-targets" else "");
 
-  dummySrc = args.dummySrc or (mkDummySrc args);
+  dummySrc =
+    if args ? dummySrc then
+      lib.warnIf
+        (args ? src && args.src != null)
+        "buildDepsOnly will ignore `src` when `dummySrc` is specified"
+        args.dummySrc
+    else
+      mkDummySrc args;
 in
 mkCargoDerivation (cleanedArgs // {
   inherit doCheck;


### PR DESCRIPTION
## Motivation
Warn if both `src` and `dummySrc` are set to hopefully avoid debugging confusion as reported in https://github.com/ipetkov/crane/issues/241

Fixes https://github.com/ipetkov/crane/issues/241

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [ ] updated `docs/API.md` (or general documentation) with changes
- [x] updated `CHANGELOG.md`
