### PR TITLE
mkDummySrc: avoid invalidation if the source name has two hashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Fixed
+* Fixed an unintentional cache invalidation whenever `buildDepsOnly` would run
+  on an unfiltered source (like `src = ./.;`).
+
 ### Changed
 * A warning will now be emitted if a derivation's `pname` or `version`
   attributes are not set and the value cannot be loaded from the derivation's

--- a/lib/mkDummySrc.nix
+++ b/lib/mkDummySrc.nix
@@ -16,11 +16,11 @@ let
     dirOf
     concatStringsSep
     hasAttr
-    head
     match
     storeDir;
 
   inherit (lib)
+    last
     optionalString
     recursiveUpdate
     removePrefix;
@@ -225,12 +225,14 @@ let
     let
       # NB: we just want to get the source's name but not depend on it
       srcStorePath = builtins.unsafeDiscardStringContext (removePrefix storeDir src);
-      nameWithoutHash = match "/[a-z0-9]+-(.*)" srcStorePath;
+      # NB: skip all potential hash sequences sometimes there can be two!
+      # https://github.com/ipetkov/crane/issues/242
+      nameWithoutHash = match "/([a-z0-9]{32}-)+(.*)" srcStorePath;
     in
     if (nameWithoutHash == null)
     # Fall back to a static name if the matching fails for any reason
     then "dummy-src"
-    else head nameWithoutHash;
+    else last nameWithoutHash;
 in
 runCommandLocal sourceName { } ''
   mkdir -p $out


### PR DESCRIPTION
## Motivation
Turns out that for whatever reason a flake source like `src = ./.;` might show up in the Nix store with _two_ hashes instead of one (not sure if this is a regression somewhere upstream, but even if it is, let's not trip up on it)

Fixes https://github.com/ipetkov/crane/issues/242

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [ ] updated `docs/API.md` (or general documentation) with changes
- [x] updated `CHANGELOG.md`
