### PR TITLE
feat: add `cargoLockParsed` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ["artifact dependencies" nightly feature](https://doc.rust-lang.org/cargo/reference/unstable.html#artifact-dependencies)
 in case a crate is used as `bin` artifact dependency.
 
+* Add `cargoLockParsed` option to `vendorCargoDeps` to support `Cargo.lock`
+files parsed as nix attribute sets.
+
 ## [0.11.3] - 2023-02-19
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * Add a stubbed binary target to each "dummy" crate generated to support
 ["artifact dependencies" nightly feature](https://doc.rust-lang.org/cargo/reference/unstable.html#artifact-dependencies)
 in case a crate is used as `bin` artifact dependency.
-
 * Add `cargoLockParsed` option to `vendorCargoDeps` to support `Cargo.lock`
 files parsed as nix attribute sets.
 
@@ -22,6 +21,11 @@ files parsed as nix attribute sets.
   on an unfiltered source (like `src = ./.;`).
 
 ### Changed
+* **Breaking** (technically): `mkCargoDerivation` will remove the following
+  attributes before lowering to `mkDerivation`: `cargoLock`, `cargoLockContents`
+  and `cargoLockParsed`. If your derivation needs these values to be present
+  they can be explicitly passed through via `.overrideAttrs`
+  `buildDepsOnly` as `dummySrc` will take priority
 * A warning will now be emitted if a derivation's `pname` or `version`
   attributes are not set and the value cannot be loaded from the derivation's
   root `Cargo.toml`. To resolve it consider setting `pname = "...";` or `version

--- a/checks/default.nix
+++ b/checks/default.nix
@@ -37,20 +37,33 @@ in
 
   # NB: explicitly using a github release (not crates.io release)
   # which lacks a Cargo.lock file, so we can test adding our own
-  cargoLockOverride = myLib.buildPackage rec {
-    pname = "cargo-llvm-cov";
-    version = "0.4.14";
+  cargoLockOverride =
+    let
+      cargoLock = ./testCargoLockOverride.lock;
+      cargoLockContents = builtins.readFile cargoLock;
+      cargoLockParsed = builtins.fromTOML cargoLockContents;
+    in
+    pkgs.linkFarmFromDrvs "cargoLockOverride-tests" (map
+      (args:
+        myLib.buildPackage (args // rec {
+          pname = "cargo-llvm-cov";
+          version = "0.4.14";
 
-    src = pkgs.fetchFromGitHub {
-      owner = "taiki-e";
-      repo = pname;
-      rev = "v${version}";
-      sha256 = "sha256-sNwizxYVUNyv5InR8HS+CyUsroA79h/FpouS+fMWJUI=";
-    };
+          src = pkgs.fetchFromGitHub {
+            owner = "taiki-e";
+            repo = pname;
+            rev = "v${version}";
+            sha256 = "sha256-sNwizxYVUNyv5InR8HS+CyUsroA79h/FpouS+fMWJUI=";
+          };
 
-    doCheck = false; # Tests need llvm-tools installed
-    cargoLock = ./testCargoLockOverride.lock;
-  };
+          doCheck = false; # Tests need llvm-tools installed
+        }))
+      [
+        { inherit cargoLock; }
+        { inherit cargoLockContents; }
+        { inherit cargoLockParsed; }
+      ]
+    );
 
   cargoTarpaulin = lib.optionalAttrs x64Linux (myLib.cargoTarpaulin {
     src = ./simple;

--- a/docs/API.md
+++ b/docs/API.md
@@ -1026,6 +1026,7 @@ the vendored directories (i.e. this configuration can be appended to the
 * `src`: a directory which includes a Cargo.lock file at its root.
 * `cargoLock`: a path to a Cargo.lock file
 * `cargoLockContents`: the contents of a Cargo.lock file as a string
+* `cargoLockParsed`: the parsed contents of Cargo.lock as an attribute set
 
 At least one of the above attributes must be specified, or an error will be
 raised during evaluation.

--- a/docs/API.md
+++ b/docs/API.md
@@ -804,6 +804,9 @@ environment variables during the build, you can bring them back via
 `.overrideAttrs`.
 
 * `buildPhaseCargoCommand`
+* `cargoLock`
+* `cargoLockContents`
+* `cargoLockParsed`
 * `checkPhaseCargoCommand`
 * `installPhaseCommand`
 * `pnameSuffix`

--- a/lib/mkCargoDerivation.nix
+++ b/lib/mkCargoDerivation.nix
@@ -5,7 +5,6 @@
 , crateNameFromCargoToml
 , inheritCargoArtifactsHook
 , installCargoArtifactsHook
-, lib
 , stdenv
 , vendorCargoDeps
 , zstd
@@ -31,6 +30,8 @@ let
   chosenStdenv = args.stdenv or stdenv;
   cleanedArgs = builtins.removeAttrs args [
     "buildPhaseCargoCommand"
+    "cargoLock"
+    "cargoLockContents"
     "cargoLockParsed"
     "checkPhaseCargoCommand"
     "installPhaseCommand"

--- a/lib/mkCargoDerivation.nix
+++ b/lib/mkCargoDerivation.nix
@@ -31,6 +31,7 @@ let
   chosenStdenv = args.stdenv or stdenv;
   cleanedArgs = builtins.removeAttrs args [
     "buildPhaseCargoCommand"
+    "cargoLockParsed"
     "checkPhaseCargoCommand"
     "installPhaseCommand"
     "pnameSuffix"

--- a/lib/vendorCargoDeps.nix
+++ b/lib/vendorCargoDeps.nix
@@ -43,7 +43,7 @@ let
     '')
     (attrNames sources);
 
-  lock = builtins.fromTOML cargoLockContents;
+  lock = args.cargoLockParsed or (builtins.fromTOML cargoLockContents);
   lockPackages = lock.package or (throw "Cargo.lock missing [[package]] definitions");
 
   vendoredRegistries = vendorCargoRegistries {


### PR DESCRIPTION
## Motivation

So I can process `Cargo.lock` with nix without using IFD: https://github.com/nix-community/nix-init/commit/27ed3100259b980633caccc1ac8a7dd6440ba3dd

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [x] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [x] updated `docs/API.md` (or general documentation) with changes
- [x] updated `CHANGELOG.md`
