### PR TITLE
feat: add support for `wit` files

### DIFF
--- a/lib/downloadCargoPackageFromGit.nix
+++ b/lib/downloadCargoPackageFromGit.nix
@@ -29,6 +29,11 @@ in
 runCommandLocal "cargo-git" deps ''
   mkdir -p $out
   existing_crates=()
+  for f in $(find ${repo} -type f -name '*.wit'); do
+    local path=$(realpath --relative-to=${repo} $f)
+    mkdir -p $out/$(dirname $path)
+    cp -L --copy-contents $f $out/$path;
+  done
   while read -r cargoToml; do
     local crate=$(
       cargo metadata --format-version 1 --no-deps --manifest-path "$cargoToml" |

--- a/lib/findCargoFiles.nix
+++ b/lib/findCargoFiles.nix
@@ -6,6 +6,7 @@ let
   inherit (lib)
     flatten
     groupBy
+    hasSuffix
     mapAttrs
     mapAttrsToList;
 
@@ -17,6 +18,7 @@ let
         cur = dir + "/${name}";
         isConfig = parentIsDotCargo && (name == "config" || name == "config.toml");
         isCargoToml = name == "Cargo.toml";
+        isWit = hasSuffix ".wit" name;
       in
       if type == "directory"
       then listFilesRecursive (name == ".cargo") cur
@@ -24,6 +26,8 @@ let
       then [{ path = cur; type = "cargoTomls"; }]
       else if isConfig
       then [{ path = cur; type = "cargoConfigs"; }]
+      else if isWit
+      then [{ path = cur; type = "wits"; }]
       else [ ]
     )
     (builtins.readDir dir));
@@ -36,6 +40,7 @@ let
   default = {
     cargoTomls = [ ];
     cargoConfigs = [ ];
+    wits = [ ];
   };
 in
 default // cleaned

--- a/lib/mkDummySrc.nix
+++ b/lib/mkDummySrc.nix
@@ -105,7 +105,7 @@ let
         (p: removePrefix uncleanSrcBasePath (toString p))
         # Allow the default `Cargo.lock` location to be picked up here
         # (if it exists) so it automattically appears in the cleaned source
-        (uncleanFiles.cargoConfigs ++ [ "Cargo.lock" ]);
+        (uncleanFiles.cargoConfigs ++ uncleanFiles.wits ++ [ "Cargo.lock" ]);
     in
     lib.cleanSourceWith {
       inherit src;

--- a/lib/vendorGitDeps.nix
+++ b/lib/vendorGitDeps.nix
@@ -112,6 +112,13 @@ let
       nameValuePair (hash id) (runCommandLocal "linkLockedDeps" { } ''
         mkdir -p $out
         ${linkPsInLock}
+        for f in $(find ${extractedPackages} -type f -name '*.wit'); do
+          local path=$(realpath --relative-to=${extractedPackages} $f)
+          mkdir -p $out/$(dirname $path)
+          if [ ! -f $out/$path ]; then
+            cp $f $out/$path;
+          fi
+        done
       '')
     )
     lockedGitGroups;


### PR DESCRIPTION
## Motivation
<!--
Thank you for your contribution! Please add a brief description below about the change and what is the motivation
behind it.
-->

(sorry, clicked the "open PR" button too fast)

This PR adds support for WIT files https://github.com/WebAssembly/component-model/blob/main/design/mvp/WIT.md, used by WebAssembly components to generate bindings via https://github.com/bytecodealliance/wit-bindgen

Today, `.wit` files are trimmed by `crane`, which means `bindgen` macro cannot find them (it searches by paths) in the project being built, but, more importantly, in dependencies (here's an example https://github.com/wasmCloud/wasmCloud/actions/runs/4415710680/jobs/7739037159
> wasmcloud-deps> error: failed to read file "/nix/store/4f8fkwmzdh62bjr3wpl2kphq2vixdkj6-vendor-cargo-deps/225fe4a8a7631cbf30190f12e81bfc52813aac3e2e059f80292a8f336881417f/host-0.0.0/../wit"
)

An example of an "unbuildable" WIT-enabled Rust project, which is often included as a depedency is https://github.com/bytecodealliance/preview2-prototyping

Would this PR be something you'd be interested in merging @ipetkov ?

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [ ] updated `docs/API.md` (or general documentation) with changes
- [ ] updated `CHANGELOG.md`
