### PR TITLE
buildPackage: don't inherit installPhase when calling buildDepsOnly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### [0.12.1] - 2023-04-10
 
+### Changed
+* **Breaking**: When setting a default value for `cargoArtifacts`,
+  `buildPackage` will now ignore `installPhase` and `installPhaseCommand` when
+  calling `buildPackage`. To bring back the old behavior, please specify
+  `cargoArtifacts` explicitly
+
 ### Added
 * `vendorMultipleCargoDeps` can now be used to vendor crates from multiple
   distinct `Cargo.lock` files. Notably this allows for building the standard

--- a/docs/API.md
+++ b/docs/API.md
@@ -177,8 +177,10 @@ install hooks.
   `target` directory, which will be reused at the start of the derivation.
   Useful for caching incremental cargo builds.
   - Default value: the result of `buildDepsOnly` after applying the arguments
-    set (with the respective default values). `installCargoArtifactsMode` will
-    be set to `"use-zstd"` if not specified.
+    set (with the respective default values).
+  - `installCargoArtifactsMode` will be set to `"use-zstd"` if not specified.
+  - `installPhase` and `installPhaseCommand` will be removed (in favor of their
+    default values provided by `buildDepsOnly`)
 * `cargoBuildCommand`: A cargo invocation to run during the derivation's build
   phase
   - Default value: `"cargo build --profile release"`


### PR DESCRIPTION
## Motivation
* When setting a default value for `cargoArtifacts`,
  `buildPackage` will now ignore `installPhase` and `installPhaseCommand` when
  calling `buildPackage`. To bring back the old behavior, please specify
  `cargoArtifacts` explicitly

Refs https://github.com/ipetkov/crane/discussions/296

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [x] updated `docs/API.md` (or general documentation) with changes
- [x] updated `CHANGELOG.md`
