### PR TITLE
fix: building trunk projects that use sass, add test

### DIFF
--- a/checks/trunk.nix
+++ b/checks/trunk.nix
@@ -30,6 +30,7 @@ let
 in
 runCommand "trunkTests" { } ''
   test -f ${trunkSimple}/*.wasm
+  test -f ${trunkSimple}/*.css
   test -f ${trunkSimpleNoArtifacts}/*.wasm
   mkdir -p $out
 ''

--- a/checks/trunk/index.html
+++ b/checks/trunk/index.html
@@ -3,5 +3,6 @@
   <head>
     <meta charset="utf-8" />
     <title>Trunk App</title>
+    <link data-trunk rel="scss" href="./main.scss" />
   </head>
 </html>

--- a/checks/trunk/main.scss
+++ b/checks/trunk/main.scss
@@ -1,0 +1,3 @@
+body {
+    background-color: #eee;
+}

--- a/examples/trunk-workspace/client/index.html
+++ b/examples/trunk-workspace/client/index.html
@@ -3,5 +3,6 @@
   <head>
     <meta charset="utf-8" />
     <title>Trunk App</title>
+    <link data-trunk rel="scss" href="./main.scss" />
   </head>
 </html>

--- a/examples/trunk-workspace/client/main.scss
+++ b/examples/trunk-workspace/client/main.scss
@@ -1,0 +1,3 @@
+body {
+    background-color: #eee;
+}

--- a/examples/trunk/index.html
+++ b/examples/trunk/index.html
@@ -3,5 +3,6 @@
   <head>
     <meta charset="utf-8" />
     <title>Trunk App</title>
+    <link data-trunk rel="scss" href="./main.scss" />
   </head>
 </html>

--- a/examples/trunk/main.scss
+++ b/examples/trunk/main.scss
@@ -1,0 +1,3 @@
+body {
+    background-color: #eee;
+}

--- a/lib/buildTrunkPackage.nix
+++ b/lib/buildTrunkPackage.nix
@@ -44,7 +44,7 @@ mkCargoDerivation (args // {
   # whatever tools actually make it into the builder's PATH
   preConfigure = ''
     echo configuring trunk tools
-    export TRUNK_TOOLS_SASS=$(sass --version | cut -d' ' -f1)
+    export TRUNK_TOOLS_SASS=$(sass --version | head -n1)
     export TRUNK_TOOLS_WASM_BINDGEN=$(wasm-bindgen --version | cut -d' ' -f2)
     export TRUNK_TOOLS_WASM_OPT=$(wasm-opt --version | cut -d' ' -f3)
 


### PR DESCRIPTION
## Motivation

The current format for `TRUNK_TOOLS_SASS` is incorrect from Trunk's perspective, it expects the entire first line from the command `sass --version`, this is no problem with the native version of `dart-sass` which outputs only the version `1.56.0`. But the version currently in use is compiled to javascript and has aditional information `1.56.0 compiled with dart2js 2.18.4`.

This PR fixes the proccessing done to `TRUNK_TOOLS_SASS` to match what is expected from Trunk. It also tests sass compilation, and adds a small sass file to the trunk examples.

Thanks to this comment for highligthing the issue: https://github.com/ipetkov/crane/issues/295#issuecomment-1532096291.

## Checklist

- [x] added tests to verify new behavior
- [x] added an example template or updated an existing one
- [ ] updated `docs/API.md` (or general documentation) with changes
- [ ] updated `CHANGELOG.md`
