### PR TITLE
fix: incremental compilation in trunk examples, set target using env var

### DIFF
--- a/checks/trunk.nix
+++ b/checks/trunk.nix
@@ -17,7 +17,7 @@ let
 
   # default build
   cargoArtifacts = myLibWasm.buildDepsOnly (defaultArgs // {
-    cargoExtraArgs = "--target=wasm32-unknown-unknown";
+    CARGO_BUILD_TARGET = "wasm32-unknown-unknown";
   });
   trunkSimple = myLibWasm.buildTrunkPackage (defaultArgs // {
     inherit cargoArtifacts;

--- a/examples/trunk-workspace/flake.nix
+++ b/examples/trunk-workspace/flake.nix
@@ -62,10 +62,8 @@
 
         # Native packages
 
-        # We can avoid building our client's dependencies for the native target.
         nativeArgs = commonArgs // {
           pname = "trunk-workspace-native";
-          cargoExtraArgs = "--workspace --exclude=client";
         };
 
         # Build *just* the cargo dependencies, so we can reuse
@@ -87,6 +85,7 @@
         wasmArgs = commonArgs // {
           pname = "trunk-workspace-wasm";
           cargoExtraArgs = "--package=client";
+          CARGO_BUILD_TARGET = "wasm32-unknown-unknown";
         };
 
         cargoArtifactsWasm = craneLib.buildDepsOnly (wasmArgs // {

--- a/examples/trunk/flake.nix
+++ b/examples/trunk/flake.nix
@@ -54,7 +54,7 @@
         commonArgs = {
           inherit src;
           # We must force the target, otherwise cargo will attempt to use your native target
-          cargoExtraArgs = "--target=wasm32-unknown-unknown";
+          CARGO_BUILD_TARGET = "wasm32-unknown-unknown";
         };
 
         # Build *just* the cargo dependencies, so we can reuse


### PR DESCRIPTION
## Motivation
<!--
Thank you for your contribution! Please add a brief description below about the change and what is the motivation
behind it.
-->

There are currently two issues that cause unnecessary recompilation in the `trunk-workspace` example:
- Excluding the client from native artifacts causes it to be built when running clippy.
- `CARGO_BUILD_TARGET` is not set in `wasmArgs`, that was previously done automatically.

Also replaced all usage `cargoExtraArgs = "--target..."` with `CARGO_BUILD_TARGET`, so it's easier to add arguments without overwriting the target.

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [ ] added tests to verify new behavior
- [x] added an example template or updated an existing one
- [ ] updated `docs/API.md` (or general documentation) with changes
- [ ] updated `CHANGELOG.md`
