### PR TITLE
examples: remove darwin SDKs from cross compile example

### DIFF
--- a/examples/cross-rust-overlay/flake.nix
+++ b/examples/cross-rust-overlay/flake.nix
@@ -47,8 +47,7 @@
         # Normally you can stick this function into its own file and pass
         # its path to `callPackage`.
         crateExpression =
-          { darwin
-          , openssl
+          { openssl
           , libiconv
           , lib
           , pkg-config
@@ -73,12 +72,6 @@
             # overridden above.
             nativeBuildInputs = [
               pkg-config
-            ] ++ lib.optionals stdenv.buildPlatform.isDarwin [
-              # Additional darwin specific inputs can be set here
-              # This should include nay libraries needed for linking proc macros
-              # since they run on the build platform itself
-              libiconv
-              darwin.apple_sdk.frameworks.Security
             ];
 
             # Dependencies which need to be built for the platform on which


### PR DESCRIPTION
## Motivation
Seems like these SDKs aren't necessary, and worse, they're causing issues for some reason. Might as well simplify the example a bit!

Fixes #320 

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [ ] updated `docs/API.md` (or general documentation) with changes
- [ ] updated `CHANGELOG.md`
