### PR TITLE
Symlink cargo build artifacts instead of copying them

### DIFF
--- a/lib/cargoTarpaulin.nix
+++ b/lib/cargoTarpaulin.nix
@@ -3,7 +3,7 @@
 }:
 
 { cargoExtraArgs ? ""
-, cargoTarpaulinExtraArgs ? "--skip-clean --out Xml --output-dir $out"
+, cargoTarpaulinExtraArgs ? "--out Xml --output-dir $out"
 , ...
 }@origArgs:
 let

--- a/lib/setupHooks/inheritCargoArtifacts.nix
+++ b/lib/setupHooks/inheritCargoArtifacts.nix
@@ -1,8 +1,10 @@
 { makeSetupHook
+, rsync
 }:
 
 makeSetupHook
 {
   name = "inheritCargoArtifactsHook";
+  propagatedBuildInputs = [ rsync ];
 } ./inheritCargoArtifactsHook.sh
 


### PR DESCRIPTION
## Motivation

Avoid copying big cargo build artifacts from the nix store, when using `cargoArtifacts`.
This works by just symlinking everything in `target/release/build` and `target/release/deps`. and uses rsync to copy other files. AFAIK the big files are all contained in these folders and are content-addressed by hash, so this *should* be safe.

What I have noticed (even before this change), is that cargo tarpaulin generally seems to rebuild the cargo artifacts, ignoring previous artifacts, even with `--skip-clean`, this fails as it tries to regenerate already built artifacts and tries to write into the build folders.
This should probably be investigated, so that cargo tarpaulin reuses the previously built/cached dependencies.
I have for now just removed `--skip-clean` in cargo tarpaulin, as it doesn't seem to have the intended effect anyway?
Without that flag, all tests run through.

Btw. I have noticed the (now removed) comment, but I have not experienced any issues other than the cargo tarpaulin above.

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [ ] updated `docs/API.md` (or general documentation) with changes
- [ ] updated `CHANGELOG.md`
