### PR TITLE
Natively support sparse registries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 * Added support for the [Trunk](https://trunkrs.dev) wasm app build tool
+* Added support for sparse registries
 
 ### [0.12.1] - 2023-04-10
 

--- a/checks/default.nix
+++ b/checks/default.nix
@@ -391,6 +391,13 @@ in
           indexUrl = "https://github.com/Hirevo/alexandrie-index";
           rev = "90df25daf291d402d1ded8c32c23d5e1498c6725";
         })
+        (myLib.registryFromSparse {
+          indexUrl = "https://index.crates.io/";
+          sha256 = "d16740883624df970adac38c70e35cf077a2a105faa3862f8f99a65da96b14a3";
+          fetchurlExtraArgs = {
+            # Extra parameters which will be passed to the fetchurl invocation for each crate
+          };
+        })
       ];
     in
     myLibWithRegistry.buildPackage {

--- a/checks/default.nix
+++ b/checks/default.nix
@@ -393,7 +393,7 @@ in
         })
         (myLib.registryFromSparse {
           indexUrl = "https://index.crates.io/";
-          sha256 = "d16740883624df970adac38c70e35cf077a2a105faa3862f8f99a65da96b14a3";
+          configSha256 = "d16740883624df970adac38c70e35cf077a2a105faa3862f8f99a65da96b14a3";
           fetchurlExtraArgs = {
             # Extra parameters which will be passed to the fetchurl invocation for each crate
           };

--- a/checks/default.nix
+++ b/checks/default.nix
@@ -392,11 +392,8 @@ in
           rev = "90df25daf291d402d1ded8c32c23d5e1498c6725";
         })
         (myLib.registryFromSparse {
-          indexUrl = "https://index.crates.io/";
+          indexUrl = "https://index.crates.io";
           configSha256 = "d16740883624df970adac38c70e35cf077a2a105faa3862f8f99a65da96b14a3";
-          fetchurlExtraArgs = {
-            # Extra parameters which will be passed to the fetchurl invocation for each crate
-          };
         })
       ];
     in

--- a/docs/API.md
+++ b/docs/API.md
@@ -38,6 +38,8 @@ use when downloading crate sources. Each entry can be defined using:
   registry's `config.json` file
 * `registryFromGitIndex`: if you would like the download URL to be inferred from
   the index's source directly.
+* `registryFromSparse`: if you would like the download URL to be inferred from
+  the index's source directly, and the index is a sparse index.
 
 See the documentation on each function for more specifics.
 
@@ -54,6 +56,12 @@ newLib = craneLib.appendCrateRegistries [
     indexUrl = "https://github.com/Hirevo/alexandrie-index";
     rev = "90df25daf291d402d1ded8c32c23d5e1498c6725";
     fetchurlExtraArgs = {};
+  })
+
+  # Or even
+  (lib.registryFromSparse {
+    url = "https://index.crates.io/";
+    sha256 = "d16740883624df970adac38c70e35cf077a2a105faa3862f8f99a65da96b14a3";
   })
 ];
 ```

--- a/examples/alt-registry/.cargo/config.toml
+++ b/examples/alt-registry/.cargo/config.toml
@@ -1,2 +1,5 @@
 [registries.alexandrie]
 index = "https://github.com/Hirevo/alexandrie-index"
+
+[registries.sparse-crates]
+index = "sparse+https://index.crates.io/"

--- a/examples/alt-registry/Cargo.lock
+++ b/examples/alt-registry/Cargo.lock
@@ -7,6 +7,7 @@ name = "alt-registry"
 version = "0.1.0"
 dependencies = [
  "byteorder",
+ "bytes 1.4.0 (sparse+https://index.crates.io/)",
  "epitech_api",
 ]
 
@@ -59,6 +60,12 @@ checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
 name = "bytes"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
+
+[[package]]
+name = "bytes"
+version = "1.4.0"
+source = "sparse+https://index.crates.io/"
 checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
@@ -360,7 +367,7 @@ version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482"
 dependencies = [
- "bytes 1.4.0",
+ "bytes 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv",
  "itoa 1.0.6",
 ]

--- a/examples/alt-registry/Cargo.toml
+++ b/examples/alt-registry/Cargo.toml
@@ -5,4 +5,5 @@ edition = "2021"
 
 [dependencies]
 byteorder = { version = "*" }
+bytes = { version = "*", registry = "sparse-crates" }
 epitech_api = { version = "*", registry = "alexandrie" }

--- a/examples/alt-registry/flake.nix
+++ b/examples/alt-registry/flake.nix
@@ -42,7 +42,7 @@
 
           # If the registry in question is a sparse index, instead configure as
           (craneLibOrig.registryFromSparse {
-            indexUrl = "https://index.crates.io/";
+            indexUrl = "https://index.crates.io";
             configSha256 = "d16740883624df970adac38c70e35cf077a2a105faa3862f8f99a65da96b14a3";
             fetchurlExtraArgs = {
               # Extra parameters which will be passed to the fetchurl invocation for each crate

--- a/examples/alt-registry/flake.nix
+++ b/examples/alt-registry/flake.nix
@@ -40,6 +40,16 @@
             };
           })
 
+          # If the registry in question is a sparse index, instead configure as
+          (craneLibOrig.registryFromSparse {
+            url = "https://index.crates.io/";
+            sha256 = "d16740883624df970adac38c70e35cf077a2a105faa3862f8f99a65da96b14a3";
+            fetchurlExtraArgs = {
+              # Extra parameters which will be passed to the fetchurl invocation for each crate
+            };
+          })
+          # where the sha256 is the sha256 of https://index.crates.io/config.json.
+
           # As a more lightweight alternative, the `dl` endpoint of the registry's `config.json`
           # file can be copied here to avoid needing to copy the index to the Nix store.
           # (craneLibOrig.registryFromDownloadUrl {

--- a/examples/alt-registry/flake.nix
+++ b/examples/alt-registry/flake.nix
@@ -43,7 +43,7 @@
           # If the registry in question is a sparse index, instead configure as
           (craneLibOrig.registryFromSparse {
             indexUrl = "https://index.crates.io/";
-            sha256 = "d16740883624df970adac38c70e35cf077a2a105faa3862f8f99a65da96b14a3";
+            configSha256 = "d16740883624df970adac38c70e35cf077a2a105faa3862f8f99a65da96b14a3";
             fetchurlExtraArgs = {
               # Extra parameters which will be passed to the fetchurl invocation for each crate
             };

--- a/examples/alt-registry/flake.nix
+++ b/examples/alt-registry/flake.nix
@@ -42,7 +42,7 @@
 
           # If the registry in question is a sparse index, instead configure as
           (craneLibOrig.registryFromSparse {
-            url = "https://index.crates.io/";
+            indexUrl = "https://index.crates.io/";
             sha256 = "d16740883624df970adac38c70e35cf077a2a105faa3862f8f99a65da96b14a3";
             fetchurlExtraArgs = {
               # Extra parameters which will be passed to the fetchurl invocation for each crate

--- a/flake.lock
+++ b/flake.lock
@@ -36,11 +36,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1683020768,
-        "narHash": "sha256-ZyZl6k9NWS5QPwD3NoAVz/eSgodQDvl+y+fu8MVbrHc=",
+        "lastModified": 1684120848,
+        "narHash": "sha256-gIwJ5ac1FwZEkCRwjY+gLwgD4G1Bw3Xtr2jr2XihMPo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "44f30edf5661d86fb3a95841c35127f3d0ea8b0f",
+        "rev": "0cb867999eec4085e1c9ca61c09b72261fa63bb4",
         "type": "github"
       },
       "original": {
@@ -68,11 +68,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1683080331,
-        "narHash": "sha256-nGDvJ1DAxZIwdn6ww8IFwzoHb2rqBP4wv/65Wt5vflk=",
+        "lastModified": 1684117262,
+        "narHash": "sha256-ZSF4CZqeyk6QwTjal73KPMuTWiU6w/p8ygEimrPb7u4=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "d59c3fa0cba8336e115b376c2d9e91053aa59e56",
+        "rev": "4679872d2dd3e94ffef75efcbf77ea11549d90a7",
         "type": "github"
       },
       "original": {

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -64,6 +64,7 @@ in
 
   registryFromDownloadUrl = callPackage ./registryFromDownloadUrl.nix { };
   registryFromGitIndex = callPackage ./registryFromGitIndex.nix { };
+  registryFromSparse = callPackage ./registryFromSparse.nix { };
   removeReferencesToVendoredSourcesHook = callPackage ./setupHooks/removeReferencesToVendoredSources.nix { };
   urlForCargoPackage = callPackage ./urlForCargoPackage.nix { };
   vendorCargoDeps = callPackage ./vendorCargoDeps.nix { };

--- a/lib/registryFromDownloadUrl.nix
+++ b/lib/registryFromDownloadUrl.nix
@@ -4,6 +4,7 @@
 # https://doc.rust-lang.org/cargo/reference/registries.html
 { dl
 , indexUrl
+, registryPrefix ? "registry+"
 , fetchurlExtraArgs ? { }
 }:
 let
@@ -18,7 +19,6 @@ let
 
   fullDownloadUrl = if hasMarker then dl else "${dl}/{crate}/{version}/download";
 
-  registryPrefix = "registry+";
   registryIndexUrl =
     if lib.hasPrefix registryPrefix indexUrl
     then indexUrl

--- a/lib/registryFromDownloadUrl.nix
+++ b/lib/registryFromDownloadUrl.nix
@@ -19,12 +19,10 @@ let
 
   fullDownloadUrl = if hasMarker then dl else "${dl}/{crate}/{version}/download";
 
-  slashTerminatedIndexUrl = if lib.hasSuffix "/" indexUrl then indexUrl else "${indexUrl}/";
-
   registryIndexUrl =
-    if lib.hasPrefix registryPrefix slashTerminatedIndexUrl
-    then slashTerminatedIndexUrl
-    else "${registryPrefix}${slashTerminatedIndexUrl}";
+    if lib.hasPrefix registryPrefix indexUrl
+    then indexUrl
+    else "${registryPrefix}${indexUrl}";
 in
 {
   "${registryIndexUrl}" = {

--- a/lib/registryFromDownloadUrl.nix
+++ b/lib/registryFromDownloadUrl.nix
@@ -19,10 +19,12 @@ let
 
   fullDownloadUrl = if hasMarker then dl else "${dl}/{crate}/{version}/download";
 
+  slashTerminatedIndexUrl = if lib.hasSuffix "/" indexUrl then indexUrl else "${indexUrl}/";
+
   registryIndexUrl =
-    if lib.hasPrefix registryPrefix indexUrl
-    then indexUrl
-    else "${registryPrefix}${indexUrl}";
+    if lib.hasPrefix registryPrefix slashTerminatedIndexUrl
+    then slashTerminatedIndexUrl
+    else "${registryPrefix}${slashTerminatedIndexUrl}";
 in
 {
   "${registryIndexUrl}" = {

--- a/lib/registryFromSparse.nix
+++ b/lib/registryFromSparse.nix
@@ -1,14 +1,15 @@
-{ registryFromDownloadUrl }:
+{ registryFromDownloadUrl, lib }:
 
 { indexUrl
-, sha256
+, configSha256
 , fetchurlExtraArgs ? { }
 }:
 
 let
+  slashTerminatedIndexUrl = if lib.hasSuffix "/" indexUrl then indexUrl else "${indexUrl}/";
   configContents = builtins.readFile "${builtins.fetchurl {
-    inherit sha256;
-    url = "${indexUrl}config.json";
+    url = "${slashTerminatedIndexUrl}config.json";
+    sha256 = configSha256;
   }}";
 
   config = builtins.fromJSON configContents;
@@ -18,6 +19,7 @@ let
   '');
 in
 registryFromDownloadUrl {
-  inherit dl indexUrl fetchurlExtraArgs;
+  inherit dl fetchurlExtraArgs;
   registryPrefix = "sparse+";
+  indexUrl = slashTerminatedIndexUrl;
 }

--- a/lib/registryFromSparse.nix
+++ b/lib/registryFromSparse.nix
@@ -1,5 +1,4 @@
-{ registryFromDownloadUrl
-}:
+{ registryFromDownloadUrl }:
 
 { indexUrl
 , sha256

--- a/lib/registryFromSparse.nix
+++ b/lib/registryFromSparse.nix
@@ -1,0 +1,24 @@
+{ registryFromDownloadUrl
+}:
+
+{ indexUrl
+, sha256
+, fetchurlExtraArgs ? { }
+}:
+
+let
+  configContents = builtins.readFile "${builtins.fetchurl {
+    inherit sha256;
+    url = "${indexUrl}config.json";
+  }}";
+
+  config = builtins.fromJSON configContents;
+  dl = config.dl or (throw ''
+    registry config does not have a "dl" endpoint:
+    ${configContents}
+  '');
+in
+registryFromDownloadUrl {
+  inherit dl indexUrl fetchurlExtraArgs;
+  registryPrefix = "sparse+";
+}

--- a/lib/urlForCargoPackage.nix
+++ b/lib/urlForCargoPackage.nix
@@ -19,8 +19,10 @@ let
     else if nameLen == 3 then "3/${substr 0 1 name}"
     else "${substr 0 2 name}/${substr 2 4 name}";
 
+  knownRegistries = lib.concatStringsSep " " (builtins.attrNames crateRegistries);
   registry = crateRegistries.${source} or (throw ''
     not sure how to download crates from ${source}.
+    known registries are ${knownRegistries}.
     for example, this can be resolved with:
 
     craneLib = crane.lib.''${system}.appendCrateRegistries [
@@ -33,6 +35,12 @@ let
       (lib.registryFromGitIndex {
         url = "https://github.com/Hirevo/alexandrie-index";
         rev = "90df25daf291d402d1ded8c32c23d5e1498c6725";
+      })
+
+      # Or even
+      (lib.registryFromSparse {
+        url = "https://index.crates.io/";
+        sha256 = "d16740883624df970adac38c70e35cf077a2a105faa3862f8f99a65da96b14a3";
       })
     ];
 

--- a/lib/urlForCargoPackage.nix
+++ b/lib/urlForCargoPackage.nix
@@ -19,10 +19,10 @@ let
     else if nameLen == 3 then "3/${substr 0 1 name}"
     else "${substr 0 2 name}/${substr 2 4 name}";
 
-  knownRegistries = lib.concatStringsSep " " (builtins.attrNames crateRegistries);
+  knownRegistries = "\n  " + lib.concatStringsSep "\n  " (builtins.attrNames crateRegistries) + "\n";
   registry = crateRegistries.${source} or (throw ''
     not sure how to download crates from ${source}.
-    known registries are ${knownRegistries}.
+    known registries are: ${knownRegistries}
     for example, this can be resolved with:
 
     craneLib = crane.lib.''${system}.appendCrateRegistries [
@@ -40,7 +40,7 @@ let
       # Or even
       (lib.registryFromSparse {
         indexUrl = "https://index.crates.io/";
-        sha256 = "d16740883624df970adac38c70e35cf077a2a105faa3862f8f99a65da96b14a3";
+        configSha256 = "d16740883624df970adac38c70e35cf077a2a105faa3862f8f99a65da96b14a3";
       })
     ];
 

--- a/lib/urlForCargoPackage.nix
+++ b/lib/urlForCargoPackage.nix
@@ -39,7 +39,7 @@ let
 
       # Or even
       (lib.registryFromSparse {
-        url = "https://index.crates.io/";
+        indexUrl = "https://index.crates.io/";
         sha256 = "d16740883624df970adac38c70e35cf077a2a105faa3862f8f99a65da96b14a3";
       })
     ];


### PR DESCRIPTION
## Motivation

With Cargo 1.68.0, sparse registries were made stable. With sparse registries, index metadata is stored in an HTTP api rather than in a git repository.

As relevant to Crane, the relevant changes are mostly that registries do not always start with `registry+` and mostly start with `registry+` or `sparse+` depending on whether the registry is sparse or not.

This PR adjusts the core of Crane to differentiate between `registry` and `sparse`, and adds a new sparse registry factory to make things easy.

I'm new to Nix, so it's possible and likely that my code is incorrect.

## Checklist

- [X] added tests to verify new behavior
- [X] added an example template or updated an existing one
- [X] updated `docs/API.md` (or general documentation) with changes
- [X] updated `CHANGELOG.md`
