### PR TITLE
Keep "resolver" when cleaning Cargo.toml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 * Added support for the [Trunk](https://trunkrs.dev) wasm app build tool
+* `resolver` key is no longer cleaned from Cargo.toml
 
 ### [0.12.1] - 2023-04-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 * Added support for the [Trunk](https://trunkrs.dev) wasm app build tool
+
+### Changed
 * `resolver` key is no longer cleaned from Cargo.toml
 
 ### [0.12.1] - 2023-04-10

--- a/checks/cleanCargoTomlTests/complex/expected.toml
+++ b/checks/cleanCargoTomlTests/complex/expected.toml
@@ -73,6 +73,7 @@ path = "src/lib.rs"
 [package]
 edition = "2021"
 name = "some name"
+resolver = "2"
 version = "1.2.3"
 workspace = "some/path/to/workspace"
 

--- a/lib/cleanCargoToml.nix
+++ b/lib/cleanCargoToml.nix
@@ -30,6 +30,7 @@ let
     # (but listed here for audit purposes)
     # "edition"      # Influences cargo behavior
     # "name"         # Required
+    # "resolver"     # Influences cargo behavior when edition != 2021
     # "version"      # Required
     # "workspace"    # Keep project structure as is
   ];

--- a/lib/cleanCargoToml.nix
+++ b/lib/cleanCargoToml.nix
@@ -24,7 +24,6 @@ let
     "publish"
     "readme"
     "repository"
-    "resolver"
     "rust-version"
 
     # Additional package attributes which are expressly kept in


### PR DESCRIPTION
For projects using version != 2021 and resolver = 2, the resolver information needs to be kept or otherwise the dependency build might fail. It doesn't hurt to always keep the information, so it's now always included in the cleaned Cargo.toml.

I created a minimal repro of the issue [here](https://github.com/Detegr/crane-resolver-repro).

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [x] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [ ] updated `docs/API.md` (or general documentation) with changes
- [x] updated `CHANGELOG.md`
