### PR TITLE
fix: Strip store references in buildTrunkPackage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 * Added support for the [Trunk](https://trunkrs.dev) wasm app build tool
 
+### Fixed
+* `buildTrunkPackage` will now strip references to store files by default
+
 ### [0.12.1] - 2023-04-10
 
 ### Changed

--- a/lib/buildTrunkPackage.nix
+++ b/lib/buildTrunkPackage.nix
@@ -3,10 +3,10 @@
 , crateNameFromCargoToml
 , mkCargoDerivation
 , nodePackages
+, removeReferencesToVendoredSourcesHook
 , trunk
 , vendorCargoDeps
 , wasm-bindgen-cli
-, removeReferencesToVendoredSourcesHook
 }:
 
 { trunkExtraArgs ? ""
@@ -63,7 +63,7 @@ mkCargoDerivation (args // {
     trunk ${trunkExtraArgs} build $profileArgs ${trunkExtraBuildArgs} "${trunkIndexPath}"
   '';
 
-  installPhaseCommand = args.installPhase or ''
+  installPhaseCommand = args.installPhaseCommand or ''
     cp -r "$(dirname "${trunkIndexPath}")/dist" $out
   '';
 

--- a/lib/buildTrunkPackage.nix
+++ b/lib/buildTrunkPackage.nix
@@ -6,6 +6,7 @@
 , trunk
 , vendorCargoDeps
 , wasm-bindgen-cli
+, removeReferencesToVendoredSourcesHook
 }:
 
 { trunkExtraArgs ? ""
@@ -62,9 +63,12 @@ mkCargoDerivation (args // {
     trunk ${trunkExtraArgs} build $profileArgs ${trunkExtraBuildArgs} "${trunkIndexPath}"
   '';
 
-  installPhase = args.installPhase or ''
+  installPhaseCommand = args.installPhase or ''
     cp -r "$(dirname "${trunkIndexPath}")/dist" $out
   '';
+
+  # Installing artifacts on a distributable dir does not make much sense
+  doInstallCargoArtifacts = args.doInstallCargoArtifacts or false;
 
   nativeBuildInputs = (args.nativeBuildInputs or [ ]) ++ [
     binaryen
@@ -73,5 +77,7 @@ mkCargoDerivation (args // {
     nodePackages.sass
     trunk
     wasm-bindgen-cli
+    # Store references are certainly false positives
+    removeReferencesToVendoredSourcesHook
   ];
 })


### PR DESCRIPTION


## Motivation
<!--
Thank you for your contribution! Please add a brief description below about the change and what is the motivation
behind it.
-->

The output of `buildTrunkPackage` should never have runtime dependencies. 
Not only are they redundant but they also increase the closure greatly.
This makes a big difference when using nix to build docker images (from 64Mb to 5Mb).

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [ ] updated `docs/API.md` (or general documentation) with changes
- [x] updated `CHANGELOG.md`
