### PR TITLE
Clean install hooks from buildDepsOnly invocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+* **Breaking** (technically): if `buildPackage` is called _without_ setting
+  `cargoArtifacts`, the default `buildDepsOnly` invocation will now stop running
+  any installation hooks
 
 ### Added
 * Added support for the [Trunk](https://trunkrs.dev) wasm app build tool

--- a/docs/API.md
+++ b/docs/API.md
@@ -179,8 +179,8 @@ install hooks.
   - Default value: the result of `buildDepsOnly` after applying the arguments
     set (with the respective default values).
   - `installCargoArtifactsMode` will be set to `"use-zstd"` if not specified.
-  - `installPhase` and `installPhaseCommand` will be removed (in favor of their
-    default values provided by `buildDepsOnly`)
+  - `installPhase` and `installPhaseCommand` will be removed, and no
+    installation hooks will be run
 * `cargoBuildCommand`: A cargo invocation to run during the derivation's build
   phase
   - Default value: `"cargo build --profile release"`

--- a/lib/buildPackage.nix
+++ b/lib/buildPackage.nix
@@ -42,7 +42,7 @@ mkCargoDerivation (cleanedArgs // memoizedArgs // {
         installCargoArtifactsMode = args.installCargoArtifactsMode or "use-zstd";
       };
     in
-    buildDepsOnly (removeAttrs depsArgs [ "installPhase" "installPhaseCommand" ])
+    buildDepsOnly (removeAttrs depsArgs [ "installPhase" "installPhaseCommand" "preInstall" "postInstall" ])
   );
 
   buildPhaseCargoCommand = args.buildPhaseCargoCommand or ''

--- a/lib/buildPackage.nix
+++ b/lib/buildPackage.nix
@@ -37,12 +37,11 @@ mkCargoDerivation (cleanedArgs // memoizedArgs // {
   doInstallCargoArtifacts = args.doInstallCargoArtifacts or false;
 
   cargoArtifacts = args.cargoArtifacts or (
-    let
-      depsArgs = args // memoizedArgs // {
-        installCargoArtifactsMode = args.installCargoArtifactsMode or "use-zstd";
-      };
-    in
-    buildDepsOnly (removeAttrs depsArgs [ "installPhase" "installPhaseCommand" "preInstall" "postInstall" ])
+    buildDepsOnly (args // memoizedArgs // {
+      installCargoArtifactsMode = args.installCargoArtifactsMode or "use-zstd";
+      # NB: we intentionally don't run any hooks here since we don't want to actually install
+      installPhase = "mkdir -p $out";
+    })
   );
 
   buildPhaseCargoCommand = args.buildPhaseCargoCommand or ''


### PR DESCRIPTION
## Motivation
<!--
Thank you for your contribution! Please add a brief description below about the change and what is the motivation
behind it.
-->

Currently, install hooks get passed down to `buildDepsOnly` call, and, if they need any source files not included in the dummy source, build fails.

It seems reasonable to clean them together with custom install commands.

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [ ] updated `docs/API.md` (or general documentation) with changes
- [ ] updated `CHANGELOG.md`
