### PR TITLE
fix(Trunk): Set the `wasm-opt` version as expected by Trunk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 * `buildTrunkPackage` will now strip references to store files by default
+* `buildTrunkPackage` will now set the right `wasm-opt` version
 
 ### [0.12.1] - 2023-04-10
 

--- a/lib/buildTrunkPackage.nix
+++ b/lib/buildTrunkPackage.nix
@@ -47,7 +47,7 @@ mkCargoDerivation (args // {
     echo configuring trunk tools
     export TRUNK_TOOLS_SASS=$(sass --version | head -n1)
     export TRUNK_TOOLS_WASM_BINDGEN=$(wasm-bindgen --version | cut -d' ' -f2)
-    export TRUNK_TOOLS_WASM_OPT=$(wasm-opt --version | cut -d' ' -f3)
+    export TRUNK_TOOLS_WASM_OPT="version_$(wasm-opt --version | cut -d' ' -f3)"
 
     echo "TRUNK_TOOLS_SASS=''${TRUNK_TOOLS_SASS}"
     echo "TRUNK_TOOLS_WASM_BINDGEN=''${TRUNK_TOOLS_WASM_BINDGEN}"


### PR DESCRIPTION
Trunk expect a version number with this specific format: "version_{num}"
(see https://github.com/thedodd/trunk/blob/master/src/tools.rs#L92)

## Motivation
<!--
Thank you for your contribution! Please add a brief description below about the change and what is the motivation
behind it.
-->
When using `<link data-trunk rel="rust" data-wasm-opt="4" />` `buildTrunkPackage` fails while trying to download `wasm-opt`

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [ ] updated `docs/API.md` (or general documentation) with changes
- [X] updated `CHANGELOG.md`


For the test part, we can add the `data-wasm-opt="4"` to one of the existing test, but I'm waiting your input before doing so.