### PR TITLE
inheritCargoArtifactsHook: symlink dependency rlib and rmeta files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 * Added support for the [Trunk](https://trunkrs.dev) wasm app build tool
 
+### Changed
+* `inheritCargoArtifactsHook` will now symlink dependency `.rlib` and `.rmeta`
+  files. This means that derivations which reuse existing cargo artifacts will
+  run faster as fewer files (and bytes!) need to be copied around
+
 ### [0.12.1] - 2023-04-10
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * `inheritCargoArtifactsHook` will now symlink dependency `.rlib` and `.rmeta`
   files. This means that derivations which reuse existing cargo artifacts will
   run faster as fewer files (and bytes!) need to be copied around
+* `cargoTarpaulin`'s default `cargoTarpaulinExtraArgs` no longer include
+  `--skip-clean`
 
 ### Changed
 * **Breaking**: dropped compatibility for Nix versions below 2.13.3

--- a/docs/API.md
+++ b/docs/API.md
@@ -622,7 +622,7 @@ Except where noted below, all derivation attributes are delegated to
   - Default value: `""`
 * `cargoTarpaulinExtraArgs`: additional flags to be passed in the cargo
   tarpaulin invocation
-  - Default value: `"--skip-clean --out Xml --output-dir $out"`
+  - Default value: `"--out Xml --output-dir $out"`
 
 #### Native build dependencies
 The `cargo-tarpaulin` package is automatically appended as a native build input to any

--- a/docs/API.md
+++ b/docs/API.md
@@ -927,6 +927,7 @@ hooks:
 * `configureCargoVendoredDepsHook`
 * `inheritCargoArtifactsHook`
 * `installCargoArtifactsHook`
+* `rsync`
 * `zstd`
 
 ### `craneLib.mkDummySrc`

--- a/lib/cargoTarpaulin.nix
+++ b/lib/cargoTarpaulin.nix
@@ -3,7 +3,7 @@
 }:
 
 { cargoExtraArgs ? ""
-, cargoTarpaulinExtraArgs ? "--skip-clean --out Xml --output-dir $out"
+, cargoTarpaulinExtraArgs ? "--out Xml --output-dir $out"
 , ...
 }@origArgs:
 let

--- a/lib/cargoTarpaulin.nix
+++ b/lib/cargoTarpaulin.nix
@@ -3,7 +3,7 @@
 }:
 
 { cargoExtraArgs ? ""
-, cargoTarpaulinExtraArgs ? "--out Xml --output-dir $out"
+, cargoTarpaulinExtraArgs ? "--skip-clean --out Xml --output-dir $out"
 , ...
 }@origArgs:
 let

--- a/lib/mkCargoDerivation.nix
+++ b/lib/mkCargoDerivation.nix
@@ -5,6 +5,7 @@
 , crateNameFromCargoToml
 , inheritCargoArtifactsHook
 , installCargoArtifactsHook
+, rsync
 , stdenv
 , vendorCargoDeps
 , zstd
@@ -59,6 +60,7 @@ chosenStdenv.mkDerivation (cleanedArgs // {
     configureCargoVendoredDepsHook
     inheritCargoArtifactsHook
     installCargoArtifactsHook
+    rsync
     zstd
   ];
 

--- a/lib/setupHooks/inheritCargoArtifacts.nix
+++ b/lib/setupHooks/inheritCargoArtifacts.nix
@@ -1,8 +1,10 @@
 { makeSetupHook
+, rsync
 }:
 
 makeSetupHook
 {
   name = "inheritCargoArtifactsHook";
+  propagatedBuildInputs = [ rsync ];
 } ./inheritCargoArtifactsHook.sh
 

--- a/lib/setupHooks/inheritCargoArtifacts.nix
+++ b/lib/setupHooks/inheritCargoArtifacts.nix
@@ -5,6 +5,5 @@
 makeSetupHook
 {
   name = "inheritCargoArtifactsHook";
-  propagatedBuildInputs = [ rsync ];
 } ./inheritCargoArtifactsHook.sh
 

--- a/lib/setupHooks/inheritCargoArtifactsHook.sh
+++ b/lib/setupHooks/inheritCargoArtifactsHook.sh
@@ -24,23 +24,47 @@ inheritCargoArtifacts() {
   elif [ -d "${preparedArtifacts}" ]; then
     echo "copying cargo artifacts from ${preparedArtifacts} to ${cargoTargetDir}"
 
-    # copy target dir but ignore content-addressed build artifacts
-    rsync -r --chmod=Du=rwx --exclude "*/build/*" --exclude "*/deps/*" --exclude "*/*/build/*" --exclude "*/*/deps/*" "${preparedArtifacts}/" "${cargoTargetDir}/"
-
-    # symlink all remaining content-addressed artifacts
-    pushd "${cargoTargetDir}"
-      for d in $(ls -d */{deps,build} */*/{deps,build}); do
-          ls "${preparedArtifacts}/${d}" | xargs -P 100 -I '##{}##' ln -fs "${preparedArtifacts}/${d}/##{}##" "${d}/##{}##"
-      done
-    popd
-
-    # Keep existing permissions (e.g. exectuable), but also make things writable
-    # since the store is read-only and cargo would otherwise choke
-    chmod -R u+w "${cargoTargetDir}"
-
+    # Dependency .rlib and .rmeta files are content addressed and thus are not written to after
+    # being built (since changing `Cargo.lock` would rebuild everything anyway), which makes them
+    # good candidates for symlinking (esp. since they can make up 60-70% of the artifact directory
+    # on most projects). Thus we ignore them when copying all other artifacts below as we will
+    # symlink them afterwards. Note that we scope these checks to the `/deps` subdirectory; the
+    # workspace's own .rlib and .rmeta files appear one directory up (and these may require being
+    # writable depending on how the actual workspace build is being invoked, so we'll leave them
+    # alone).
+    #
+    # NB: keep the executable bit only if set on the original file
+    # but make all files writable as sometimes read-only files will make the build choke
+    #
     # NB: cargo also doesn't like it if `.cargo-lock` files remain with a
-    # timestamp in the distant past so we need to delete them here
-    find "${cargoTargetDir}" -name '.cargo-lock' -delete
+    # timestamp in the distant past so we avoid copying them here
+    rsync \
+      --recursive \
+      --links \
+      --times \
+      --chmod=u+w \
+      --executability \
+      --exclude 'deps/*.rlib' \
+      --exclude 'deps/*.rmeta' \
+      --exclude '.cargo-lock' \
+      "${preparedArtifacts}/" \
+      "${cargoTargetDir}/"
+
+    local linkCandidates=$(mktemp linkCandidatesXXXX.txt)
+    find "${preparedArtifacts}" \
+      '(' -path '*/deps/*.rlib' -or -path '*/deps/*.rmeta' ')' \
+      -printf "%P\n" \
+      >"${linkCandidates}"
+
+    # Next create any missing directories up front so we can avoid redundant checks later
+    cat "${linkCandidates}" \
+      | xargs --no-run-if-empty -n1 dirname \
+      | sort -u \
+      | (cd "${cargoTargetDir}"; xargs --no-run-if-empty mkdir -p)
+
+    # Lastly do the actual symlinking
+    cat "${linkCandidates}" \
+      | xargs -P ${NIX_BUILD_CORES} -I '##{}##' ln -s "${preparedArtifacts}/##{}##" "${cargoTargetDir}/##{}##"
   else
     echo unable to copy cargo artifacts, \"${preparedArtifacts}\" looks invalid
     false


### PR DESCRIPTION
## Motivation
This is a much simpler (i.e. less ambitious, and easier to land) version of #322 

Dependency `*.rlib` and `*.rmeta` files never change (as they would only change if `Cargo.lock` changes which would invalidate the entire build anyway) so we can get away with symlinking them to the inherited artifacts instead of having to deeply copy the files.

Fewer copies means faster builds!

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [x] updated `docs/API.md` (or general documentation) with changes
- [x] updated `CHANGELOG.md`
