### PR TITLE
inheritCargoArtifactsHook: allow disabling symlink behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   dependencies (i.e. when the `bindeps` feature is used) by default
 * `inheritCargoArtifactsHook` will now symlink dependency `.rlib` and `.rmeta`
   files. This means that derivations which reuse existing cargo artifacts will
-  run faster as fewer files (and bytes!) need to be copied around
-* `cargoTarpaulin`'s default `cargoTarpaulinExtraArgs` no longer include
-  `--skip-clean`
+  run faster as fewer files (and bytes!) need to be copied around. To disable
+  this behavior, set `doNotLinkInheritedArtifacts = true;`.
+* `cargoTarpaulin` will now set `doNotLinkInheritedArtifacts = true;` unless
+  otherwise specified
 
 ### Changed
 * **Breaking**: dropped compatibility for Nix versions below 2.13.3

--- a/docs/API.md
+++ b/docs/API.md
@@ -622,7 +622,8 @@ Except where noted below, all derivation attributes are delegated to
   - Default value: `""`
 * `cargoTarpaulinExtraArgs`: additional flags to be passed in the cargo
   tarpaulin invocation
-  - Default value: `"--out Xml --output-dir $out"`
+  - Default value: `"--skip-clean --out Xml --output-dir $out"`
+* `doNotLinkInheritedArtifacts` will be set to `true` if not specified.
 
 #### Native build dependencies
 The `cargo-tarpaulin` package is automatically appended as a native build input to any
@@ -1357,6 +1358,11 @@ directory using a previous derivation. It takes two positional arguments:
    * If not specified, the value of `$CARGO_TARGET_DIR` will be used
    * If `CARGO_TARGET_DIR` is not set, cargo's default target location  (i.e.
      `./target`) will be used.
+
+Note that as an optimization, some dependency artifacts will be symlinked
+instead of (deeply) copied to `$CARGO_TARGET_DIR`. To disable this behavior set
+`doNotLinkInheritedArtifacts`, and all artifacts will be copied as plain,
+writable files.
 
 **Automatic behavior:** if `cargoArtifacts` is set, then
 `inheritCargoArtifacts "$cargoArtifacts" "$CARGO_TARGET_DIR"` will be run as a

--- a/lib/cargoTarpaulin.nix
+++ b/lib/cargoTarpaulin.nix
@@ -3,7 +3,7 @@
 }:
 
 { cargoExtraArgs ? ""
-, cargoTarpaulinExtraArgs ? "--out Xml --output-dir $out"
+, cargoTarpaulinExtraArgs ? "--skip-clean --out Xml --output-dir $out"
 , ...
 }@origArgs:
 let
@@ -16,6 +16,9 @@ mkCargoDerivation (args // {
   buildPhaseCargoCommand = "cargoWithProfile tarpaulin ${cargoExtraArgs} ${cargoTarpaulinExtraArgs}";
 
   pnameSuffix = "-tarpaulin";
+
+  # With `--skip-clean` cargo-tarpaulin tries to mutate dependency files in place
+  doNotLinkInheritedArtifacts = args.doNotLinkInheritedArtifacts or true;
 
   nativeBuildInputs = (args.nativeBuildInputs or [ ]) ++ [ cargo-tarpaulin ];
 })

--- a/lib/setupHooks/inheritCargoArtifactsHook.sh
+++ b/lib/setupHooks/inheritCargoArtifactsHook.sh
@@ -24,47 +24,68 @@ inheritCargoArtifacts() {
   elif [ -d "${preparedArtifacts}" ]; then
     echo "copying cargo artifacts from ${preparedArtifacts} to ${cargoTargetDir}"
 
-    # Dependency .rlib and .rmeta files are content addressed and thus are not written to after
-    # being built (since changing `Cargo.lock` would rebuild everything anyway), which makes them
-    # good candidates for symlinking (esp. since they can make up 60-70% of the artifact directory
-    # on most projects). Thus we ignore them when copying all other artifacts below as we will
-    # symlink them afterwards. Note that we scope these checks to the `/deps` subdirectory; the
-    # workspace's own .rlib and .rmeta files appear one directory up (and these may require being
-    # writable depending on how the actual workspace build is being invoked, so we'll leave them
-    # alone).
-    #
-    # NB: keep the executable bit only if set on the original file
-    # but make all files writable as sometimes read-only files will make the build choke
-    #
-    # NB: cargo also doesn't like it if `.cargo-lock` files remain with a
-    # timestamp in the distant past so we avoid copying them here
-    rsync \
-      --recursive \
-      --links \
-      --times \
-      --chmod=u+w \
-      --executability \
-      --exclude 'deps/*.rlib' \
-      --exclude 'deps/*.rmeta' \
-      --exclude '.cargo-lock' \
-      "${preparedArtifacts}/" \
-      "${cargoTargetDir}/"
+    if [ -n "${doNotLinkInheritedArtifacts}" ]; then
+      echo 'will deep copy artifacts (instead of symlinking) as requested'
 
-    local linkCandidates=$(mktemp linkCandidatesXXXX.txt)
-    find "${preparedArtifacts}" \
-      '(' -path '*/deps/*.rlib' -or -path '*/deps/*.rmeta' ')' \
-      -printf "%P\n" \
-      >"${linkCandidates}"
+      # Notes:
+      # - --no-target-directory to avoid nesting (i.e. `./target/target`)
+      # - preserve timestamps to avoid rebuilding
+      # - no-preserve ownership (root) so we can make the files writable
+      cp -r "${preparedArtifacts}" \
+        --no-target-directory "${cargoTargetDir}" \
+        --preserve=timestamps \
+        --no-preserve=ownership
 
-    # Next create any missing directories up front so we can avoid redundant checks later
-    cat "${linkCandidates}" \
-      | xargs --no-run-if-empty -n1 dirname \
-      | sort -u \
-      | (cd "${cargoTargetDir}"; xargs --no-run-if-empty mkdir -p)
+      # Keep existing permissions (e.g. exectuable), but also make things writable
+      # since the store is read-only and cargo would otherwise choke
+      chmod -R u+w "${cargoTargetDir}"
 
-    # Lastly do the actual symlinking
-    cat "${linkCandidates}" \
-      | xargs -P ${NIX_BUILD_CORES} -I '##{}##' ln -s "${preparedArtifacts}/##{}##" "${cargoTargetDir}/##{}##"
+      # NB: cargo also doesn't like it if `.cargo-lock` files remain with a
+      # timestamp in the distant past so we need to delete them here
+      find "${cargoTargetDir}" -name '.cargo-lock' -delete
+    else
+      # Dependency .rlib and .rmeta files are content addressed and thus are not written to after
+      # being built (since changing `Cargo.lock` would rebuild everything anyway), which makes them
+      # good candidates for symlinking (esp. since they can make up 60-70% of the artifact directory
+      # on most projects). Thus we ignore them when copying all other artifacts below as we will
+      # symlink them afterwards. Note that we scope these checks to the `/deps` subdirectory; the
+      # workspace's own .rlib and .rmeta files appear one directory up (and these may require being
+      # writable depending on how the actual workspace build is being invoked, so we'll leave them
+      # alone).
+      #
+      # NB: keep the executable bit only if set on the original file
+      # but make all files writable as sometimes read-only files will make the build choke
+      #
+      # NB: cargo also doesn't like it if `.cargo-lock` files remain with a
+      # timestamp in the distant past so we avoid copying them here
+      rsync \
+        --recursive \
+        --links \
+        --times \
+        --chmod=u+w \
+        --executability \
+        --exclude 'deps/*.rlib' \
+        --exclude 'deps/*.rmeta' \
+        --exclude '.cargo-lock' \
+        "${preparedArtifacts}/" \
+        "${cargoTargetDir}/"
+
+      local linkCandidates=$(mktemp linkCandidatesXXXX.txt)
+      find "${preparedArtifacts}" \
+        '(' -path '*/deps/*.rlib' -or -path '*/deps/*.rmeta' ')' \
+        -printf "%P\n" \
+        >"${linkCandidates}"
+
+      # Next create any missing directories up front so we can avoid redundant checks later
+      cat "${linkCandidates}" \
+        | xargs --no-run-if-empty -n1 dirname \
+        | sort -u \
+        | (cd "${cargoTargetDir}"; xargs --no-run-if-empty mkdir -p)
+
+      # Lastly do the actual symlinking
+      cat "${linkCandidates}" \
+        | xargs -P ${NIX_BUILD_CORES} -I '##{}##' ln -s "${preparedArtifacts}/##{}##" "${cargoTargetDir}/##{}##"
+    fi
   else
     echo unable to copy cargo artifacts, \"${preparedArtifacts}\" looks invalid
     false


### PR DESCRIPTION
## Motivation
Allow disabling the symlinking behavior of `inheritCargoArtifactsHook` in case it becomes necessary

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [x] updated `docs/API.md` (or general documentation) with changes
- [x] updated `CHANGELOG.md`
