### PR TITLE
cargoNextest: default doNotLinkInheritedArtifacts to true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   this behavior, set `doNotLinkInheritedArtifacts = true;`.
 * `cargoTarpaulin` will now set `doNotLinkInheritedArtifacts = true;` unless
   otherwise specified
+* `cargoNextest` will now set `doNotLinkInheritedArtifacts = true;` unless
+  otherwise specified
 
 ### Changed
 * **Breaking**: dropped compatibility for Nix versions below 2.13.3

--- a/docs/API.md
+++ b/docs/API.md
@@ -579,6 +579,7 @@ Except where noted below, all derivation attributes are delegated to
 * `partitionType`: The kind of nextest partition to run (e.g. `"count"` or
   `"hash"` based).
   - Default value: `"count"`
+* `doNotLinkInheritedArtifacts` will be set to `true` if not specified.
 
 #### Native build dependencies
 The `cargo-nextest` package is automatically appended as a native build input to any

--- a/lib/cargoNextest.nix
+++ b/lib/cargoNextest.nix
@@ -25,6 +25,9 @@ let
     pnameSuffix = "-nextest${extraSuffix}";
     doCheck = args.doCheck or true;
 
+    # cargo-nextest tries to mutate dependency files in place
+    doNotLinkInheritedArtifacts = args.doNotLinkInheritedArtifacts or true;
+
     buildPhaseCargoCommand = args.buildPhaseCargoCommand or ''
       mkdir -p $out
       cargo nextest --version


### PR DESCRIPTION
## Motivation
<!--
Thank you for your contribution! Please add a brief description below about the change and what is the motivation
behind it.
-->

I ran into this [error](https://hercules-ci.com/accounts/github/nix-community/derivations/%2Fnix%2Fstore%2Fakwc3ss7lpzad2qjnrwpba1rvr5s4g1p-nix-init-nextest-0.2.3.drv/log?via-job=2f2bb641-30b4-4af6-972d-704d72e8f939) when updating crane in nix-init

```
error: output file /build/source/target/release/deps/libcfg_if-77e05c14db152ae0.rmeta is not writeable -- check its permissions
error: could not compile `cfg-if` (lib) due to previous error
warning: build failed, waiting for other jobs to finish...
error: output file /build/source/target/release/deps/libunicode_ident-b898913f0583b713.rmeta is not writeable -- check its permissions
error: could not compile `unicode-ident` (lib) due to previous error
error: output file /build/source/target/release/deps/libautocfg-75cf3ebdb83349e2.rmeta is not writeable -- check its permissions
error: could not compile `autocfg` (lib) due to previous error
error: output file /build/source/target/release/deps/libpkg_config-3b05c32a2d82ba84.rmeta is not writeable -- check its permissions
error: could not compile `pkg-config` (lib) due to previous error
error: output file /build/source/target/release/deps/libversion_check-712139cd5c88007d.rmeta is not writeable -- check its permissions
error: could not compile `version_check` (lib) due to previous error
error: output file /build/source/target/release/deps/libonce_cell-e6fc23961df30ba1.rmeta is not writeable -- check its permissions
error: could not compile `once_cell` (lib) due to previous error
error: command `/nix/store/lr1r376f6za0pm5warmn2kxak4bl7pay-rust-nightly-default-2023-06-29/bin/cargo test --no-run --message-format json-render-diagnostics --profile release --no-default-features` exited with code 101
```

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [x] updated `docs/API.md` (or general documentation) with changes
- [x] updated `CHANGELOG.md`
