### PR TITLE
inheritCargoArtifactsHook: fix doNotLinkInheritedArtifacts handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * Added support for sparse registries
 
 ### Changed
+* **Breaking**: dropped compatibility for Nix versions below 2.13.3
+* **Breaking**: dropped compatibility for nixpkgs-22.05. nixpkgs-23.05 and
 * **Breaking** (technically): if `buildPackage` is called _without_ setting
   `cargoArtifacts`, the default `buildDepsOnly` invocation will now stop running
   any installation hooks
@@ -23,10 +25,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * `cargoTarpaulin` will now set `doNotLinkInheritedArtifacts = true;` unless
   otherwise specified
 * Update `crane-utils` dependencies for successful build in nightly Rust (2023-06-28)
-
-### Changed
-* **Breaking**: dropped compatibility for Nix versions below 2.13.3
-* **Breaking**: dropped compatibility for nixpkgs-22.05. nixpkgs-23.05 and
 
 ### [0.12.2] - 2023-06-06
 

--- a/checks/default.nix
+++ b/checks/default.nix
@@ -98,12 +98,12 @@ in
   # https://github.com/ipetkov/crane/issues/356
   cargoTarpaulinAfterClippy = lib.optionalAttrs x64Linux (myLib.cargoTarpaulin {
     src = ./simple;
-      cargoArtifacts = myLib.cargoClippy {
+    cargoArtifacts = myLib.cargoClippy {
+      src = ./simple;
+      cargoArtifacts = myLib.buildDepsOnly {
         src = ./simple;
-        cargoArtifacts = myLib.buildDepsOnly {
-          src = ./simple;
-        };
       };
+    };
   });
 
   compilesFresh = callPackage ./compilesFresh.nix { };

--- a/checks/default.nix
+++ b/checks/default.nix
@@ -95,6 +95,17 @@ in
     };
   });
 
+  # https://github.com/ipetkov/crane/issues/356
+  cargoTarpaulinAfterClippy = lib.optionalAttrs x64Linux (myLib.cargoTarpaulin {
+    src = ./simple;
+      cargoArtifacts = myLib.cargoClippy {
+        src = ./simple;
+        cargoArtifacts = myLib.buildDepsOnly {
+          src = ./simple;
+        };
+      };
+  });
+
   compilesFresh = callPackage ./compilesFresh.nix { };
   compilesFreshSimple = self.compilesFresh "simple" (myLib.cargoBuild) {
     src = ./simple;

--- a/lib/setupHooks/inheritCargoArtifactsHook.sh
+++ b/lib/setupHooks/inheritCargoArtifactsHook.sh
@@ -28,10 +28,12 @@ inheritCargoArtifacts() {
       echo 'will deep copy artifacts (instead of symlinking) as requested'
 
       # Notes:
+      # - --dereference to follow and deeply resolve any symlinks
       # - --no-target-directory to avoid nesting (i.e. `./target/target`)
       # - preserve timestamps to avoid rebuilding
       # - no-preserve ownership (root) so we can make the files writable
       cp -r "${preparedArtifacts}" \
+        --dereference \
         --no-target-directory "${cargoTargetDir}" \
         --preserve=timestamps \
         --no-preserve=ownership


### PR DESCRIPTION
## Motivation
* This ensures that when doNotLinkInheritedArtifacts is set, artifact symlinks are deeply resolved

Fixes #356 

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [x] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [ ] updated `docs/API.md` (or general documentation) with changes
- [ ] updated `CHANGELOG.md`
