### PR TITLE
Trunk: use native dart-sass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Changed
+* `buildTrunkPackage` will now use `dart-sass` instead of `nodePackages.sass`
+
 ## [0.13.0] - 2023-08-07
 
 ### Added
@@ -27,7 +30,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * `cargoTarpaulin` will now set `doNotLinkInheritedArtifacts = true;` unless
   otherwise specified
 * Update `crane-utils` dependencies for successful build in nightly Rust (2023-06-28)
-* `buildTrunkPackage` will now use `dart-sass` instead of `nodePackages.sass`
 
 ## [0.12.2] - 2023-06-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * `cargoTarpaulin` will now set `doNotLinkInheritedArtifacts = true;` unless
   otherwise specified
 * Update `crane-utils` dependencies for successful build in nightly Rust (2023-06-28)
+* `buildTrunkPackage` will now use `dart-sass` instead of `nodePackages.sass`
 
 ### [0.12.2] - 2023-06-06
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -282,7 +282,7 @@ environment variables during the build, you can bring them back via
 #### Native build dependencies and included hooks
 The following hooks are automatically added as native build inputs:
 * `binaryen`
-* `nodePackages.sass`
+* `dart-sass`
 * `trunk`
 * `wasm-bindgen-cli`
 

--- a/lib/buildTrunkPackage.nix
+++ b/lib/buildTrunkPackage.nix
@@ -2,7 +2,7 @@
 , buildDepsOnly
 , crateNameFromCargoToml
 , mkCargoDerivation
-, nodePackages
+, dart-sass
 , removeReferencesToVendoredSourcesHook
 , trunk
 , vendorCargoDeps
@@ -72,9 +72,7 @@ mkCargoDerivation (args // {
 
   nativeBuildInputs = (args.nativeBuildInputs or [ ]) ++ [
     binaryen
-    # dart-sass compiled to javascript
-    # TODO: replace with a native version when it comes to nixpkgs
-    nodePackages.sass
+    dart-sass
     trunk
     wasm-bindgen-cli
     # Store references are certainly false positives


### PR DESCRIPTION
Replace the javascript version of `dart-sass` with a native binary version. `nodePackages.sass` and `dart-sass` are the same program compiled to different targets, so this is not a breaking change, except maybe bumping the minimum supported version of nixpkgs to 23.05. 

## Motivation
Should improve build times and reduce disk usage by not requiring nodejs.

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [ ] updated `docs/API.md` (or general documentation) with changes
- [x] updated `CHANGELOG.md`
