### PR TITLE
various: change `cargoExtraArgs` defaults to include `--locked`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Changed
+* **Breaking** (technically): `buildDepsOnly`, `buildPackage`, `cargoBuild`,
+  `cargoClippy`, `cargoDoc`, `cargoLlvmCov`, and `cargoTest`'s defaults have
+  been changed such that if `cargoExtraArgs` have not been set, a default value
+  of `--locked` will be used. This ensures that a project's committed
+  `Cargo.lock` is exactly what is expected (without implicit changes at build
+  time) but this may end up rejecting builds which were previously passing. To
+  get the old behavior back, set `cargoExtraArgs = "";`
+
 ## [0.13.1] - 2023-08-22
 
 ### Changed

--- a/checks/default.nix
+++ b/checks/default.nix
@@ -76,6 +76,7 @@ in
             sha256 = "sha256-sNwizxYVUNyv5InR8HS+CyUsroA79h/FpouS+fMWJUI=";
           };
 
+          cargoExtraArgs = "--offline";
           doCheck = false; # Tests need llvm-tools installed
           buildInputs = lib.optionals isDarwin [
             pkgs.libiconv
@@ -576,6 +577,7 @@ in
     postUnpack = ''
       cd $sourceRoot/workspace
       sourceRoot="."
+      [[ -f Cargo.lock ]] || ln ../Cargo.lock
     '';
     cargoLock = ./workspace-not-at-root/workspace/Cargo.lock;
     cargoToml = ./workspace-not-at-root/workspace/Cargo.toml;

--- a/docs/API.md
+++ b/docs/API.md
@@ -113,7 +113,7 @@ to influence its behavior.
   - Default value: `"--all-targets"` if `doCheck` is set to true, `""` otherwise
 * `cargoExtraArgs`: additional flags to be passed in the cargo invocation (e.g.
   enabling specific features)
-  - Default value: `""`
+  - Default value: `"--locked"`
 * `cargoTestCommand`: A cargo invocation to run during the derivation's check
   phase
   - Default value: `"cargo test --profile release"`
@@ -197,7 +197,7 @@ install hooks.
       altogether.
 * `cargoExtraArgs`: additional flags to be passed in the cargo invocation (e.g.
   enabling specific features)
-  - Default value: `""`
+  - Default value: `"--locked"`
 * `cargoTestCommand`: A cargo invocation to run during the derivation's check
   phase
   - Default value: `"cargo test --profile release"`
@@ -363,7 +363,7 @@ Except where noted below, all derivation attributes are delegated to
 #### Optional attributes
 * `cargoExtraArgs`: additional flags to be passed in the cargo invocation (e.g.
   enabling specific features)
-  - Default value: `""`
+  - Default value: `"--locked"`
 
 #### Remove attributes
 The following attributes will be removed before being lowered to
@@ -403,7 +403,7 @@ Except where noted below, all derivation attributes are delegated to
   - Default value: `"--all-targets"`
 * `cargoExtraArgs`: additional flags to be passed in the cargo invocation (e.g.
   enabling specific features)
-  - Default value: `""`
+  - Default value: `"--locked"`
 
 #### Native build dependencies
 The `clippy` package is automatically appended as a native build input to any
@@ -447,7 +447,7 @@ Except where noted below, all derivation attributes are delegated to
   - Default value: `"--no-deps"`
 * `cargoExtraArgs`: additional flags to be passed in the cargo invocation (e.g.
   enabling specific features)
-  - Default value: `""`
+  - Default value: `"--locked"`
 
 #### Remove attributes
 The following attributes will be removed before being lowered to
@@ -517,7 +517,7 @@ Except where noted below, all derivation attributes are delegated to
 
 #### Optional attributes
 * `cargoExtraArgs`: additional flags to be passed in the cargo invocation
-  - Default value: `""`
+  - Default value: `"--locked"`
 * `cargoLlvmCovCommand`: cargo-llvm-cov command to run
   - Default value: `"test"`
 * `cargoLlvmCovExtraArgs`: additional flags to be passed in the cargo
@@ -653,7 +653,7 @@ Except where noted below, all derivation attributes are delegated to
 
 #### Optional attributes
 * `cargoExtraArgs`: additional flags to be passed in the cargo invocation
-  - Default value: `""`
+  - Default value: `"--locked"`
 * `cargoTestArgs`: additional flags to be passed in the cargo
   invocation
   - Default value: `""`

--- a/lib/buildDepsOnly.nix
+++ b/lib/buildDepsOnly.nix
@@ -7,7 +7,7 @@
 
 { cargoBuildCommand ? "cargoWithProfile build"
 , cargoCheckCommand ? "cargoWithProfile check"
-, cargoExtraArgs ? ""
+, cargoExtraArgs ? "--locked"
 , cargoTestCommand ? "cargoWithProfile test"
 , cargoTestExtraArgs ? ""
 , ...

--- a/lib/buildPackage.nix
+++ b/lib/buildPackage.nix
@@ -9,7 +9,7 @@
 }:
 
 { cargoBuildCommand ? "cargoWithProfile build"
-, cargoExtraArgs ? ""
+, cargoExtraArgs ? "--locked"
 , cargoTestCommand ? "cargoWithProfile test"
 , cargoTestExtraArgs ? ""
 , ...

--- a/lib/cargoBuild.nix
+++ b/lib/cargoBuild.nix
@@ -2,7 +2,7 @@
 }:
 
 { cargoArtifacts
-, cargoExtraArgs ? ""
+, cargoExtraArgs ? "--locked"
 , ...
 }@origArgs:
 let

--- a/lib/cargoClippy.nix
+++ b/lib/cargoClippy.nix
@@ -4,7 +4,7 @@
 
 { cargoArtifacts
 , cargoClippyExtraArgs ? "--all-targets"
-, cargoExtraArgs ? ""
+, cargoExtraArgs ? "--locked"
 , ...
 }@origArgs:
 let

--- a/lib/cargoDoc.nix
+++ b/lib/cargoDoc.nix
@@ -2,7 +2,7 @@
 }:
 
 { cargoDocExtraArgs ? "--no-deps"
-, cargoExtraArgs ? ""
+, cargoExtraArgs ? "--locked"
 , ...
 }@origArgs:
 let

--- a/lib/cargoLlvmCov.nix
+++ b/lib/cargoLlvmCov.nix
@@ -2,7 +2,7 @@
 , cargo-llvm-cov
 }:
 
-{ cargoExtraArgs ? ""
+{ cargoExtraArgs ? "--locked"
 , cargoLlvmCovCommand ? "test"
 , cargoLlvmCovExtraArgs ? "--lcov --output-path $out"
 , ...

--- a/lib/cargoTest.nix
+++ b/lib/cargoTest.nix
@@ -2,7 +2,7 @@
 }:
 
 { cargoArtifacts
-, cargoExtraArgs ? ""
+, cargoExtraArgs ? "--locked"
 , cargoTestExtraArgs ? ""
 , ...
 }@origArgs:


### PR DESCRIPTION
## Motivation
The new defaults should help catch situations where a `Cargo.lock` file isn't fully up to date and leading to cache invalidations.

Fixes https://github.com/ipetkov/crane/issues/372

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [x] updated `docs/API.md` (or general documentation) with changes
- [x] updated `CHANGELOG.md`
