### PR TITLE
Don't install `target/release` in `cargoDoc`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   time) but this may end up rejecting builds which were previously passing. To
   get the old behavior back, set `cargoExtraArgs = "";`
 * Fixed a bug when testing proc macro crates with `cargoNextest` on macO. ([#376](https://github.com/ipetkov/crane/pull/376))
+* `target/release` is no longer installed from `cargoDoc`.
 
 ## [0.13.1] - 2023-08-22
 

--- a/lib/cargoDoc.nix
+++ b/lib/cargoDoc.nix
@@ -3,16 +3,22 @@
 
 { cargoDocExtraArgs ? "--no-deps"
 , cargoExtraArgs ? "--locked"
+, preInstall ? ""
 , ...
 }@origArgs:
 let
   args = (builtins.removeAttrs origArgs [
     "cargoDocExtraArgs"
     "cargoExtraArgs"
+    "preInstall"
   ]);
 in
 mkCargoDerivation (args // {
   pnameSuffix = "-doc";
 
   buildPhaseCargoCommand = "cargoWithProfile doc ${cargoExtraArgs} ${cargoDocExtraArgs}";
+
+  preInstall = preInstall + ''
+    rm -rf target/release
+  '';
 })


### PR DESCRIPTION
## Motivation
Right now, `craneLib.cargoDoc` output includes the contents of `target/release`:

```ShellSession
$ exa --tree --level 2 result/target/release
result/target/release
├── build
│  ├── simple-277affac19bb59bc
│  └── simple-b13f3c7ff4e09d62
├── crane-dummy -> /nix/store/sbxa6xwi2f67a2kcngcvlvsp49xicq2m-simple-deps-0.1.0/target/release/crane-dummy
├── crane-dummy.d -> /nix/store/sbxa6xwi2f67a2kcngcvlvsp49xicq2m-simple-deps-0.1.0/target/release/crane-dummy.d
├── deps
│  ├── byteorder-aeb8a302464a1b59.d -> /nix/store/sbxa6xwi2f67a2kcngcvlvsp49xicq2m-simple-deps-0.1.0/target/release/de
ps/byteorder-aeb8a302464a1b59.d
│  ├── byteorder-f76acca05a702bfb.d -> /nix/store/sbxa6xwi2f67a2kcngcvlvsp49xicq2m-simple-deps-0.1.0/target/release/deps/byteorder-f76acca05a702bfb.d
│  ├── crane_dummy-8abc31b05855626c.d -> /nix/store/sbxa6xwi2f67a2kcngcvlvsp49xicq2m-simple-deps-0.1.0/target/release/deps/crane_dummy-8abc31b05855626c.d
│  ├── crane_dummy-54bb6b807d416584.d -> /nix/store/sbxa6xwi2f67a2kcngcvlvsp49xicq2m-simple-deps-0.1.0/target/release/deps/crane_dummy-54bb6b807d416584.d
│  └── ...
├── examples
├── incremental
├── libsimple.d -> /nix/store/sbxa6xwi2f67a2kcngcvlvsp49xicq2m-simple-deps-0.1.0/target/release/libsimple.d
└── libsimple.rlib -> /nix/store/sbxa6xwi2f67a2kcngcvlvsp49xicq2m-simple-deps-0.1.0/target/release/libsimple.rlib
```

These are symlinks, so they don't add disk space, but they do clutter up the output and potentially increase the closure size (as well as adding a dependency on the `cargoArtifacts` derivation).

Adding `rm -rf target/release` to the `preInstall` hook _works_, but it feels a little messy. Maybe a better solution would be to modify `installCargoArtifactsHook.sh` to not symlink these files in the first place?

What do you think?

## Checklist
- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [ ] updated `docs/API.md` (or general documentation) with changes
- [x] updated `CHANGELOG.md`
