### PR TITLE
various: switch to using runCommand to improve caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * `cargoDoc` will now install generated documentation in `$out/share/doc`
 * Fixed a bug when testing proc macro crates with `cargoNextest` on macOS.
   ([#376](https://github.com/ipetkov/crane/pull/376))
+* Replaced various internal usages of `runCommandLocal` with `runCommand` for
+  more optimal behavior when downloading cached artifacts
 
 ## [0.13.1] - 2023-08-22
 

--- a/checks/cargoAudit.nix
+++ b/checks/cargoAudit.nix
@@ -1,7 +1,7 @@
 { cargoAudit
 , fetchFromGitHub
 , linkFarmFromDrvs
-, runCommandLocal
+, runCommand
 }:
 
 let
@@ -17,7 +17,7 @@ let
 
   simpleWithAuditToml = (auditWith "simple-with-audit-toml" ./simple-with-audit-toml);
 
-  containsAuditTomlInSrc = runCommandLocal "containsAuditTomlInSrc" { } ''
+  containsAuditTomlInSrc = runCommand "containsAuditTomlInSrc" { } ''
     if [[ -f ${simpleWithAuditToml.src}/.cargo/audit.toml ]]; then
       touch $out
     else

--- a/lib/downloadCargoPackage.nix
+++ b/lib/downloadCargoPackage.nix
@@ -1,6 +1,6 @@
 { fetchurl
 , urlForCargoPackage
-, runCommandLocal
+, runCommand
 }:
 
 { name
@@ -16,7 +16,7 @@ let
     sha256 = checksum;
   });
 in
-runCommandLocal "cargo-package-${name}-${version}" { } ''
+runCommand "cargo-package-${name}-${version}" { } ''
   mkdir -p $out
   tar -xzf ${tarball} -C $out --strip-components=1
   echo '{"files":{}, "package":"${checksum}"}' > $out/.cargo-checksum.json

--- a/lib/downloadCargoPackageFromGit.nix
+++ b/lib/downloadCargoPackageFromGit.nix
@@ -2,7 +2,7 @@
 , craneUtils
 , jq
 , lib
-, runCommandLocal
+, runCommand
 }:
 
 { git
@@ -26,7 +26,7 @@ let
     ];
   };
 in
-runCommandLocal "cargo-git" deps ''
+runCommand "cargo-git" deps ''
   mkdir -p $out
   existing_crates=()
   while read -r cargoToml; do

--- a/lib/mkDummySrc.nix
+++ b/lib/mkDummySrc.nix
@@ -1,7 +1,7 @@
 { cleanCargoToml
 , findCargoFiles
 , lib
-, runCommandLocal
+, runCommand
 , writeText
 , writeTOML
 }:
@@ -236,7 +236,7 @@ let
     then "dummy-src"
     else last nameWithoutHash;
 in
-runCommandLocal sourceName { } ''
+runCommand sourceName { } ''
   mkdir -p $out
   cp --recursive --no-preserve=mode,ownership ${cleanSrc}/. -t $out
   ${copyCargoLock}


### PR DESCRIPTION
## Motivation

Switch to using runCommand to improve caching

For example, commands which extract a tarball should be cached (i.e should use `runCommand` not `runCommandLocal`) because it allows builds to download the unpacked result instead of having to write both to the store

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [ ] updated `docs/API.md` (or general documentation) with changes
- [x] updated `CHANGELOG.md`
