### PR TITLE
Much faster symlinking, safer interactions with `rustc`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   `Cargo.lock` is exactly what is expected (without implicit changes at build
   time) but this may end up rejecting builds which were previously passing. To
   get the old behavior back, set `cargoExtraArgs = "";`
-* **Breaking**: `cargoDoc` will no longer install cargo artifacts by default.
-  Set `doInstallCargoArtifacts = true;` to get the old behavior back.
+* **Breaking**: `cargoDoc` and `cargoClippy` will no longer install cargo artifacts
+  by default. Set `doInstallCargoArtifacts = true;` to get the old behavior back.
+* **Breaking**: rustc is now executed with a wrapper script. Therefore providing
+  your own value of `RUSTC_WRAPPER` will no longer work. We do not believe that
+  this is commonly used.
+* Large performance improvement when symlinking artifacts.
 * `cargoDoc` will now install generated documentation in `$out/share/doc`
 * Fixed a bug when testing proc macro crates with `cargoNextest` on macOS.
   ([#376](https://github.com/ipetkov/crane/pull/376))

--- a/docs/API.md
+++ b/docs/API.md
@@ -1439,16 +1439,15 @@ identical files against a directory of previously prepared cargo artifacts.
 It takes three positional arguments:
 1. the installation directory for the output.
    * An error will be raised if not specified
-   * If the specified path is a directory which exists then the current cargo
-     artifacts will be compared with the contents of said directory. Any files
-     whose contents and paths match will be symbolically linked together to
-     reduce the size of the data stored in the Nix store.
 1. the path to cargo's artifact directory
    * An error will be raised if not specified
 1. a path to the previously prepared cargo artifacts
    * An error will be raised if not specified
    * `/dev/null` can be specified here if there is no previous directory to
      deduplicate against
+
+'symlinks.tar' will be created in the output directory in this case. It contains
+symlinks to all of the dep files in this output, simplifying the untar behaviour.
 
 Defines `prepareAndInstallCargoArtifactsDir()` which handles installing cargo's
 artifact directory to the derivation's output. It takes three positional

--- a/lib/cargoClippy.nix
+++ b/lib/cargoClippy.nix
@@ -19,5 +19,7 @@ mkCargoDerivation (args // {
 
   buildPhaseCargoCommand = "cargoWithProfile clippy ${cargoExtraArgs} ${cargoClippyExtraArgs}";
 
+  doInstallCargoArtifacts = false;
+
   nativeBuildInputs = (args.nativeBuildInputs or [ ]) ++ [ clippy ];
 })


### PR DESCRIPTION
## Motivation

Fixes #385.

This MR represents a large performance improvement in practical terms in simple Crane situations.

For some unscientific numbers, I tested in the following fashion.

For each of the two versions of crane (master, this branch), and my simple closed source software project (it's 1kloc, about 170 crate deps, mostly just hyper):
1. I ran `nix flake check` to ensure that any crate downloads were done, any supporting derivations complete.
1. I then added a new crate (anyhow) and ran `nix flake check` again. This times the whole flow after a dependency is added.
1. I then changed a constant and re-ran, simulating the usual flow.

Because this project is relatively small, I would expect that this represents a 'worst case' scenario. For example, when uncompressed, it contains 500MB of dependencies, whereas another project I work on represents 3.6GB.

The results were as follows:
Before this PR:
- build with new dep: 2m15s
- build with new code: 1m19s After this PR:
- build with new dep: 1m22s
- build with new code: 32s

In addition, it is more robust to crate rebuilds.

How it works/why it's better:

1. Drop the diffing behaviour when doing symlinking. This is an explicit tradeoff - if one is doing symlinking on inheritance, we would expect any duplicate data to be in the form of symlinks, for which diffing file content is unhelpful. Given that this only helps the case where we are not symlinking on inheritance, are not archiving on install, it seems reasonable for it to be potentially slower in this case. I say potentially slower since if we have target dirs of 1GB, we are trading 2GB of reads for up to 1GB fewer writes. I'd note here that Nix store optimisation will cover for space savings. But, main argument: common case should be archival or symlinking, and we can boost the performance of the common case by removing this behaviour.
1. Instead, we build a `symlinks.tar` containing symlinks to the outputs of this derivation.
1. When inheriting, instead of traversing the tree and creating symlinks, we just extract this tar. This is great beacuse it means that on both derivation end and derivation start, we avoid forking O(num files produced by cargo build) processes. Since even small projects have thousands of files emitted (my own has 2033 output files). Effectively, GNU tar is much more optimised than the pre-existing bash script. In addition, the data written in the deps-only build is write-once, read many (hopefully). By pushing the directory traversal into the read side, we convert random IO into sequential.
1. At this point, we still have the problem where rustc may try to write to a file. We use a `RUSTC_WRAPPER` to instead write to a temporary directory, and after the command is finished we copy the artifacts from the out dir back to the target location. There is a potential (small) slowdown caused by this - I observe cargo to use rustc's stderr to kick off new builds as soon as it can, and so had to capture rustc's stdout. However, this effect is most likely very minor.


## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [x] updated `docs/API.md` (or general documentation) with changes
- [x] updated `CHANGELOG.md`
