### PR TITLE
feature: incremental zstd mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   offline evaluations. The `outputHashes` attribute can now be optionally
   specified in `vendorCargoDeps`, `vendorGitDeps`, `vendorMultipleCargoDeps`, or
   anything else which delegates to them.
+* `use-zstd` mode uses a chained, incremental approach to avoid redundancy.
+  Old behavior (taking a full snapshot of the cargo artifacts can be achieved
+  by setting `installCargoArtifactsMode = "use-zstd-full"`.
+  ([#387](https://github.com/ipetkov/crane/pull/387))
 
 ### Changed
 * **Breaking** (technically): `buildDepsOnly`, `buildPackage`, `cargoBuild`,

--- a/lib/setupHooks/inheritCargoArtifactsHook.sh
+++ b/lib/setupHooks/inheritCargoArtifactsHook.sh
@@ -17,10 +17,18 @@ inheritCargoArtifacts() {
 
   mkdir -p "${cargoTargetDir}"
   if [ -f "${preparedArtifacts}" ]; then
+
+    if [ -f "${preparedArtifacts}.prev" ]; then
+      inheritCargoArtifacts "$(readlink -f "${preparedArtifacts}.prev")" "$cargoTargetDir"
+    fi
+
     echo "decompressing cargo artifacts from ${preparedArtifacts} to ${cargoTargetDir}"
 
     zstd -d "${preparedArtifacts}" --stdout | \
       tar -x -C "${cargoTargetDir}" --strip-components=1
+    rm -f "${cargoTargetDir}/.crane-previous-archive"
+    ln -s "${preparedArtifacts}" "${cargoTargetDir}/.crane-previous-archive"
+
   elif [ -d "${preparedArtifacts}" ]; then
     echo "copying cargo artifacts from ${preparedArtifacts} to ${cargoTargetDir}"
 

--- a/lib/setupHooks/installCargoArtifactsHook.sh
+++ b/lib/setupHooks/installCargoArtifactsHook.sh
@@ -87,11 +87,11 @@ prepareAndInstallCargoArtifactsDir() {
   mkdir -p "${dir}"
 
   case "${mode}" in
-    "use-zstd")
+    "use-zstd"|"use-zstd-diff")
       compressAndInstallCargoArtifactsDirIncremental "${dir}" "${cargoTargetDir}"
       ;;
 
-    "use-zstd-no-incr")
+    "use-zstd-full")
       compressAndInstallCargoArtifactsDir "${dir}" "${cargoTargetDir}"
       ;;
 

--- a/lib/setupHooks/installCargoArtifactsHook.sh
+++ b/lib/setupHooks/installCargoArtifactsHook.sh
@@ -19,6 +19,38 @@ compressAndInstallCargoArtifactsDir() {
   )
 }
 
+compressAndInstallCargoArtifactsDirIncremental() {
+  local dir="${1:?destination directory not defined}"
+  local cargoTargetDir="${2:?cargoTargetDir not defined}"
+
+  mkdir -p "${dir}"
+
+  local dest="${dir}/target.tar.zst"
+  echo "compressing ${cargoTargetDir} to ${dest}"
+  (
+    export SOURCE_DATE_EPOCH=1
+    touch -d @${SOURCE_DATE_EPOCH} "${TMPDIR}/.crane.source-date-epoch"
+
+    find "${cargoTargetDir}" \
+      -newer "${TMPDIR}/.crane.source-date-epoch" \
+      -print0 \
+      | tar \
+      --null \
+      --no-recursion \
+      --sort=name \
+      --mtime="@${SOURCE_DATE_EPOCH}" \
+      --owner=0 \
+      --group=0 \
+      --numeric-owner \
+      --pax-option=exthdr.name=%d/PaxHeaders/%f,delete=atime,delete=ctime \
+      -c -f - -T - \
+      | zstd "-T${NIX_BUILD_CORES:-0}" -o "${dest}"
+     if [ -e "${cargoTargetDir}/.crane-previous-archive" ]; then
+       cp -a "${cargoTargetDir}/.crane-previous-archive" "${dest}.prev"
+     fi
+   )
+}
+
 dedupAndInstallCargoArtifactsDir() {
   local dest="${1:?destination directory not defined}"
   local cargoTargetDir="${2:?cargoTargetDir not defined}"
@@ -56,6 +88,10 @@ prepareAndInstallCargoArtifactsDir() {
 
   case "${mode}" in
     "use-zstd")
+      compressAndInstallCargoArtifactsDirIncremental "${dir}" "${cargoTargetDir}"
+      ;;
+
+    "use-zstd-no-incr")
       compressAndInstallCargoArtifactsDir "${dir}" "${cargoTargetDir}"
       ;;
 

--- a/lib/setupHooks/installCargoArtifactsHook.sh
+++ b/lib/setupHooks/installCargoArtifactsHook.sh
@@ -88,7 +88,15 @@ prepareAndInstallCargoArtifactsDir() {
 
   case "${mode}" in
     "use-zstd"|"use-zstd-diff")
-      compressAndInstallCargoArtifactsDirIncremental "${dir}" "${cargoTargetDir}"
+
+      # If no artifcats were inherited in the first place,
+      # it's both faster and safer (mtime handlings bugs), to use
+      # a full snapshot.
+      if [ -n "${cargoArtifacts}" ];then
+        compressAndInstallCargoArtifactsDir "${dir}" "${cargoTargetDir}"
+      else
+        compressAndInstallCargoArtifactsDirIncremental "${dir}" "${cargoTargetDir}"
+      fi
       ;;
 
     "use-zstd-full")

--- a/lib/setupHooks/installCargoArtifactsHook.sh
+++ b/lib/setupHooks/installCargoArtifactsHook.sh
@@ -1,11 +1,11 @@
-compressAndInstallCargoArtifactsDir() {
+compressAndInstallCargoArtifactsDirFull() {
   local dir="${1:?destination directory not defined}"
   local cargoTargetDir="${2:?cargoTargetDir not defined}"
 
   mkdir -p "${dir}"
 
   local dest="${dir}/target.tar.zst"
-  echo "compressing ${cargoTargetDir} to ${dest}"
+  echo "compressing full content of ${cargoTargetDir} to ${dest}"
   (
     export SOURCE_DATE_EPOCH=1
     tar --sort=name \
@@ -19,14 +19,14 @@ compressAndInstallCargoArtifactsDir() {
   )
 }
 
-compressAndInstallCargoArtifactsDirIncremental() {
+compressAndInstallCargoArtifactsDirDiff() {
   local dir="${1:?destination directory not defined}"
   local cargoTargetDir="${2:?cargoTargetDir not defined}"
 
   mkdir -p "${dir}"
 
   local dest="${dir}/target.tar.zst"
-  echo "compressing ${cargoTargetDir} to ${dest}"
+  echo "compressing new content of ${cargoTargetDir} to ${dest}"
   (
     export SOURCE_DATE_EPOCH=1
     touch -d @${SOURCE_DATE_EPOCH} "${TMPDIR}/.crane.source-date-epoch"
@@ -92,15 +92,15 @@ prepareAndInstallCargoArtifactsDir() {
       # If no artifcats were inherited in the first place,
       # it's both faster and safer (mtime handlings bugs), to use
       # a full snapshot.
-      if [ -n "${cargoArtifacts}" ];then
-        compressAndInstallCargoArtifactsDir "${dir}" "${cargoTargetDir}"
+      if [ -z "${cargoArtifacts}" ];then
+        compressAndInstallCargoArtifactsDirFull "${dir}" "${cargoTargetDir}"
       else
-        compressAndInstallCargoArtifactsDirIncremental "${dir}" "${cargoTargetDir}"
+        compressAndInstallCargoArtifactsDirDiff "${dir}" "${cargoTargetDir}"
       fi
       ;;
 
     "use-zstd-full")
-      compressAndInstallCargoArtifactsDir "${dir}" "${cargoTargetDir}"
+      compressAndInstallCargoArtifactsDirFull "${dir}" "${cargoTargetDir}"
       ;;
 
     "use-symlink")


### PR DESCRIPTION
## Motivation

Fix #76 (implement it).

This changes the `use-zstd` to create a chain of `target.tar.zst` files, each time capturing only newly created/modified files, using `mtime`, making breaking multiple `cargo` invocations into a chain of separate derivations much cheaper (virtually free in terms of disk space, extraction cost proportional to the size of whole `./target`, and compression cost relative to the size of only modified/new files).

Previous behavior (taking full snapshots of `./target` each time) is retained for time being under a new name (`use-zstd-no-incr`), as there's no guarantee that no one ever will hit a case where something modifies a file without changing mtime (though it seems unlikely). Supporting both is very easy anyway. 

**Edit**: Only later it occurred to me that incremental approach does not correct delete files (it will keep re-storing them). It could be handled, but seems unnecessary and it will have a perf cost. Current behavior is most probably OK in practice for 99.9% cases. AFAIR science goes, there are no credible reports of `./target` directory ever shrinking in the nature. But an additional reason to keep the old method around.

Possibly there should be:

* `use-zstd-incremental`
* `use-zstd-full`
* `use-zstd` (alias for `use-zstd-incremental`, or any method deemed even better in the future).

This way if anyone has a step that actually delete things, they can use `use-zstd-full` as a one-off. It might be also useful if someone really wants to introduce a break in the chain (e.g. they have really, really long chain and it seems worth it).

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [ ] updated `docs/API.md` (or general documentation) with changes
- [ ] updated `CHANGELOG.md`
