### PR TITLE
Auto-approve flake update PRs

### DIFF
--- a/.github/workflows/update-flake.yml
+++ b/.github/workflows/update-flake.yml
@@ -3,7 +3,7 @@ name: Update flake dependencies
 on:
   workflow_dispatch: # for allowing manual triggers of the workflow
   schedule:
-    - cron: '37 16 3 * *'
+    - cron: '37 16 3,18 * *'
 
 permissions:
   contents: read

--- a/.github/workflows/update-flake.yml
+++ b/.github/workflows/update-flake.yml
@@ -32,11 +32,7 @@ jobs:
           automated
           dependencies
           flake update
-    # Fine grained Personal Access Tokens do not yet work with GitHub's GraphQL API
-    # so we'll stick with manual approval for now
-    # https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token#about-personal-access-tokens
-    # - uses: peter-evans/enable-pull-request-automerge@v2
-    #   with:
-    #     token: ${{ secrets.PAT_FLAKE_UPDATE }}
-    #     pull-request-number: ${{ steps.flakeupdate.outputs.pull-request-number }}
-    #     merge-method: "squash"
+    - name: Enable Pull Request Automerge
+      run: gh pr merge --squash --delete --auto ${{ steps.flakeupdate.outputs.pull-request-number }}
+      env:
+        GH_TOKEN: ${{ secrets.PAT_FLAKE_UPDATE }}


### PR DESCRIPTION
## Motivation
Auto-approve flake update PRs as long as the test suite is passing. Also update the flake every 2 weeks instead of 4

## Checklist
- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [ ] updated `docs/API.md` (or general documentation) with changes
- [ ] updated `CHANGELOG.md`
