### PR TITLE
buildPackage: fix issue with inheriting default depsOnly artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Fixed
+
+* Fixed a bug where `buildPackage` would fail to inherit artifacts from
+  dependency crates if `cargoArtifacts` was not explicitly specified.
+
 ## [0.14.0] - 2023-09-21
 
 ### Added

--- a/lib/buildPackage.nix
+++ b/lib/buildPackage.nix
@@ -40,8 +40,10 @@ mkCargoDerivation (cleanedArgs // memoizedArgs // {
   cargoArtifacts = args.cargoArtifacts or (
     buildDepsOnly (args // memoizedArgs // {
       installCargoArtifactsMode = args.installCargoArtifactsMode or "use-zstd";
-      # NB: we intentionally don't run any hooks here since we don't want to actually install
-      installPhase = "mkdir -p $out";
+      # NB: we intentionally don't run any caller-provided hooks here since they might fail
+      # if they require any files that have been omitted by the source dummification.
+      # However, we still _do_ want to run the installation hook with the actual artifacts
+      installPhase = "prepareAndInstallCargoArtifactsDir";
     })
   );
 


### PR DESCRIPTION
## Motivation
* When https://github.com/ipetkov/crane/pull/334 fixed ignoring caller-specified installation hooks, it inadvertently turned off the build hook which installed the actual cargo artifacts

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [ ] updated `docs/API.md` (or general documentation) with changes
- [x] updated `CHANGELOG.md`
