### PR TITLE
fix: isolate scope of craneUtils

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -1,8 +1,10 @@
 { lib
 , newScope
-  # , craneUtils ? (import ./. { inherit lib newScope; craneUtils = throw "craneUtils mut not depend on itself"; }).craneUtils
-  # , craneUtils ? callPackage ../pkgs/crane-utils { };
-, craneUtilsIsolate ? true
+  # craneUtils to use
+  # when missing, will be generated in a new scope
+  # when null will be generated in the current scope
+  # when set, will be used
+, craneUtils ? (import ./. { inherit lib newScope; craneUtils = null; }).craneUtils
 }:
 
 lib.makeScope newScope (self:
@@ -10,10 +12,11 @@ let
   inherit (self) callPackage;
 
   craneUtils' =
-    if craneUtilsIsolate then
-      (import ./. { inherit lib newScope; craneUtilsIsolate = false; }).craneUtils
+    if craneUtils == null then
+      callPackage ../pkgs/crane-utils { }
     else
-      callPackage ../pkgs/crane-utils { };
+      craneUtils;
+
   internalCrateNameFromCargoToml = callPackage ./internalCrateNameFromCargoToml.nix { };
 in
 {

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -1,11 +1,19 @@
 { lib
 , newScope
+  # , craneUtils ? (import ./. { inherit lib newScope; craneUtils = throw "craneUtils mut not depend on itself"; }).craneUtils
+  # , craneUtils ? callPackage ../pkgs/crane-utils { };
+, craneUtilsIsolate ? true
 }:
 
 lib.makeScope newScope (self:
 let
   inherit (self) callPackage;
 
+  craneUtils' =
+    if craneUtilsIsolate then
+      (import ./. { inherit lib newScope; craneUtilsIsolate = false; }).craneUtils
+    else
+      callPackage ../pkgs/crane-utils { };
   internalCrateNameFromCargoToml = callPackage ./internalCrateNameFromCargoToml.nix { };
 in
 {
@@ -30,7 +38,9 @@ in
   cleanCargoToml = callPackage ./cleanCargoToml.nix { };
   configureCargoCommonVarsHook = callPackage ./setupHooks/configureCargoCommonVars.nix { };
   configureCargoVendoredDepsHook = callPackage ./setupHooks/configureCargoVendoredDeps.nix { };
-  craneUtils = callPackage ../pkgs/crane-utils { };
+
+  craneUtils = craneUtils';
+
   devShell = callPackage ./devShell.nix { };
 
   crateNameFromCargoToml = callPackage ./crateNameFromCargoToml.nix {


### PR DESCRIPTION
## Motivation

As things are currently it's not feasible to use `craneLib.overrideScope` to override anything that is used by `craneUtils`, because it will affect it as well. Eg. You want to inject some args to every `mkCargoDerivation` be overriding it? Well, now `craneUtils` will try to compile it.


IMO, `craneUtils` is an input to the scope. But I understand that it makes sense to be build with with `craneLib` itself.

There's probably some better way to do it, but I mainly wanted to explain the issue by showing the solution.

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [ ] updated `docs/API.md` (or general documentation) with changes
- [ ] updated `CHANGELOG.md`
