### PR TITLE
Replace `toml` dependency with `toml_edit` to preserve comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   ([#376](https://github.com/ipetkov/crane/pull/376))
 * Replaced various internal usages of `runCommandLocal` with `runCommand` for
   more optimal behavior when downloading cached artifacts
+* Fixed a bug when a git dependency crate relies on reading non-TOML metadata
+  from Cargo.toml at build time.
+  ([#407](https://github.com/ipetkov/crane/pull/407))
 
 ## [0.13.1] - 2023-08-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
-### Changed
-* Fixed a bug when a git dependency crate relies on reading non-TOML metadata
-  from Cargo.toml at build time.
-  ([#407](https://github.com/ipetkov/crane/pull/407))
+### Fixed
+* Fixed handling of Cargo workspace inheritance for git-dependencies where said
+  crate relies on reading non-TOML metadata (i.e. comments) from its Cargo.toml
+  at build time. ([#407](https://github.com/ipetkov/crane/pull/407))
 
 ## [0.14.1] - 2023-09-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Changed
+* Fixed a bug when a git dependency crate relies on reading non-TOML metadata
+  from Cargo.toml at build time.
+  ([#407](https://github.com/ipetkov/crane/pull/407))
+
 ## [0.14.0] - 2023-09-21
 
 ### Added
@@ -31,9 +36,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   ([#376](https://github.com/ipetkov/crane/pull/376))
 * Replaced various internal usages of `runCommandLocal` with `runCommand` for
   more optimal behavior when downloading cached artifacts
-* Fixed a bug when a git dependency crate relies on reading non-TOML metadata
-  from Cargo.toml at build time.
-  ([#407](https://github.com/ipetkov/crane/pull/407))
 
 ## [0.13.1] - 2023-08-22
 

--- a/pkgs/crane-utils/Cargo.lock
+++ b/pkgs/crane-utils/Cargo.lock
@@ -16,7 +16,7 @@ dependencies = [
  "pretty_assertions",
  "serde",
  "serde_json",
- "toml",
+ "toml_edit",
 ]
 
 [[package]]
@@ -125,15 +125,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_spanned"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96426c9936fd7a0124915f9185ea1d20aa9445cc9821142f0a73bc9207a2e186"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "syn"
 version = "2.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -145,36 +136,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17e963a819c331dcacd7ab957d80bc2b9a9c1e71c804826d2f283dd65306542"
-dependencies = [
- "indexmap",
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_edit",
-]
-
-[[package]]
 name = "toml_datetime"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "toml_edit"
-version = "0.19.14"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8123f27e969974a3dfba720fdb560be359f57b44302d280ba72e76a74480e8a"
+checksum = "ca676d9ba1a322c1b64eb8045a5ec5c0cfb0c9d08e15e9ff622589ad5221c8fe"
 dependencies = [
  "indexmap",
- "serde",
- "serde_spanned",
  "toml_datetime",
  "winnow",
 ]

--- a/pkgs/crane-utils/Cargo.toml
+++ b/pkgs/crane-utils/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 anyhow = "1"
 serde_json = "1"
 serde = { version = "1", features = ["derive"] }
-toml = { version = "0.7.3", features = ["preserve_order"] }
+toml_edit = "0.20.1"
 
 [dev-dependencies]
 pretty_assertions = "1.3.0"

--- a/pkgs/crane-utils/src/bin/crane-resolve-workspace-inheritance.rs
+++ b/pkgs/crane-utils/src/bin/crane-resolve-workspace-inheritance.rs
@@ -451,7 +451,7 @@ mod tests {
             version = "some version"
 
             [workspace.dependencies]
-            # workspace comments are not copied
+            # top-level workspace comments are not copied - only the values are merged
             foo = { version = "foo-vers" }
             bar = { version = "bar-vers", default-features = false }
             baz = { version = "baz-vers", features = ["baz-feat", "baz-feat2"] }


### PR DESCRIPTION
## Motivation
<!--
Thank you for your contribution! Please add a brief description below about the change and what is the motivation
behind it.
-->

As discussed in #394, crane currently uses the [`toml` crate] dependency in `crane-resolve-workspace-inheritance.rs` in order to merge the workspace root Cargo.toml with the current crate's Cargo.toml. This script is run on all git dependencies of the built crate.

One unfortunate side effect of using the [`toml` crate] is that all comments are removed from Cargo.toml.  This is an issue if proc macros or build scripts are expecting to read non-TOML metadata from Cargo.toml (e.g. [`document-features`] used by some embedded libraries, such as [`embassy-stmf32`](https://github.com/embassy-rs/embassy/tree/main/embassy-stm32))

### Solution

This PR adapts the existing `crane-resolve-workspace-inheritance.rs` script to use [`toml_edit`] instead of the [`toml` crate], to preserve comments.

#### Remarks
- There are two kinds of Tables in toml_edit, so some complexity (e.g. `trait TableLikeExt`) is needed to merge any combination of tables.
- The TOML key/value formatting cleanup is not strictly required, but I included this to keep the current smoke test mostly unchanged.   One possible alternative is to use the [`toml` crate] as a dev-dependency, to only check the TOML is equal and avoid string equality; then the `fmt` module could be removed.


I tested this on my minimal example from #394, and it appears to work correctly.  (reference https://github.com/danjl1100/example_uses_dep_using_document_features/commit/7cc5174ed13868d49eef1900e88e3c7157b112e4)

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [x] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [ ] updated `docs/API.md` (or general documentation) with changes
- [x] updated `CHANGELOG.md`


[`toml` crate]: https://lib.rs/crates/toml
[`toml_edit`]: https://lib.rs/crates/toml_edit
[`document-features`]: https://lib.rs/crates/document-features
[`embassy-stmf32`]: https://github.com/embassy-rs/embassy/tree/main/embassy-stm32