### PR TITLE
cargoAudit: ignore yanked crates by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Changed
+* `cargoAudit` will pass `--ignore yanked` by default if `cargoAuditExtraArgs`
+  are not specified. This is because `cargo-audit` cannot check for yanked
+  crates from inside of the sandbox. To get the old behavior back, set
+  `cargoAuditExtraArgs = "";`.
+
 ### Fixed
 * Fixed handling of Cargo workspace inheritance for git-dependencies where said
   crate relies on reading non-TOML metadata (i.e. comments) from its Cargo.toml

--- a/checks/simple-with-audit-toml/.cargo/audit.toml
+++ b/checks/simple-with-audit-toml/.cargo/audit.toml
@@ -14,7 +14,7 @@ format = "terminal" # "terminal" (human readable report) or "json"
 quiet = false # Only print information on error
 show_tree = true # Show inverse dependency trees along with advisories (default: true)
 
+# Doesn't work in the sandbox
 [yanked]
-enabled = true # Warn for yanked crates in Cargo.lock (default: true)
-update_index = true # Auto-update the crates.io index (default: true)
-
+enabled = false # Warn for yanked crates in Cargo.lock (default: true)
+update_index = false # Auto-update the crates.io index (default: true)

--- a/docs/API.md
+++ b/docs/API.md
@@ -315,7 +315,7 @@ Except where noted below, all derivation attributes are delegated to
 
 #### Optional attributes
 * `cargoAuditExtraArgs`: additional flags to be passed in the cargo-audit invocation
-  - Default value: `""`
+  - Default value: `"--ignore yanked"`
 * `cargoExtraArgs`: additional flags to be passed in the cargo invocation
   - Default value: `""`
 * `pname`: the name of the derivation; will _not_ be introspected from a

--- a/lib/cargoAudit.nix
+++ b/lib/cargoAudit.nix
@@ -4,7 +4,7 @@
 }:
 
 { advisory-db
-, cargoAuditExtraArgs ? ""
+, cargoAuditExtraArgs ? "--ignore yanked"
 , cargoExtraArgs ? ""
 , src
 , ...


### PR DESCRIPTION
## Motivation
* Checking for yanked crates requires network access (to ping the crates.io index) which won't work from inside the sandbox

Fixes https://github.com/ipetkov/crane/issues/421

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [x] updated `docs/API.md` (or general documentation) with changes
- [x] updated `CHANGELOG.md`
