### PR TITLE
mkCargoDerivation: replace Cargo.lock with contents of `cargoLock`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,19 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Added
+* `replaceCargoLockHook` can now be used to easily replace or insert a
+  `Cargo.lock` file in the current derivation
+
 ### Changed
 * `cargoAudit` will pass `--ignore yanked` by default if `cargoAuditExtraArgs`
   are not specified. This is because `cargo-audit` cannot check for yanked
   crates from inside of the sandbox. To get the old behavior back, set
   `cargoAuditExtraArgs = "";`.
+* `mkCargoDerivation` (and by extension anything which delegates to it) will now
+  automatically use the value of `cargoLock` or the contents of
+  `cargoLockContents`/`cargoLockParsed` to replace the workspace `Cargo.lock`
+  file. To disable this behavior, set `doNotReplaceCargoLock = true;`.
 
 ### Fixed
 * Fixed handling of Cargo workspace inheritance for git-dependencies where said

--- a/checks/default.nix
+++ b/checks/default.nix
@@ -609,7 +609,6 @@ in
     postUnpack = ''
       cd $sourceRoot/workspace
       sourceRoot="."
-      [[ -f Cargo.lock ]] || ln ../Cargo.lock
     '';
     cargoLock = ./workspace-not-at-root/workspace/Cargo.lock;
     cargoToml = ./workspace-not-at-root/workspace/Cargo.toml;

--- a/docs/API.md
+++ b/docs/API.md
@@ -931,6 +931,16 @@ This is a fairly low-level abstraction, so consider using `buildPackage` or
   - Default value: the build phase will run `preBuild` hooks, print the cargo
     version, log and evaluate `buildPhaseCargoCommand`, and run `postBuild`
     hooks
+* `cargoLock`: if set will be passed through to the derivation and the path it
+  points to will be copied as the workspace `Cargo.lock`
+  - Unset by default
+* `cargoLockContents`: if set and `cargoLock` is missing or null, its value will
+  be written as the workspace `Cargo.lock`
+  - Unset by default
+* `cargoLockParsed`: if set and both `cargoLock` and `cargoLockContents` are
+  missing or null, its value will be serialized as TOML and the result written
+  as the workspace `Cargo.lock`
+  - Unset by default
 * `cargoVendorDir`: A path (or derivation) of vendored cargo sources which can
   be consumed without network access. Directory structure should basically
   follow the output of `cargo vendor`.
@@ -992,6 +1002,7 @@ hooks:
 * `configureCargoVendoredDepsHook`
 * `inheritCargoArtifactsHook`
 * `installCargoArtifactsHook`
+* `replaceCargoLockHook`
 * `rsync`
 * `zstd`
 
@@ -1539,3 +1550,15 @@ sources themselves. It takes two positional arguments:
 `doNotRemoveReferencesToVendorDir` is not set, then
 `removeReferencesToVendoredSources "$out" "$cargoVendorDir"` will be run as a
 post install hook.
+
+### `craneLib.replaceCargoLockHook`
+
+Defines `replaceCargoLock()` which handles replacing or inserting a specified
+`Cargo.lock` file in the current directory. It takes one positional argument:
+1. a file which will be copied to `Cargo.lock` in the current directory
+   * If not specified, the value of `$cargoLock` will be used
+   * If `$cargoLock` is not set, an error will be raised
+
+**Automatic behavior:** if `cargoLock` is set and
+`doNotReplaceCargoLock` is not set, then `replaceCargoLock "$cargoLock"` will be
+run as a post unpack hook.

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -67,6 +67,7 @@ in
   registryFromGitIndex = callPackage ./registryFromGitIndex.nix { };
   registryFromSparse = callPackage ./registryFromSparse.nix { };
   removeReferencesToVendoredSourcesHook = callPackage ./setupHooks/removeReferencesToVendoredSources.nix { };
+  replaceCargoLockHook = callPackage ./setupHooks/replaceCargoLockHook.nix { };
   urlForCargoPackage = callPackage ./urlForCargoPackage.nix { };
   vendorCargoDeps = callPackage ./vendorCargoDeps.nix { };
   vendorMultipleCargoDeps = callPackage ./vendorMultipleCargoDeps.nix { };

--- a/lib/setupHooks/replaceCargoLockHook.nix
+++ b/lib/setupHooks/replaceCargoLockHook.nix
@@ -1,0 +1,7 @@
+{ makeSetupHook
+}:
+
+makeSetupHook
+{
+  name = "replaceCargoLockHook";
+} ./replaceCargoLockHook.sh

--- a/lib/setupHooks/replaceCargoLockHook.sh
+++ b/lib/setupHooks/replaceCargoLockHook.sh
@@ -1,0 +1,20 @@
+replaceCargoLock() {
+  local cargoLockOverride="${1:-${cargoLock:?not defined}}"
+
+  if [[ -f Cargo.lock ]]; then
+    echo "moving Cargo.lock to Cargo.lock.orig, then will use ${cargoLockOverride} as Cargo.lock"
+     mv Cargo.lock Cargo.lock.orig
+  else
+    echo "will use ${cargoLockOverride} as Cargo.lock"
+  fi
+
+  cp --no-preserve=ownership,mode "${cargoLock}" Cargo.lock
+}
+
+if [ -n "${cargoLock:-}" ]; then
+  if [ -n "${doNotReplaceCargoLock:-}" ]; then
+    echo "skipping Cargo.lock override as requested";
+  else
+    postUnpackHooks+=(replaceCargoLock)
+  fi
+fi


### PR DESCRIPTION
## Motivation
* The vendoring helpers already accept a `cargoLock` override, so automatically linking it in the derivation (if set) makes it a bit easier without having the caller manually do the link themselves

Fixes https://github.com/ipetkov/crane/issues/422

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [x] updated `docs/API.md` (or general documentation) with changes
- [x] updated `CHANGELOG.md`
