### PR TITLE
ci: only push to cachix on the main branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
     - uses: cachix/cachix-action@v12
       with:
         name: crane
-        authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+        authToken: ${{ github.ref == 'refs/heads/master' && secrets.CACHIX_AUTH_TOKEN || '' }}
     - name: flake checks
       run: nix develop --accept-flake-config --command ./ci/fast-flake-check.sh ${{ matrix.nixpkgs-override }} -- --keep-going
     - name: extra tests
@@ -76,7 +76,7 @@ jobs:
     - uses: cachix/cachix-action@v12
       with:
         name: crane
-        authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+        authToken: ${{ github.ref == 'refs/heads/master' && secrets.CACHIX_AUTH_TOKEN || '' }}
     - name: validate examples
       run: |
         # Nix won't write a lockfile when --override-input is used (which is good because it will
@@ -97,9 +97,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: cachix/install-nix-action@v23
-    - uses: cachix/cachix-action@v12
-      with:
-        name: deadnix
+    - uses: DeterminateSystems/magic-nix-cache-action@main
     - name: check for dead code
       run: nix run github:astro/deadnix -- .
 
@@ -108,5 +106,6 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: cachix/install-nix-action@v23
+    - uses: DeterminateSystems/magic-nix-cache-action@main
     - name: check formatting
       run: nix fmt --accept-flake-config -- --check .


### PR DESCRIPTION
## Motivation
* PRs are more ephemeral and if they cause massive rebuilds, they're likely to continue causing rebuilds as feedback is being addressed, so we can cut down on the cache (push) pressure until the changes are actually landed

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [ ] updated `docs/API.md` (or general documentation) with changes
- [ ] updated `CHANGELOG.md`
