### PR TITLE
chore: update all examples with `strictDeps = true;`

### DIFF
--- a/checks/default.nix
+++ b/checks/default.nix
@@ -15,8 +15,10 @@ let
   aarch64Darwin = pkgs.hostPlatform.system == "aarch64-darwin";
 in
 {
+  # https://github.com/ipetkov/crane/issues/411
   bzip2Sys = myLib.buildPackage {
     src = ./bzip2-sys;
+    strictDeps = false; # Explicitly repro original report
     installCargoArtifactsMode = "use-zstd";
     nativeBuildInputs = [ pkgs.pkg-config ];
   };
@@ -119,6 +121,7 @@ in
     let
       codesignPackage = myLib.buildPackage {
         src = ./codesign;
+        strictDeps = true;
         nativeBuildInputs = [ pkgs.pkg-config pkgs.libiconv ];
         buildInputs = [ pkgs.openssl ];
         dontStrip = true;
@@ -497,11 +500,13 @@ in
     in
     myLibWithRegistry.buildPackage {
       src = ../examples/alt-registry;
-      nativeBuildInputs = with pkgs; [
-        pkg-config
-        openssl
+      strictDeps = true;
+      nativeBuildInputs = [
+        pkgs.pkg-config
       ];
-      buildInputs = lib.optionals isDarwin [
+      buildInputs = [
+        pkgs.openssl
+      ] ++ lib.optionals isDarwin [
         pkgs.libiconv
         pkgs.darwin.apple_sdk.frameworks.Security
       ];

--- a/docs/introduction/artifact-reuse.md
+++ b/docs/introduction/artifact-reuse.md
@@ -36,6 +36,7 @@ Here's how we can set up our flake to achieve our goals:
         # Common derivation arguments used for all builds
         commonArgs = {
           src = craneLib.cleanCargoSource (craneLib.path ./.);
+          strictDeps = true;
 
           buildInputs = with pkgs; [
             # Add extra build inputs here, etc.

--- a/docs/introduction/sequential-builds.md
+++ b/docs/introduction/sequential-builds.md
@@ -27,6 +27,7 @@ build.
         # Common derivation arguments used for all builds
         commonArgs = {
           src = craneLib.cleanCargoSource (craneLib.path ./.);
+          strictDeps = true;
 
           buildInputs = with pkgs; [
             # Add extra build inputs here, etc.

--- a/examples/alt-registry/flake.nix
+++ b/examples/alt-registry/flake.nix
@@ -63,9 +63,11 @@
 
         my-crate = craneLib.buildPackage {
           src = craneLib.cleanCargoSource (craneLib.path ./.);
+          strictDeps = true;
 
           buildInputs = [
             # Add additional build inputs here
+            pkgs.openssl
           ] ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [
             # Additional darwin specific inputs can be set here
             pkgs.libiconv
@@ -73,9 +75,8 @@
           ];
 
           # Specific to our example, but not always necessary in the general case.
-          nativeBuildInputs = with pkgs; [
-            pkg-config
-            openssl
+          nativeBuildInputs = [
+            pkgs.pkg-config
           ];
         };
       in

--- a/examples/build-std/flake.nix
+++ b/examples/build-std/flake.nix
@@ -43,6 +43,7 @@
 
         my-crate = craneLib.buildPackage {
           inherit src;
+          strictDeps = true;
 
           cargoVendorDir = craneLib.vendorMultipleCargoDeps {
             inherit (craneLib.findCargoFiles src) cargoConfigs;

--- a/examples/cross-musl/flake.nix
+++ b/examples/cross-musl/flake.nix
@@ -36,6 +36,7 @@
 
         my-crate = craneLib.buildPackage {
           src = craneLib.cleanCargoSource (craneLib.path ./.);
+          strictDeps = true;
 
           CARGO_BUILD_TARGET = "x86_64-unknown-linux-musl";
           CARGO_BUILD_RUSTFLAGS = "-C target-feature=+crt-static";

--- a/examples/cross-rust-overlay/flake.nix
+++ b/examples/cross-rust-overlay/flake.nix
@@ -56,6 +56,7 @@
           }:
           craneLib.buildPackage {
             src = craneLib.cleanCargoSource (craneLib.path ./.);
+            strictDeps = true;
 
             # Build-time tools which are target agnostic. build = host = target = your-machine.
             # Emulators should essentially also go `nativeBuildInputs`. But with some packaging issue,

--- a/examples/custom-toolchain/flake.nix
+++ b/examples/custom-toolchain/flake.nix
@@ -40,6 +40,7 @@
 
         my-crate = craneLib.buildPackage {
           src = craneLib.cleanCargoSource (craneLib.path ./.);
+          strictDeps = true;
 
           cargoExtraArgs = "--target wasm32-wasi";
 

--- a/examples/quick-start-simple/flake.nix
+++ b/examples/quick-start-simple/flake.nix
@@ -22,6 +22,7 @@
         craneLib = crane.lib.${system};
         my-crate = craneLib.buildPackage {
           src = craneLib.cleanCargoSource (craneLib.path ./.);
+          strictDeps = true;
 
           buildInputs = [
             # Add additional build inputs here

--- a/examples/quick-start/flake.nix
+++ b/examples/quick-start/flake.nix
@@ -38,6 +38,7 @@
         # Common arguments can be set here to avoid repeating them later
         commonArgs = {
           inherit src;
+          strictDeps = true;
 
           buildInputs = [
             # Add additional build inputs here

--- a/examples/trunk-workspace/flake.nix
+++ b/examples/trunk-workspace/flake.nix
@@ -66,6 +66,7 @@
           inherit src;
           pname = "trunk-workspace";
           version = "0.1.0";
+          strictDeps = true;
 
           buildInputs = [
             # Add additional build inputs here

--- a/examples/trunk/flake.nix
+++ b/examples/trunk/flake.nix
@@ -61,6 +61,7 @@
         # Common arguments can be set here to avoid repeating them later
         commonArgs = {
           inherit src;
+          strictDeps = true;
           # We must force the target, otherwise cargo will attempt to use your native target
           CARGO_BUILD_TARGET = "wasm32-unknown-unknown";
 


### PR DESCRIPTION
## Motivation
It can be a common source of rebuilds if `buildInputs`/`nativeBuildInputs` are not set up properly, plus it's good hygiene to always have it on.

There are no plans to make this a default behavior of `mkCargoDerivation`, however, as that would be a departure from `mkDerivation` which might end up being surprising

Fixes https://github.com/ipetkov/crane/issues/403

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [ ] updated `docs/API.md` (or general documentation) with changes
- [ ] updated `CHANGELOG.md`
