### PR TITLE
ci: also use fast-flake-check for examples

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,7 @@ jobs:
         name: crane
         authToken: ${{ github.ref == 'refs/heads/master' && secrets.CACHIX_AUTH_TOKEN || '' }}
     - name: flake checks
-      run: nix develop --accept-flake-config --command ./ci/fast-flake-check.sh ${{ matrix.nixpkgs-override }} -- --keep-going
+      run: nix develop --accept-flake-config --command ./ci/fast-flake-check.sh ${{ matrix.nixpkgs-override }}
     - name: extra tests
       run: nix develop --accept-flake-config ${{ matrix.nixpkgs-override }} --command ./extra-tests/test.sh
 
@@ -87,8 +87,9 @@ jobs:
         for f in $(find examples -maxdepth 1 -mindepth 1 -type d ${{ matrix.filter }} | sort -u); do
           pushd "${f}"
           echo "validating ${f}"
-          # NB: check the entire flake here, not just `.#checks`
-          nix flake check --accept-flake-config --print-build-logs --override-input crane ../.. ${{ matrix.nixpkgs-override }}
+          nix develop ../..# --accept-flake-config --command ../../ci/fast-flake-check.sh --override-input crane ../.. ${{ matrix.nixpkgs-override }}
+          # NB: evaluate the rest flake here, but don't build anything
+          nix flake check --no-build --accept-flake-config --print-build-logs --override-input crane ../.. ${{ matrix.nixpkgs-override }}
           popd
         done
 

--- a/ci/fast-flake-check.sh
+++ b/ci/fast-flake-check.sh
@@ -2,7 +2,7 @@
 curSystem=$(nix eval --raw --impure --expr builtins.currentSystem)
 
 nixEvalJobsArgs=()
-while [[ $# -ge 0 ]]; do
+while [[ $# -gt 0 ]]; do
   arg="$1"
   shift 1
 

--- a/examples/cross-windows/flake.nix
+++ b/examples/cross-windows/flake.nix
@@ -32,9 +32,8 @@
           ];
 
         craneLib = (crane.mkLib pkgs).overrideToolchain toolchain;
-      in
-      {
-        packages.default = craneLib.buildPackage {
+
+        my-crate = craneLib.buildPackage {
           src = craneLib.cleanCargoSource (craneLib.path ./.);
 
           strictDeps = true;
@@ -46,6 +45,16 @@
             pkgsCross.mingwW64.stdenv.cc
             pkgsCross.mingwW64.windows.pthreads
           ];
+        };
+      in
+      {
+        packages = {
+          inherit my-crate;
+          default = my-crate;
+        };
+
+        checks = {
+          inherit my-crate;
         };
       }
     );


### PR DESCRIPTION
## Motivation
We can use `nix flake check --no-build` to evaluate the rest of the flake, but still do a fast build of the checks themselves

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [ ] updated `docs/API.md` (or general documentation) with changes
- [ ] updated `CHANGELOG.md`
