### PR TITLE
replaceCargoLockHook: run as prePatchHook not postUnpack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * `devShell` will now additionally include `clippy` and `rustfmt` from the
   currently configured toolchain
 
+### Fixed
+* `replaceCargoLockHook` now runs as a `prePatch` hook (rather
+  than `postUnpack`) which correctly replaces the `Cargo.lock` in the source
+  directory rather than the parent directory
+
 ## [0.14.2] - 2023-10-15
 
 ### Added

--- a/checks/default.nix
+++ b/checks/default.nix
@@ -375,6 +375,18 @@ in
   simple = myLib.buildPackage {
     src = myLib.cleanCargoSource ./simple;
   };
+
+  simpleWithLockOverride = myLib.buildPackage {
+    cargoVendorDir = myLib.vendorCargoDeps { src = ./simple; };
+    src = lib.cleanSourceWith {
+      src = ./simple;
+      # Intentionally filter out Cargo.lock
+      filter = path: type: !(lib.hasSuffix "Cargo.lock" path);
+    };
+
+    cargoLock = ./simple/Cargo.lock;
+  };
+
   simpleGit = myLib.buildPackage {
     src = myLib.cleanCargoSource ./simple-git;
     buildInputs = lib.optionals isDarwin [

--- a/docs/API.md
+++ b/docs/API.md
@@ -1566,4 +1566,4 @@ Defines `replaceCargoLock()` which handles replacing or inserting a specified
 
 **Automatic behavior:** if `cargoLock` is set and
 `doNotReplaceCargoLock` is not set, then `replaceCargoLock "$cargoLock"` will be
-run as a post unpack hook.
+run as a pre patch hook.

--- a/lib/setupHooks/replaceCargoLockHook.sh
+++ b/lib/setupHooks/replaceCargoLockHook.sh
@@ -15,6 +15,6 @@ if [ -n "${cargoLock:-}" ]; then
   if [ -n "${doNotReplaceCargoLock:-}" ]; then
     echo "skipping Cargo.lock override as requested";
   else
-    postUnpackHooks+=(replaceCargoLock)
+    prePatchHooks+=(replaceCargoLock)
   fi
 fi


### PR DESCRIPTION
## Motivation
Copying the overridden Cargo.lock cannot be done as a `postUnpack` hook because the builder does not `cd` into the unpacked source until after those hooks are done (thus we effectively end up linking the `Cargo.lock` to `..` when the build runs).

The fix is to change the hook to run later as a `prePatch` hook

Fixes https://github.com/ipetkov/crane/issues/422

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [x] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [x] updated `docs/API.md` (or general documentation) with changes
- [x] updated `CHANGELOG.md`
