### PR TITLE
ci: pin all example inputs with a single testing flake.lock

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,7 @@ jobs:
         name: crane
         authToken: ${{ github.ref == 'refs/heads/master' && secrets.CACHIX_AUTH_TOKEN || '' }}
     - name: flake checks
-      run: nix develop --accept-flake-config --command ./ci/fast-flake-check.sh ${{ matrix.nixpkgs-override }}
+      run: nix develop --accept-flake-config --command ./ci/fast-flake-check.sh . ${{ matrix.nixpkgs-override }}
     - name: extra tests
       run: nix develop --accept-flake-config ${{ matrix.nixpkgs-override }} --command ./extra-tests/test.sh
 
@@ -58,14 +58,15 @@ jobs:
           - os: ubuntu-latest
             # Latest and greatest release of Nix
             install_url: https://nixos.org/nix/install
+            nixpkgs: ".#nixpkgs"
           - os: ubuntu-latest
             # The 23.05 branch ships with Nix 2.11.1
             install_url: https://releases.nixos.org/nix/nix-2.13.3/install
-            nixpkgs-override: "--override-input nixpkgs github:NixOS/nixpkgs/release-23.05"
+            nixpkgs: "./test#nixpkgs"
           - os: macos-12
             # Latest and greatest release of Nix
             install_url: https://nixos.org/nix/install
-            nixpkgs-override: "--override-input nixpkgs github:NixOS/nixpkgs/nixpkgs-23.05-darwin"
+            nixpkgs: "./test#nixpkgs-darwin"
             filter: "-not -name build-std -not -name cross-rust-overlay"
     runs-on: ${{ matrix.os }}
     steps:
@@ -78,20 +79,16 @@ jobs:
         name: crane
         authToken: ${{ github.ref == 'refs/heads/master' && secrets.CACHIX_AUTH_TOKEN || '' }}
     - name: validate examples
+      # Nix won't write a lockfile when --override-input is used (which is good because it will
+      # complain that the lock file is .gitignored), but nix-eval-jobs doesn't, so we'll have to
+      # "opt-out" of our lockfile .gitignore
       run: |
-        # Nix won't write a lockfile when --override-input is used (which is good because it will
-        # complain that the lock file is .gitignored), but nix-eval-jobs doesn't, so we'll have to
-        # "opt-out" of our lockfile .gitignore
         rm ./examples/.gitignore
-
-        for f in $(find examples -maxdepth 1 -mindepth 1 -type d ${{ matrix.filter }} | sort -u); do
-          pushd "${f}"
-          echo "validating ${f}"
-          nix develop ../..# --accept-flake-config --command ../../ci/fast-flake-check.sh --override-input crane ../.. ${{ matrix.nixpkgs-override }}
-          # NB: evaluate the rest flake here, but don't build anything
-          nix flake check --no-build --accept-flake-config --print-build-logs --override-input crane ../.. ${{ matrix.nixpkgs-override }}
-          popd
-        done
+        nix develop .# --accept-flake-config --command bash -c '
+          for f in $(find ./examples -maxdepth 1 -mindepth 1 -type d ${{ matrix.filter }} | sort -u); do
+            ./ci/check-example.sh "${f}" ${{ matrix.nixpkgs }}
+          done
+        '
 
   check-dead-code:
     runs-on: ubuntu-latest

--- a/ci/check-example.sh
+++ b/ci/check-example.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+gitRoot="$(git rev-parse --show-toplevel)"
+
+example="${1:?missing example}"
+nixpkgsFrom="${2:?missing nixpkgsFrom}"
+shift 2
+
+nixpkgsFromFlake="$(echo "${nixpkgsFrom}" | cut -d# -f1)"
+nixpkgsFromInput="$(echo "${nixpkgsFrom}" | cut -d# -f2)"
+chosenNixpkgs="$("${gitRoot}/ci/ref-from-lock.sh" "${nixpkgsFromFlake}" "${nixpkgsFromInput}")"
+
+commonArgs=(
+  "${example}"
+  --override-input crane "${gitRoot}"
+  --override-input nixpkgs "${chosenNixpkgs}"
+  "$@"
+)
+
+echo "--- checking ${example}"
+
+# nix-eval-jobs doesn't (yet) support --reference-lock-file: https://github.com/nix-community/nix-eval-jobs/pull/210
+# Nix older than 2.15 also doesn't support it
+cp {"${gitRoot}/test","${example}"}/flake.lock
+trap "rm -f ${example}/flake.lock" EXIT
+
+"${gitRoot}/ci/fast-flake-check.sh" "${commonArgs[@]}"
+
+# NB: evaluate the rest flake here, but don't build anything
+nix flake check \
+  --no-build \
+  --no-write-lock-file \
+  --accept-flake-config \
+  --print-build-logs \
+  "${commonArgs[@]}"

--- a/ci/fast-flake-check.sh
+++ b/ci/fast-flake-check.sh
@@ -1,5 +1,13 @@
 #!/usr/bin/env bash
+set -euo pipefail
+
 curSystem=$(nix eval --raw --impure --expr builtins.currentSystem)
+
+flake='.'
+if [[ $# -gt 0 && "${1:-}" != '--' ]]; then
+  flake="${1}"
+  shift 1
+fi
 
 nixEvalJobsArgs=()
 while [[ $# -gt 0 ]]; do
@@ -16,7 +24,7 @@ done
 nix-eval-jobs \
   --gc-roots-dir gcroot \
   --check-cache-status \
-  --flake ".#checks.${curSystem}" \
+  --flake "${flake}#checks.${curSystem}" \
   "${nixEvalJobsArgs[@]}" \
   | jq -r 'select(.isCached | not).drvPath as $drvPath | "\($drvPath)^*"' \
   | xargs --no-run-if-empty nix build --no-link --print-build-logs "$@"

--- a/ci/ref-from-lock.sh
+++ b/ci/ref-from-lock.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+flakeLock="${1:?missing flake.lock}"
+input="${2:?missing input}"
+
+jq -r <"${flakeLock}/flake.lock" '.nodes.root.inputs."'"${input}"'" as $name | .nodes | getpath([$name]).locked | "\(.type):\(.owner)/\(.repo)/\(.rev)"'

--- a/test/flake.lock
+++ b/test/flake.lock
@@ -1,0 +1,290 @@
+{
+  "nodes": {
+    "advisory-db": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1697318478,
+        "narHash": "sha256-ZEDgHfurZiv9lBGTmHnQ0YECoi6H2NYs3pTo1VU1koQ=",
+        "owner": "rustsec",
+        "repo": "advisory-db",
+        "rev": "71d80e811f2e29a4b82d3e545ad6591e35227e03",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rustsec",
+        "repo": "advisory-db",
+        "type": "github"
+      }
+    },
+    "crane": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "flake-utils": "flake-utils",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-overlay": "rust-overlay"
+      },
+      "locked": {
+        "lastModified": 1697648018,
+        "narHash": "sha256-C7hHmozOpuG4G6/NAnd0/EE1osAzgIV+6eZbuRYtf5U=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "bd2e69ee84552b2befe2594060513ea9e01bfeea",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1697610178,
+        "narHash": "sha256-1wdFrJU3ga81CbAWqx4Ix4GyXN8iC3tZg3BPI3R17ks=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "6de79c0b8dfb584d5423bec1612fcc357b32f60f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1694529238,
+        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1694529238,
+        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1697655685,
+        "narHash": "sha256-79Kuv+QdgsVc+rkibuAgWHnh8IXrLBTOKg5nM0Qvux0=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "80c1aab725151632ddc2a20caeb914e76dd0673c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "release-23.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-darwin": {
+      "locked": {
+        "lastModified": 1697613407,
+        "narHash": "sha256-0I+N1ln3gGvxTFOAxgBDNl8Mxepbio3YkOql2VKxqRI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "88a11a83389232bb305ff0bfb4ec191f38d3b511",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-23.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-for-wasm-bindgen": {
+      "locked": {
+        "lastModified": 1691495139,
+        "narHash": "sha256-+zZIRTtXlA8gN8HPzczphPnB9L+yYpidBmFxKqWQy+A=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "4e6868b1aa3766ab1de169922bb3826143941973",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "4e6868b1aa3766ab1de169922bb3826143941973",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "advisory-db": "advisory-db",
+        "crane": "crane",
+        "fenix": "fenix",
+        "flake-compat": "flake-compat_2",
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-darwin": "nixpkgs-darwin",
+        "nixpkgs-for-wasm-bindgen": "nixpkgs-for-wasm-bindgen",
+        "rust-overlay": "rust-overlay_2"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1697480602,
+        "narHash": "sha256-XiBylVAQRwulBD0pEbct9ir+dLEAe8j3oJyrNnmRL3w=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "d6afb4fa239fe7b5b34e5cefa9e58148fdff65b8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "flake-utils": [
+          "crane",
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "crane",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1697595136,
+        "narHash": "sha256-9honwiIeMbBKi7FzfEy89f1ShUiXz/gVxZSS048pKyc=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "a2ccfb2134622b28668a274e403ba6f075ae1223",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "rust-overlay_2": {
+      "inputs": {
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1697595136,
+        "narHash": "sha256-9honwiIeMbBKi7FzfEy89f1ShUiXz/gVxZSS048pKyc=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "a2ccfb2134622b28668a274e403ba6f075ae1223",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/test/flake.nix
+++ b/test/flake.nix
@@ -1,0 +1,44 @@
+{
+  inputs = {
+    # NB: nixpkgs-unstable testing will come from the root flake
+    nixpkgs.url = "github:NixOS/nixpkgs/release-23.05";
+    nixpkgs-darwin.url = "github:NixOS/nixpkgs/nixpkgs-23.05-darwin";
+
+    # The version of wasm-bindgen-cli needs to match the version in Cargo.lock
+    # Update this to include the version you need
+    nixpkgs-for-wasm-bindgen.url = "github:NixOS/nixpkgs/4e6868b1aa3766ab1de169922bb3826143941973";
+
+    advisory-db = {
+      url = "github:rustsec/advisory-db";
+      flake = false;
+    };
+
+    crane = {
+      url = "github:ipetkov/crane";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    fenix = {
+      url = "github:nix-community/fenix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    flake-compat = {
+      url = "github:edolstra/flake-compat";
+      flake = false;
+    };
+
+    flake-utils.url = "github:numtide/flake-utils";
+
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs = {
+        nixpkgs.follows = "nixpkgs";
+        flake-utils.follows = "flake-utils";
+      };
+    };
+
+  };
+
+  outputs = _: { };
+}


### PR DESCRIPTION
## Motivation
Should give us better/more consistent caching (and avoid random headaches when the nixpkgs-darwin branch updates and then we're stuck recompiling for hours for an unrelated change)

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [ ] updated `docs/API.md` (or general documentation) with changes
- [ ] updated `CHANGELOG.md`
