### PR TITLE
chore: drop all public dependencies except for `nixpkgs`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   approach to avoid redundancy. Old behavior (taking a full snapshot of the
   cargo artifacts) can be achieved by setting `doCompressAndInstallFullArchive =
   true`.
+* All dependencies (outside of `nixpkgs`) have been dropped from the (main)
+  flake.lock file so they do not pollute downstream projects' lock files.
 
 ## [0.14.3] - 2023-10-17
 

--- a/extra-tests/dummy-does-not-depend-on-flake-source-via-path/flake.nix
+++ b/extra-tests/dummy-does-not-depend-on-flake-source-via-path/flake.nix
@@ -2,7 +2,7 @@
   inputs = {
     crane.url = "github:ipetkov/crane";
     nixpkgs.follows = "crane/nixpkgs";
-    flake-utils.follows = "crane/flake-utils";
+    flake-utils.url = "github:numtide/flake-utils";
   };
 
   outputs = { flake-utils, crane, ... }: flake-utils.lib.eachDefaultSystem

--- a/extra-tests/dummy-does-not-depend-on-flake-source-via-self/flake.nix
+++ b/extra-tests/dummy-does-not-depend-on-flake-source-via-self/flake.nix
@@ -2,7 +2,7 @@
   inputs = {
     crane.url = "github:ipetkov/crane";
     nixpkgs.follows = "crane/nixpkgs";
-    flake-utils.follows = "crane/flake-utils";
+    flake-utils.url = "github:numtide/flake-utils";
   };
 
   outputs = { self, flake-utils, crane, ... }: flake-utils.lib.eachDefaultSystem

--- a/extra-tests/fetch-cargo-git/flake.nix
+++ b/extra-tests/fetch-cargo-git/flake.nix
@@ -1,7 +1,7 @@
 {
   inputs = {
     crane.url = "github:ipetkov/crane";
-    flake-utils.follows = "crane/flake-utils";
+    flake-utils.url = "github:numtide/flake-utils";
   };
 
   outputs = { flake-utils, crane, ... }: flake-utils.lib.eachDefaultSystem

--- a/flake.lock
+++ b/flake.lock
@@ -1,21 +1,5 @@
 {
   "nodes": {
-    "flake-compat": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1696426674,
-        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -52,7 +36,6 @@
     },
     "root": {
       "inputs": {
-        "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
         "rust-overlay": "rust-overlay"

--- a/flake.lock
+++ b/flake.lock
@@ -1,23 +1,5 @@
 {
   "nodes": {
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1694529238,
-        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1697379843,
@@ -36,23 +18,7 @@
     },
     "root": {
       "inputs": {
-        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
       }
     }
   },

--- a/flake.lock
+++ b/flake.lock
@@ -37,31 +37,7 @@
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs",
-        "rust-overlay": "rust-overlay"
-      }
-    },
-    "rust-overlay": {
-      "inputs": {
-        "flake-utils": [
-          "flake-utils"
-        ],
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1697595136,
-        "narHash": "sha256-9honwiIeMbBKi7FzfEy89f1ShUiXz/gVxZSS048pKyc=",
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "rev": "a2ccfb2134622b28668a274e403ba6f075ae1223",
-        "type": "github"
-      },
-      "original": {
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "type": "github"
+        "nixpkgs": "nixpkgs"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -4,11 +4,6 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
 
-    flake-compat = {
-      url = "github:edolstra/flake-compat";
-      flake = false;
-    };
-
     flake-utils.url = "github:numtide/flake-utils";
 
     rust-overlay = {

--- a/flake.nix
+++ b/flake.nix
@@ -1,18 +1,14 @@
 {
   description = "A Nix library for building cargo projects. Never build twice thanks to incremental artifact caching.";
 
-  inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
-
-    flake-utils.url = "github:numtide/flake-utils";
-  };
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
 
   nixConfig = {
     extra-substituters = [ "https://crane.cachix.org" ];
     extra-trusted-public-keys = [ "crane.cachix.org-1:8Scfpmn9w+hGdXH/Q9tTLiYAE/2dnJYRJP7kl80GuRk=" ];
   };
 
-  outputs = { nixpkgs, flake-utils, ... }:
+  outputs = { nixpkgs, ... }:
     let
       mkLib = pkgs: import ./lib {
         inherit (pkgs) lib newScope;
@@ -27,6 +23,30 @@
           url = "https://github.com/${locked.owner}/${locked.repo}/archive/${locked.rev}.tar.gz";
           sha256 = locked.narHash;
         };
+
+      eachSystem = systems: f:
+        let
+          # Merge together the outputs for all systems.
+          op = attrs: system:
+            let
+              ret = f system;
+              op = attrs: key: attrs //
+                {
+                  ${key} = (attrs.${key} or { })
+                    // { ${system} = ret.${key}; };
+                }
+              ;
+            in
+            builtins.foldl' op attrs (builtins.attrNames ret);
+        in
+        builtins.foldl' op { } systems;
+
+      eachDefaultSystem = eachSystem [
+        "aarch64-linux"
+        "aarch64-darwin"
+        "x86_64-darwin"
+        "x86_64-linux"
+      ];
     in
     {
       inherit mkLib;
@@ -85,7 +105,7 @@
           path = ./examples/trunk-workspace;
         };
       };
-    } // flake-utils.lib.eachDefaultSystem (system:
+    } // eachDefaultSystem (system:
       let
         pkgs = import nixpkgs {
           inherit system;

--- a/shell.nix
+++ b/shell.nix
@@ -1,5 +1,5 @@
 let
-  lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+  lock = builtins.fromJSON (builtins.readFile ./test/flake.lock);
   locked = lock.nodes.flake-compat.locked;
   compat = fetchTarball {
     url = "https://github.com/${locked.owner}/${locked.repo}/archive/${locked.rev}.tar.gz";


### PR DESCRIPTION
## Motivation
There's no point in polluting downstreams' lockfiles with our own internal dependencies, we can hide them by using an internal `flake.lock`

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [ ] updated `docs/API.md` (or general documentation) with changes
- [x] updated `CHANGELOG.md`
