### PR TITLE
installCargoArtifactsHook: change default installation mode to use-zstd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   approach to avoid redundancy. Old behavior (taking a full snapshot of the
   cargo artifacts) can be achieved by setting `doCompressAndInstallFullArchive =
   true`.
+* The default `installCargoArtifactsMode` has been changed to `use-zstd`,
+  meaning cargo artifacts will be compressed to a series of incremental, zstd
+  compressed tarballs across derivations. To get the old behavior back, set
+  `installCargoArtifactsMode = "use-symlink"` to any derivation which produces
+  cargo artifacts.
 * All dependencies (outside of `nixpkgs`) have been dropped from the (main)
   flake.lock file so they do not pollute downstream projects' lock files.
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -187,7 +187,6 @@ install hooks.
   Useful for caching incremental cargo builds.
   - Default value: the result of `buildDepsOnly` after applying the arguments
     set (with the respective default values).
-  - `installCargoArtifactsMode` will be set to `"use-zstd"` if not specified.
   - `installPhase` and `installPhaseCommand` will be removed, and no
     installation hooks will be run
 * `cargoBuildCommand`: A cargo invocation to run during the derivation's build
@@ -257,7 +256,6 @@ Except where noted below, all derivation attributes are delegated to
     set (with the respective default values).
   - `CARGO_BUILD_TARGET` will be set to `"wasm32-unknown-unknown"` if not specified.
   - `doCheck` will be set to `false` if not specified.
-  - `installCargoArtifactsMode` will be set to `"use-zstd"` if not specified.
   - `installPhase` and `installPhaseCommand` will be removed (in favor of their
     default values provided by `buildDepsOnly`)
 * `installPhaseCommand`: the command(s) which are expected to install the
@@ -1541,7 +1539,7 @@ arguments:
      `./target`) will be used.
 1. the installation mode to apply
    * If specified, the value of `$installCargoArtifactsMode` will be used,
-     otherwise, a default value of `"use-symlink" will be used
+     otherwise, a default value of `"use-zstd" will be used
    * If set to "use-symlink" then `dedupAndInstallCargoArtifactsDir()` will be
      used.
      - If `$cargoArtifacts` is defined and `$cargoArtifacts/target` is a valid

--- a/lib/buildPackage.nix
+++ b/lib/buildPackage.nix
@@ -39,7 +39,6 @@ mkCargoDerivation (cleanedArgs // memoizedArgs // {
 
   cargoArtifacts = args.cargoArtifacts or (
     buildDepsOnly (args // memoizedArgs // {
-      installCargoArtifactsMode = args.installCargoArtifactsMode or "use-zstd";
       # NB: we intentionally don't run any caller-provided hooks here since they might fail
       # if they require any files that have been omitted by the source dummification.
       # However, we still _do_ want to run the installation hook with the actual artifacts

--- a/lib/buildTrunkPackage.nix
+++ b/lib/buildTrunkPackage.nix
@@ -37,7 +37,6 @@ mkCargoDerivation (args // {
 
   cargoArtifacts = args.cargoArtifacts or (buildDepsOnly (args // {
     CARGO_BUILD_TARGET = args.CARGO_BUILD_TARGET or "wasm32-unknown-unknown";
-    installCargoArtifactsMode = args.installCargoArtifactsMode or "use-zstd";
     doCheck = args.doCheck or false;
   }));
 

--- a/lib/setupHooks/installCargoArtifactsHook.sh
+++ b/lib/setupHooks/installCargoArtifactsHook.sh
@@ -76,7 +76,7 @@ prepareAndInstallCargoArtifactsDir() {
   # or fall back to defaults if none are provided
   local dir="${1:-${out}}"
   local cargoTargetDir="${2:-${CARGO_TARGET_DIR:-target}}"
-  local mode="${3:-${installCargoArtifactsMode:-use-symlink}}"
+  local mode="${3:-${installCargoArtifactsMode:-use-zstd}}"
   local prevCargoArtifacts="${4:-${cargoArtifacts:""}}"
 
   mkdir -p "${dir}"


### PR DESCRIPTION
## Motivation
Now that we have incremental zstd compression we can change the default artifact installation mode to `"use-zstd"`. To get the old behavior back set `installCargoArtifactsMode = "use-symlink";`

Fixes https://github.com/ipetkov/crane/issues/441

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [x] updated `docs/API.md` (or general documentation) with changes
- [x] updated `CHANGELOG.md`
