### PR TITLE
mkDummySrc: fix cleaning to work with Nix store overrides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 gcroot
 result*
 target/
+/extra-tests/*/alt-store
 /extra-tests/*/flake.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * All dependencies (outside of `nixpkgs`) have been dropped from the (main)
   flake.lock file so they do not pollute downstream projects' lock files.
 
+### Fixed
+* `mkDummySrc` now properly handles file cleaning (and file including) when a
+  build is invoked with a `--store ...` override
+
 ## [0.14.3] - 2023-10-17
 
 ### Changed

--- a/extra-tests/alt-store/flake.nix
+++ b/extra-tests/alt-store/flake.nix
@@ -1,0 +1,18 @@
+{
+  inputs = {
+    crane.url = "github:ipetkov/crane";
+    nixpkgs.follows = "crane/nixpkgs";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { flake-utils, crane, ... }: flake-utils.lib.eachDefaultSystem (system:
+    let
+      craneLib = crane.lib.${system};
+    in
+    {
+      # https://github.com/ipetkov/crane/issues/446
+      packages.default = craneLib.buildPackage {
+        src = craneLib.cleanCargoSource (craneLib.path ../../checks/simple);
+      };
+    });
+}

--- a/extra-tests/alt-store/test.sh
+++ b/extra-tests/alt-store/test.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+# Regression test for https://github.com/ipetkov/crane/issues/446
+set -eu
+
+scriptDir=$(dirname "$0")
+cd "${scriptDir}"
+
+nix build .#default --override-input crane ../.. --store $(pwd)/alt-store

--- a/extra-tests/test.sh
+++ b/extra-tests/test.sh
@@ -18,6 +18,7 @@ runTest() {
 scriptPath=$(dirname "$0")
 cd "${scriptPath}"
 
+runTest ./alt-store/test.sh
 runTest ./dummy-does-not-depend-on-flake-source-via-path/test.sh
 runTest ./dummy-does-not-depend-on-flake-source-via-self/test.sh
 runTest ./fetch-cargo-git/test.sh


### PR DESCRIPTION
## Motivation
* Turns out if a build is invoked with `--store` then the source cleaning filter will observe paths rooted at the alternative store which breaks out previous string handling (and results in incorrectly ignoring files which should be included)

Fixes https://github.com/ipetkov/crane/issues/446

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [x] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [ ] updated `docs/API.md` (or general documentation) with changes
- [x] updated `CHANGELOG.md`
