### PR TITLE
buildTrunkPackage - separately export and declare shell variables (SC2155)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Fixed
+* `buildTrunkPackage`'s `preConfigure` script to fail quicker with a more
+  obvious error message if dependencies at not appropriately met
+
 ## [0.15.0] - 2023-11-05
 
 ### Added

--- a/lib/buildTrunkPackage.nix
+++ b/lib/buildTrunkPackage.nix
@@ -44,9 +44,12 @@ mkCargoDerivation (args // {
   # whatever tools actually make it into the builder's PATH
   preConfigure = ''
     echo configuring trunk tools
-    export TRUNK_TOOLS_SASS=$(sass --version | head -n1)
-    export TRUNK_TOOLS_WASM_BINDGEN=$(wasm-bindgen --version | cut -d' ' -f2)
-    export TRUNK_TOOLS_WASM_OPT="version_$(wasm-opt --version | cut -d' ' -f3)"
+    TRUNK_TOOLS_SASS=$(sass --version | head -n1)
+    TRUNK_TOOLS_WASM_BINDGEN=$(wasm-bindgen --version | cut -d' ' -f2)
+    TRUNK_TOOLS_WASM_OPT="version_$(wasm-opt --version | cut -d' ' -f3)"
+    export TRUNK_TOOLS_SASS
+    export TRUNK_TOOLS_WASM_BINDGEN
+    export TRUNK_TOOLS_WASM_OPT
 
     echo "TRUNK_TOOLS_SASS=''${TRUNK_TOOLS_SASS}"
     echo "TRUNK_TOOLS_WASM_BINDGEN=''${TRUNK_TOOLS_WASM_BINDGEN}"


### PR DESCRIPTION
Hello again! Updating my older rust project that uses `trunk` was seamless using crane's `buildTrunkPackage`.
The build Just Worked :tm: without any issues :slightly_smiling_face:

## Motivation
<!--
Thank you for your contribution! Please add a brief description below about the change and what is the motivation
behind it.
-->

While attempting to reuse the `preConfigure` hook in  buildTrunkPackage.nix (to build a trunk wrapper script for use in devshells) the `shellcheck` run by `writeShellApplication` gave some warnings:

<details>
<summary>Snippet of nix source</summary>

```nix
{
  frontend = craneLib.buildTrunkPackage { ...omitted... };

  trunkOffline = pkgs.writeShellApplication {
    name = "trunk-offline";
    # runtimeInputs - omitted
    text = ''
      ${frontend.preConfigure}
      ${pkgs.trunk}/bin/trunk "$@"
    '';
  };
}
```

</details>

Shellcheck warnings:
```text
In /nix/store/w6lkjm5zds14lbyj6sn2051kvp789l6k-trunk-offline/bin/trunk-offline line 7:
export TRUNK_TOOLS_SASS=$(sass --version | head -n1)
       ^--------------^ SC2155 (warning): Declare and assign separately to avoid masking return values.


In /nix/store/w6lkjm5zds14lbyj6sn2051kvp789l6k-trunk-offline/bin/trunk-offline line 8:
export TRUNK_TOOLS_WASM_BINDGEN=$(wasm-bindgen --version | cut -d' ' -f2)
       ^----------------------^ SC2155 (warning): Declare and assign separately to avoid masking return values.


In /nix/store/w6lkjm5zds14lbyj6sn2051kvp789l6k-trunk-offline/bin/trunk-offline line 9:
export TRUNK_TOOLS_WASM_OPT="version_$(wasm-opt --version | cut -d' ' -f3)"
       ^------------------^ SC2155 (warning): Declare and assign separately to avoid masking return values.

For more information:
  https://www.shellcheck.net/wiki/SC2155 -- Declare and assign separately to ...
```

Reviewing the linked [SC2155](https://www.shellcheck.net/wiki/SC2155) information, it seems if the inner `xyz --version` commands fail, then the `export` call will still report success. This allows the next commands to continue running, even though `trunk` will certainly fail.

This tiny PR separates the "export" from the declaration for the 3 versions.  Testing, it seems to catch the failure immediately in the copied `preConfigure` hook now. (the previous version continued trying to run `trunk` which would fail).
<details>
<summary>Of course, both versions succeed when you add the correct `runtimeInputs` (other than the `shellcheck` lint)</summary>

```patch
 trunkOffline = pkgs.writeShellApplication {
   name = "trunk-offline";
+  runtimeInputs = frontend.nativeBuildInputs;
   text = ''
     ${frontend.preConfigure}
     ${pkgs.trunk}/bin/trunk "$@"
   '';
 };
```

<!--
N.B. actual check to ignore the `shellcheck` was more like this:

trunkOffline =
  pkgs.writeShellScriptBin "trunk-offline"
  ''
    set -o errexit
    set -o nounset
    set -o pipefail
    ${frontend.preConfigure}
    ${pkgs.trunk}/bin/trunk "$@"
  '';
-->

</details>

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [ ] updated `docs/API.md` (or general documentation) with changes
- [ ] updated `CHANGELOG.md`

I didn't update the changelog, as I'm not sure whether or not it is desired for such a small change.