### PR TITLE
fix: avoid path starts with illegal character error

### DIFF
--- a/checks/default.nix
+++ b/checks/default.nix
@@ -354,12 +354,21 @@ in
   mkDummySrcTests = callPackage ./mkDummySrcTests { };
 
   # https://github.com/ipetkov/crane/issues/111
-  mkDummySrcCustom = myLib.buildPackage {
-    src = ./custom-dummy;
-    extraDummyScript = ''
-      cp -r ${./custom-dummy/.cargo} -T $out/.cargo
-    '';
-  };
+  mkDummySrcCustom =
+    let
+      src = ./custom-dummy;
+      dotCargoOnly = lib.cleanSourceWith {
+        inherit src;
+        # Only keep `*/.cargo/*`
+        filter = path: _type: lib.hasInfix ".cargo" path;
+      };
+    in
+    myLib.buildPackage {
+      src = ./custom-dummy;
+      extraDummyScript = ''
+        cp -r ${dotCargoOnly} -T $out/
+      '';
+    };
 
   noStd =
     let


### PR DESCRIPTION
## Motivation
* Looks like Nix 2.19.0 doesn't like it when a path starts with `.` so this updates the examples and tests to avoid doing that

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [x] updated `docs/API.md` (or general documentation) with changes
- [ ] updated `CHANGELOG.md`
