### PR TITLE
examples: avoid re-instantiating nixpkgs where possible

### DIFF
--- a/examples/alt-registry/flake.nix
+++ b/examples/alt-registry/flake.nix
@@ -17,9 +17,7 @@
   outputs = { self, nixpkgs, crane, flake-utils, ... }:
     flake-utils.lib.eachDefaultSystem (system:
       let
-        pkgs = import nixpkgs {
-          inherit system;
-        };
+        pkgs = nixpkgs.legacyPackages.${system};
 
         craneLibOrig = crane.lib.${system};
         craneLib = craneLibOrig.appendCrateRegistries [

--- a/examples/cross-windows/flake.nix
+++ b/examples/cross-windows/flake.nix
@@ -20,9 +20,7 @@
   outputs = { nixpkgs, crane, fenix, flake-utils, ... }:
     flake-utils.lib.eachDefaultSystem (system:
       let
-        pkgs = (import nixpkgs) {
-          inherit system;
-        };
+        pkgs = nixpkgs.legacyPackages.${system};
 
         toolchain = with fenix.packages.${system};
           combine [

--- a/examples/end-to-end-testing/flake.nix
+++ b/examples/end-to-end-testing/flake.nix
@@ -16,9 +16,7 @@
   outputs = { nixpkgs, crane, flake-utils, ... }:
     flake-utils.lib.eachDefaultSystem (system:
       let
-        pkgs = import nixpkgs {
-          inherit system;
-        };
+        pkgs = nixpkgs.legacyPackages.${system};
         inherit (pkgs) lib;
         craneLib = crane.lib.${system};
         src = craneLib.cleanCargoSource (craneLib.path ./.);

--- a/examples/quick-start-simple/flake.nix
+++ b/examples/quick-start-simple/flake.nix
@@ -15,9 +15,7 @@
   outputs = { self, nixpkgs, crane, flake-utils, ... }:
     flake-utils.lib.eachDefaultSystem (system:
       let
-        pkgs = import nixpkgs {
-          inherit system;
-        };
+        pkgs = nixpkgs.legacyPackages.${system};
 
         craneLib = crane.lib.${system};
         my-crate = craneLib.buildPackage {

--- a/examples/quick-start/flake.nix
+++ b/examples/quick-start/flake.nix
@@ -26,9 +26,7 @@
   outputs = { self, nixpkgs, crane, fenix, flake-utils, advisory-db, ... }:
     flake-utils.lib.eachDefaultSystem (system:
       let
-        pkgs = import nixpkgs {
-          inherit system;
-        };
+        pkgs = nixpkgs.legacyPackages.${system};
 
         inherit (pkgs) lib;
 

--- a/flake.nix
+++ b/flake.nix
@@ -107,9 +107,7 @@
       };
     } // eachDefaultSystem (system:
       let
-        pkgs = import nixpkgs {
-          inherit system;
-        };
+        pkgs = nixpkgs.legacyPackages.${system};
 
         # To override do: lib.overrideScope' (self: super: { ... });
         lib = mkLib pkgs;


### PR DESCRIPTION
## Motivation
* i.e. if we neither set localSystem/crossSystem, nor add overlays, we can directly utilize `nixpkgs.legacyPackages.${system}` directly and avoid re-evaluating nixpkgs an additional time

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [ ] updated `docs/API.md` (or general documentation) with changes
- [ ] updated `CHANGELOG.md`
