### PR TITLE
buildDepsOnly: pass --no-run to cargo test by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Changed
+* `buildDepsOnly` will now assume `cargoTestExtraArgs = "--no-run";` if not
+  specified (since there is no point to trying to run tests with the stripped
+  sources). To get the old behavior back, set `cargoTestExtraArgs = "";`
+
 ### Fixed
 * `buildTrunkPackage`'s `preConfigure` script to fail quicker with a more
   obvious error message if dependencies at not appropriately met

--- a/docs/API.md
+++ b/docs/API.md
@@ -122,7 +122,7 @@ to influence its behavior.
       altogether.
 * `cargoTestExtraArgs`: additional flags to be passed in the `cargoTestCommand`
   invocation (e.g. enabling specific tests)
-  - Default value: `""`
+  - Default value: `"--no-run"`
 * `cargoVendorDir`: A path (or derivation) of vendored cargo sources which can
   be consumed without network access. Directory structure should basically
   follow the output of `cargo vendor`.

--- a/lib/buildDepsOnly.nix
+++ b/lib/buildDepsOnly.nix
@@ -9,7 +9,7 @@
 , cargoCheckCommand ? "cargoWithProfile check"
 , cargoExtraArgs ? "--locked"
 , cargoTestCommand ? "cargoWithProfile test"
-, cargoTestExtraArgs ? ""
+, cargoTestExtraArgs ? "--no-run"
 , ...
 }@args:
 let


### PR DESCRIPTION
## Motivation

Fixes https://github.com/ipetkov/crane/issues/468

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [x] updated `docs/API.md` (or general documentation) with changes
- [x] updated `CHANGELOG.md`
