### PR TITLE
feat: support workspace `lints`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Added
+* Projects using `lints` `Cargo.toml` attribute with workspace inheritance are now supported
+
 ### Changed
 * **Breaking**: dropped compatibility for Nix versions below 2.18.1
 * **Breaking**: dropped compatibility for nixpkgs-23.05.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
-### Added
-* Projects using `lints` `Cargo.toml` attribute with workspace inheritance are now supported
-
 ### Changed
 * **Breaking**: dropped compatibility for Nix versions below 2.18.1
 * **Breaking**: dropped compatibility for nixpkgs-23.05.
+
+### Fixed
+* Workspace inheritance of `lints` in git dependencies is now correctly handled
 
 ## [0.15.1] - 2023-11-30
 


### PR DESCRIPTION
## Motivation
<!--
Thank you for your contribution! Please add a brief description below about the change and what is the motivation
behind it.
-->

Closes https://github.com/ipetkov/crane/issues/480 - there could probably be a nicer way to handle this, but I went with the simplest approach I could come up with - note that it appears that `lints.workspace = true` does not support per-crate overrides of the workspace setting at this time, so we don't actually need to merge anything within the crates themselves.

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [x] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [ ] updated `docs/API.md` (or general documentation) with changes
- [x] updated `CHANGELOG.md`
