### PR TITLE
vendorCargoDeps: manually splice packages to avoid cross build issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * `buildDepsOnly` now ignores any outputs (besides the default `out`)
 
 ### Fixed
-* `buildDepsOnly` no longer fails when workspace is configured with `#[deny(unused-extern-crates)]`
+* `buildDepsOnly` no longer fails when workspace is configured with
+  `#[deny(unused-extern-crates)]`
+* `vendorCargoDeps` (and friends) are now much more friendly to
+  cross-compilation definitions. Specifically, source vendoring will always
+  build dependencies to run on the build machine (and not for the host we're
+  cross compiling to).
 
 ## [0.16.0] - 2024-01-18
 

--- a/checks/default.nix
+++ b/checks/default.nix
@@ -614,9 +614,11 @@ in
 
   vendorIsCrossAgnostic =
     let
-      mkVendor = whichLib: builtins.unsafeDiscardStringContext ((whichLib.vendorCargoDeps {
-        src = ./simple-git;
-      }).drvPath);
+      mkVendor = whichLib: builtins.unsafeDiscardStringContext (
+        (whichLib.vendorCargoDeps {
+          src = ./simple-git;
+        }).drvPath
+      );
       expected = mkVendor myLib;
       actual = mkVendor myLibCross;
     in

--- a/checks/default.nix
+++ b/checks/default.nix
@@ -1,4 +1,4 @@
-{ pkgs, myLib, myPkgs }:
+{ pkgs, myLib, myLibCross }:
 
 let
   inherit (pkgs) lib;
@@ -210,6 +210,24 @@ in
       src = ./with-build-script-custom;
     };
 
+  craneUtilsChecks =
+    let
+      src = myLib.cleanCargoSource ../pkgs/crane-utils;
+      cargoArtifacts = myLib.buildDepsOnly {
+        inherit src;
+      };
+    in
+    pkgs.linkFarmFromDrvs "craneUtilsTests" [
+      (myLib.cargoClippy {
+        inherit cargoArtifacts src;
+        cargoClippyExtraArgs = "--all-targets -- --deny warnings";
+      })
+
+      (myLib.cargoFmt {
+        inherit src;
+      })
+    ];
+
   customCargoTargetDirectory =
     let
       simple = self.simple.overrideAttrs (_old: {
@@ -303,15 +321,6 @@ in
   };
 
   features = callPackage ./features { };
-
-  flakePackages =
-    let
-      pkgDrvs = builtins.attrValues myPkgs;
-      extraChecks = lib.flatten (map builtins.attrValues
-        (map (p: onlyDrvs (p.passthru.checks or { })) pkgDrvs)
-      );
-    in
-    pkgs.linkFarmFromDrvs "flake-packages" (pkgDrvs ++ extraChecks);
 
   gitOverlappingRepo = myLib.buildPackage {
     src = ./git-overlapping;
@@ -602,6 +611,24 @@ in
     );
 
   vendorGitSubset = callPackage ./vendorGitSubset.nix { };
+
+  vendorIsCrossAgnostic =
+    let
+      mkVendor = whichLib: builtins.unsafeDiscardStringContext ((whichLib.vendorCargoDeps {
+        src = ./simple-git;
+      }).drvPath);
+      expected = mkVendor myLib;
+      actual = mkVendor myLibCross;
+    in
+    pkgs.runCommand "vendorIsCrossAgnostic" { } ''
+      if [[ "${expected}" == "${actual}" ]]; then
+        touch $out
+      else
+        echo derivations differ. to debug run:
+        echo 'nix run nixpkgs#nix-diff -- "${expected}" "${actual}"'
+        exit 1
+      fi
+    '';
 
   vendorMultipleCargoDeps =
     let

--- a/flake.nix
+++ b/flake.nix
@@ -117,11 +117,6 @@
         # To override do: lib.overrideScope' (self: super: { ... });
         lib = mkLib pkgs;
 
-        packages = import ./pkgs {
-          inherit pkgs;
-          myLib = lib;
-        };
-
         checks =
           let
             pkgsChecks = import nixpkgs {
@@ -134,11 +129,19 @@
           pkgsChecks.callPackages ./checks {
             pkgs = pkgsChecks;
             myLib = mkLib pkgsChecks;
-            myPkgs = packages;
+            myLibCross = mkLib (import nixpkgs {
+              localSystem = system;
+              crossSystem = "wasm32-wasi";
+            });
           };
       in
       {
-        inherit checks lib packages;
+        inherit checks lib;
+
+        packages = import ./pkgs {
+          inherit pkgs;
+          myLib = lib;
+        };
 
         formatter = pkgs.nixpkgs-fmt;
 

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -31,7 +31,6 @@ in
   cleanCargoToml = callPackage ./cleanCargoToml.nix { };
   configureCargoCommonVarsHook = callPackage ./setupHooks/configureCargoCommonVars.nix { };
   configureCargoVendoredDepsHook = callPackage ./setupHooks/configureCargoVendoredDeps.nix { };
-  craneUtils = callPackage ../pkgs/crane-utils { };
   devShell = callPackage ./devShell.nix { };
 
   crateNameFromCargoToml = callPackage ./crateNameFromCargoToml.nix {

--- a/lib/downloadCargoPackage.nix
+++ b/lib/downloadCargoPackage.nix
@@ -1,8 +1,12 @@
-{ fetchurl
+{ pkgsBuildBuild
 , urlForCargoPackage
-, runCommand
 }:
 
+let
+  inherit (pkgsBuildBuild)
+    fetchurl
+    runCommand;
+in
 { name
 , version
 , checksum

--- a/lib/downloadCargoPackageFromGit.nix
+++ b/lib/downloadCargoPackageFromGit.nix
@@ -1,11 +1,16 @@
-{ cargo
-, craneUtils
-, jq
-, lib
-, fetchgit
-, runCommand
+{ lib
+, pkgsBuildBuild
 }:
 
+let
+  inherit (pkgsBuildBuild)
+    cargo
+    fetchgit
+    jq
+    runCommand;
+
+  craneUtils = pkgsBuildBuild.callPackage ../pkgs/crane-utils { };
+in
 { git
 , rev
 , ref ? null

--- a/lib/mkDummySrc.nix
+++ b/lib/mkDummySrc.nix
@@ -1,11 +1,15 @@
 { cleanCargoToml
 , findCargoFiles
 , lib
-, runCommand
-, writeText
+, pkgsBuildBuild
 , writeTOML
 }:
 
+let
+  inherit (pkgsBuildBuild)
+    runCommand
+    writeText;
+in
 { src
 , cargoLock ? null
 , extraDummyScript ? ""

--- a/lib/vendorCargoRegistries.nix
+++ b/lib/vendorCargoRegistries.nix
@@ -1,13 +1,12 @@
 { downloadCargoPackage
 , lib
-, runCommandLocal
+, pkgsBuildBuild
 }:
 
-{ cargoConfigs ? [ ]
-, lockPackages
-, ...
-}@args:
 let
+  inherit (pkgsBuildBuild)
+    runCommandLocal;
+
   inherit (builtins)
     attrNames
     concatStringsSep
@@ -36,7 +35,12 @@ let
   hash = hashString "sha256";
 
   hasRegistryProtocolPrefix = s: hasPrefix "registry+" s || hasPrefix "sparse+" s;
-
+in
+{ cargoConfigs ? [ ]
+, lockPackages
+, ...
+}@args:
+let
   # Local crates will show up in the lock file with no checksum/source,
   # so should filter them out without trying to download them
   lockedPackagesFromRegistry = filter

--- a/lib/vendorGitDeps.nix
+++ b/lib/vendorGitDeps.nix
@@ -1,12 +1,12 @@
 { downloadCargoPackageFromGit
 , lib
-, runCommandLocal
+, pkgsBuildBuild
 }:
 
-{ lockPackages
-, outputHashes ? { }
-}:
 let
+  inherit (pkgsBuildBuild)
+    runCommandLocal;
+
   inherit (builtins)
     any
     attrNames
@@ -33,6 +33,12 @@ let
     removePrefix;
 
   knownGitParams = [ "branch" "rev" "tag" ];
+  hash = hashString "sha256";
+in
+{ lockPackages
+, outputHashes ? { }
+}:
+let
   parseGitUrl = p:
     let
       lockUrl = removePrefix "git+" p.source;
@@ -67,8 +73,6 @@ let
     extractedParams // {
       inherit git id lockedRev;
     };
-
-  hash = hashString "sha256";
 
   # Local crates will show up in the lock file with no checksum/source
   lockedPackagesFromGit = filter

--- a/lib/vendorMultipleCargoDeps.nix
+++ b/lib/vendorMultipleCargoDeps.nix
@@ -1,16 +1,13 @@
 { lib
-, runCommandLocal
+, pkgsBuildBuild
 , vendorCargoRegistries
 , vendorGitDeps
 }:
 
-{ cargoConfigs ? [ ]
-, cargoLockContentsList ? [ ]
-, cargoLockList ? [ ]
-, cargoLockParsedList ? [ ]
-, outputHashes ? { }
-}@args:
 let
+  inherit (pkgsBuildBuild)
+    runCommandLocal;
+
   inherit (builtins)
     attrNames
     attrValues
@@ -29,7 +26,14 @@ let
   inherit (lib.lists)
     flatten
     unique;
-
+in
+{ cargoConfigs ? [ ]
+, cargoLockContentsList ? [ ]
+, cargoLockList ? [ ]
+, cargoLockParsedList ? [ ]
+, outputHashes ? { }
+}@args:
+let
   cargoLocksParsed = (map fromTOML ((map readFile cargoLockList) ++ cargoLockContentsList))
     ++ cargoLockParsedList;
 

--- a/lib/writeTOML.nix
+++ b/lib/writeTOML.nix
@@ -1,14 +1,16 @@
-# NB: ideally this should just be `remarshal` but it appears to cause an infinite loop when building
-# against the release-22.05 branch, so using this as a workaround for now
 { pkgsBuildBuild
-, runCommand
 }:
 
+let
+  inherit (pkgsBuildBuild)
+    remarshal
+    runCommand;
+in
 name: contents: runCommand name
 {
   contents = builtins.toJSON contents;
   passAsFile = [ "contents" ];
-  nativeBuildInputs = [ pkgsBuildBuild.remarshal ];
+  nativeBuildInputs = [ remarshal ];
 } ''
   remarshal -i $contentsPath -if json -of toml -o $out
 ''

--- a/pkgs/crane-utils/default.nix
+++ b/pkgs/crane-utils/default.nix
@@ -6,7 +6,7 @@ rustPlatform.buildRustPackage {
   pname = "crane-utils";
   version = "0.0.1";
 
-  src = lib.sourceFilesBySuffices ./. [".rs" ".toml" ".lock"];
+  src = lib.sourceFilesBySuffices ./. [ ".rs" ".toml" ".lock" ];
 
   cargoSha256 = "sha256-joZrcKKByaGopWzPhaytCSU+LnlhQaNIXZoh40UCSrM=";
 }

--- a/pkgs/crane-utils/default.nix
+++ b/pkgs/crane-utils/default.nix
@@ -1,35 +1,12 @@
-{ buildDepsOnly
-, cargoClippy
-, cargoFmt
-, cleanCargoSource
-, crateNameFromCargoToml
-, path
+{ lib
 , rustPlatform
 }:
 
-let
-  src = cleanCargoSource (path ./.);
-
-  cargoArtifacts = buildDepsOnly {
-    inherit src;
-  };
-in
 rustPlatform.buildRustPackage {
-  inherit src;
-  inherit (crateNameFromCargoToml { inherit src; }) pname version;
+  pname = "crane-utils";
+  version = "0.0.1";
 
-  cargoSha256 = "sha256-oE67gg4+csvsGvMn2YyRnmZCqSodbFCLvzQi7kgsnfs=";
+  src = lib.sourceFilesBySuffices ./. [".rs" ".toml" ".lock"];
 
-  passthru = {
-    checks = {
-      clippy = cargoClippy {
-        inherit cargoArtifacts src;
-        cargoClippyExtraArgs = "--all-targets -- --deny warnings";
-      };
-
-      fmt = cargoFmt {
-        inherit src;
-      };
-    };
-  };
+  cargoSha256 = "sha256-joZrcKKByaGopWzPhaytCSU+LnlhQaNIXZoh40UCSrM=";
 }


### PR DESCRIPTION
## Motivation
* Source vendoring is passed as a standalone attribute to `mkCargoDerivation`, meaning it does not automagically get spliced with the correct local/cross system inputs (i.e. what would happen if it was a `depsBuildBuild` entry)
* To fix this we need to make sure that `vendorCargoDeps` and all of its transitive dependencies always use `runCommand` (and friends) from their `pkgsBuildBuild` equivalent. This should always be safe to do (even for cross-builds) since this amounts to building up a bunch of sources which will be read by the build system
* Unfortunately I had to manually specify `pkgsBuildBuild.whatever` in multiple places as I could not get things to work by messing with the `callPackage` definition. Perhaps we should be using `makeScopeWithSplicing'` instead of `makeScope` when constructing the library, but I couldn't get it working (and I couldn't find any decent docs on how to use it online) so this will make do for the time being.

Fixes #497

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [x] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [ ] updated `docs/API.md` (or general documentation) with changes
- [x] updated `CHANGELOG.md`
