### PR TITLE
cleanCargoToml: strip out `[lints]` definitions when cleaning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Changed
+* `cleanCargoToml` now also strips out `[lints]` and `[workspace.lints]`
+  definitions. This means avoiding unnecessarily rebuilding dependencies when
+  the lint definitions change, and it avoids issues with failing to build
+  dummified sources which might have violated a lint marked as `deny` or
+  `forbid`
+
 ## [0.16.1] - 2024-01-28
 
 ### Changed

--- a/checks/cleanCargoTomlTests/complex/Cargo.toml
+++ b/checks/cleanCargoTomlTests/complex/Cargo.toml
@@ -209,5 +209,17 @@ exclude = ["crates/foo", "path/to/other"]
 root = "path/to/webproject"
 tool = ["npm", "run", "build"]
 
+[workspace.lints.clippy]
+todo = "forbid"
+
+[workspace.lints.rust]
+rust_2018_idioms = "deny"
+
 [some-unrecognized-object]
 some-unrecognized-field = "some value"
+
+[lints.clippy]
+workspace = true
+
+[lints.rust]
+missing_docs = "deny"

--- a/checks/default.nix
+++ b/checks/default.nix
@@ -209,6 +209,23 @@ in
     {
       src = ./with-build-script-custom;
     };
+  compilesFreshWorkspace = self.compilesFresh
+    {
+      check = (builtins.concatStringsSep "\n" [
+        "hello"
+        "print"
+        "world"
+      ]);
+      build = (builtins.concatStringsSep "\n" [
+        "hello"
+        "print"
+        "world"
+      ]);
+    }
+    myLib.cargoBuild
+    {
+      src = ./workspace;
+    };
 
   craneUtilsChecks =
     let

--- a/checks/workspace/Cargo.lock
+++ b/checks/workspace/Cargo.lock
@@ -3,8 +3,17 @@
 version = 3
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "hello"
 version = "0.1.0"
+dependencies = [
+ "byteorder",
+]
 
 [[package]]
 name = "print"

--- a/checks/workspace/Cargo.toml
+++ b/checks/workspace/Cargo.toml
@@ -2,3 +2,6 @@
 # NB: hello and world are intentionally left out cargo will
 # promote them to members since they are listed as path deps
 members = ["print"]
+
+[workspace.lints.rust]
+rust_2018_idioms = "deny"

--- a/checks/workspace/hello/Cargo.toml
+++ b/checks/workspace/hello/Cargo.toml
@@ -2,3 +2,9 @@
 name = "hello"
 version = "0.1.0"
 edition = "2021"
+
+[lints]
+workspace = true
+
+[dependencies]
+byteorder = "*"

--- a/lib/cleanCargoToml.nix
+++ b/lib/cleanCargoToml.nix
@@ -56,14 +56,17 @@ let
   ];
 
   cleanWorkspace = workspace: removeAttrs workspace [
+    "lints"
     "metadata"
 
     # Additional package attributes which are expressly kept in
     # (but listed here for audit purposes)
     # "default-members"
     # "exclude"
+    # "dependencies"
     # "members"
     # "package"
+    # "resolver"
   ];
 
   # https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -78,6 +81,7 @@ let
 
       topLevelCleaned = removeAttrs parsed [
         "badges" # Badges to display on a registry.
+        "lints" # Only applied to local sources, which we need to rebuild anyway
 
         # Top level attributes intentionally left in place:
         # "build-dependencies" # we want to build and cache these


### PR DESCRIPTION
## Motivation

The `[lints]` and `[workspace.lints]` tables only affect compiling crates in the current workspace, but don't affect any dependency crates (since cargo will pass in `--cap-lints allow` when building those). Thus, when we're dummifying sources, stripping these out gives us two main benefits:

* Changing (only) the lints table will now avoid rebuilding dependencies since stripping the values means we don't invalidate build caches
* Avoids build errors if the dummified sources happen to emit or allow a lint which was marked as `deny` or `forbid` by the project itself

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [x] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [ ] updated `docs/API.md` (or general documentation) with changes
- [x] updated `CHANGELOG.md`
