### PR TITLE
chore: replace overrideScope' with overrideScope

### DIFF
--- a/checks/trunk.nix
+++ b/checks/trunk.nix
@@ -14,7 +14,7 @@ let
     url = "https://github.com/NixOS/nixpkgs/archive/4e6868b1aa3766ab1de169922bb3826143941973.tar.gz";
     sha256 = "sha256:1q6bj2jjlwb10sfrhqmjpzsc3yc4x76cvky16wh0z52p7d2lhdpv";
   };
-  myLibWasm = (myLib.overrideToolchain wasmToolchain).overrideScope' (_final: _prev: {
+  myLibWasm = (myLib.overrideToolchain wasmToolchain).overrideScope (_final: _prev: {
     inherit (import tarball { inherit (stdenv) system; }) wasm-bindgen-cli;
   });
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -13,10 +13,10 @@ mkLib (import inputs.nixpkgs { system = "armv7l-linux"; })
 ```
 
 Note that if you wish to override a particular package without having to overlay
-it across all of nixpkgs, consider using `overrideScope'`:
+it across all of nixpkgs, consider using `overrideScope`:
 
 ```nix
-(mkLib pkgs).overrideScope' (final: prev: {
+(mkLib pkgs).overrideScope (final: prev: {
   cargo-tarpaulin = myCustomCargoTarpaulinVersion;
 })
 ```

--- a/docs/advanced/overriding-function-behavior.md
+++ b/docs/advanced/overriding-function-behavior.md
@@ -1,7 +1,7 @@
 ## Overriding function behavior
 
 At it's core, `crane` is instantiated via `pkgs.lib.newScope` which allows any
-internal definition to be changed or replaced via `.overrideScope'` (which
+internal definition to be changed or replaced via `.overrideScope` (which
 behaves very much like applying overlays to nixpkgs). Although this mechanism is
 incredibly powerful, care should be taken to avoid creating confusing or brittle
 integrations built on undocumented details.
@@ -17,7 +17,7 @@ Here is an example:
 
 ```nix
 let
-  craneLib = (inputs.crane.mkLib pkgs).overrideScope' (final: prev: {
+  craneLib = (inputs.crane.mkLib pkgs).overrideScope (final: prev: {
     # We override the behavior of `mkCargoDerivation` by adding a wrapper which
     # will set a default value of `CARGO_PROFILE` when not set by the caller.
     # This change will automatically be propagated to any other functions built

--- a/docs/faq/custom-nixpkgs.md
+++ b/docs/faq/custom-nixpkgs.md
@@ -35,12 +35,12 @@ in
 ```
 
 Finally, specific inputs can be overridden for the entire library via the
-`overrideScope'` API as follows. For more information, see the [API
+`overrideScope` API as follows. For more information, see the [API
 docs](../API.md) for `mkLib`/`overrideToolchain`, or checkout the
 [custom-toolchain](../../examples/custom-toolchain) example.
 
 ```nix
-crane.lib.${system}.overrideScope' (final: prev: {
+crane.lib.${system}.overrideScope (final: prev: {
   cargo-tarpaulin = myCustomCargoTarpaulinVersion;
 })
 ```

--- a/docs/faq/invalid-metadata-files-for-crate.md
+++ b/docs/faq/invalid-metadata-files-for-crate.md
@@ -10,7 +10,7 @@ let
   rustToolchain = ...;
 in
 # Incorrect usage, missing `clippy` override!
-#(crane.mkLib pkgs).overrideScope' (final: prev: {
+#(crane.mkLib pkgs).overrideScope (final: prev: {
 #  rustc = rustToolchain;
 #  cargo = rustToolchain;
 #  rustfmt = rustToolchain;

--- a/examples/trunk-workspace/flake.nix
+++ b/examples/trunk-workspace/flake.nix
@@ -39,7 +39,7 @@
           # wasm32-unknown-unknown is required for trunk.
           targets = [ "wasm32-unknown-unknown" ];
         };
-        craneLib = ((crane.mkLib pkgs).overrideToolchain rustToolchain).overrideScope' (_final: _prev: {
+        craneLib = ((crane.mkLib pkgs).overrideToolchain rustToolchain).overrideScope (_final: _prev: {
           # The version of wasm-bindgen-cli needs to match the version in Cargo.lock. You
           # can unpin this if your nixpkgs commit contains the appropriate wasm-bindgen-cli version
           inherit (import nixpkgs-for-wasm-bindgen { inherit system; }) wasm-bindgen-cli;

--- a/examples/trunk/flake.nix
+++ b/examples/trunk/flake.nix
@@ -39,7 +39,7 @@
           # wasm32-unknown-unknown is required for trunk
           targets = [ "wasm32-unknown-unknown" ];
         };
-        craneLib = ((crane.mkLib pkgs).overrideToolchain rustToolchain).overrideScope' (_final: _prev: {
+        craneLib = ((crane.mkLib pkgs).overrideToolchain rustToolchain).overrideScope (_final: _prev: {
           # The version of wasm-bindgen-cli needs to match the version in Cargo.lock. You
           # can unpin this if your nixpkgs commit contains the appropriate wasm-bindgen-cli version
           inherit (import nixpkgs-for-wasm-bindgen { inherit system; }) wasm-bindgen-cli;

--- a/flake.nix
+++ b/flake.nix
@@ -114,7 +114,7 @@
       let
         pkgs = nixpkgs.legacyPackages.${system};
 
-        # To override do: lib.overrideScope' (self: super: { ... });
+        # To override do: lib.overrideScope (self: super: { ... });
         lib = mkLib pkgs;
 
         checks =

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -9,7 +9,7 @@ let
   internalCrateNameFromCargoToml = callPackage ./internalCrateNameFromCargoToml.nix { };
 in
 {
-  appendCrateRegistries = input: self.overrideScope' (_final: prev: {
+  appendCrateRegistries = input: self.overrideScope (_final: prev: {
     crateRegistries = prev.crateRegistries // (lib.foldl (a: b: a // b) { } input);
   });
 
@@ -52,7 +52,7 @@ in
   mkCargoDerivation = callPackage ./mkCargoDerivation.nix { };
   mkDummySrc = callPackage ./mkDummySrc.nix { };
 
-  overrideToolchain = toolchain: self.overrideScope' (_final: _prev: {
+  overrideToolchain = toolchain: self.overrideScope (_final: _prev: {
     cargo = toolchain;
     clippy = toolchain;
     rustc = toolchain;


### PR DESCRIPTION
## Motivation
It used to be that `makeScope`'s `overrideScope` was deprecated in favor of `overrideScope'`. With nixpkgs-23.11 `overrideScope`'s signature was changed to that of `overrideScope'` and so the latter is now deprecated (and going away in the next stable release).

This changes all internal usage and docs to use `overrideScope` ahead of the deprecation

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [ ] updated `docs/API.md` (or general documentation) with changes
- [ ] updated `CHANGELOG.md`
