### PR TITLE
docs: document workaround for the `bindgen` crate being rebuilt

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -34,6 +34,7 @@
   * [Crates being rebuilt when using different toolchains](./faq/rebuilds-with-different-toolchains.md)
   * [Constantly rebuilding proc-macro dependencies `dev` mode](./faq/rebuilds-with-proc-macros.md)
   * [Constantly rebuilding pyo3](./faq/rebuilds-pyo3.md)
+  * [Constantly rebuilding bindgen](./faq/rebuilds-bindgen.md)
   * [Building upstream cargo crate with no `Cargo.lock`](./faq/no-cargo-lock.md)
   * [Patching `Cargo.lock` during build](./faq/patching-cargo-lock.md)
   * [Building a subset of a workspace](./faq/build-workspace-subset.md)

--- a/docs/faq/rebuilds-bindgen.md
+++ b/docs/faq/rebuilds-bindgen.md
@@ -1,0 +1,26 @@
+## I see the `bindgen` crate constantly rebuilding
+
+If you are using `rustPlatform.bindgenHook` it is worth noting that it will
+[propagate `NIX_CFLAGS_COMPILE` via
+`BINDGEN_EXTRA_CLANG_ARGS`](https://github.com/NixOS/nixpkgs/blob/3a73796bf2edb1dc026257da827678117ee7af57/pkgs/build-support/rust/hooks/rust-bindgen-hook.sh#L9).
+
+In order to support reproducible builds, [this build hook will add
+`-frandom-seed=...` to
+`NIX_CFLAGS_COMPILE`](https://github.com/NixOS/nixpkgs/blob/c0b7a892fb042ede583bdaecbbdc804acb85eabe/pkgs/build-support/setup-hooks/reproducible-builds.sh#L6)
+based on the current derivation's hash.
+
+Since dependencies are built in a separate derivation as the main package, each
+derivation essentially gets a different value for `-frandom-seed`. The `bindgen`
+crate will [observe this change and rebuild
+itself](https://github.com/rust-lang/rust-bindgen/blob/62859b2c6108c1c0f60d16b9ffe7544a4fbce48b/bindgen/build.rs#L20).
+
+A workaround for this is to set `NIX_OUTPATH_USED_AS_RANDOM_SEED` to any
+arbitrary 10 character string for _all derivations_ which share artifacts
+together.
+
+```nix
+buildPackage {
+  NIX_OUTPUT_USED_AS_RANDOM_SEED = "aaaaaaaaaa";
+  # other attributes omitted
+}
+```

--- a/docs/faq/sandbox-unfriendly-build-scripts.md
+++ b/docs/faq/sandbox-unfriendly-build-scripts.md
@@ -24,7 +24,7 @@ as such **it is not recommended**.
 ```nix
 # You have been warned
 buildPackage {
-  # other attributes omtited
+  # other attributes omitted
   postPatch = ''
     mkdir -p "$TMPDIR/nix-vendor"
     cp -r "$cargoVendorDir" -T "$TMPDIR/nix-vendor"


### PR DESCRIPTION
## Motivation

Document workaround for the `bindgen` crate being rebuilt.

Originally reported in https://github.com/ipetkov/crane/discussions/518#discussion-6194531

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [ ] updated `docs/API.md` (or general documentation) with changes
- [ ] updated `CHANGELOG.md`
