### PR TITLE
crane-utils: migrate from toml_edit to toml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   the lint definitions change, and it avoids issues with failing to build
   dummified sources which might have violated a lint marked as `deny` or
   `forbid`
+* `crane-resolve-workspace-inheritance` no longer preserves comments or ordering
 
 ### Fixed
 * Fixed an edge case with inheriting workspace dependencies where the workspace

--- a/pkgs/crane-utils/Cargo.lock
+++ b/pkgs/crane-utils/Cargo.lock
@@ -16,7 +16,7 @@ dependencies = [
  "pretty_assertions",
  "serde",
  "serde_json",
- "toml_edit",
+ "toml",
 ]
 
 [[package]]
@@ -125,6 +125,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "syn"
 version = "2.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -136,10 +145,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a9aad4a3066010876e8dcf5a8a06e70a558751117a145c6ce2b82c2e2054290"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "toml_edit"
@@ -148,6 +172,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c1b5fd4128cc8d3e0cb74d4ed9a9cc7c7284becd4df68f5f940e1ad123606f6"
 dependencies = [
  "indexmap",
+ "serde",
+ "serde_spanned",
  "toml_datetime",
  "winnow",
 ]

--- a/pkgs/crane-utils/Cargo.toml
+++ b/pkgs/crane-utils/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 anyhow = "1"
 serde_json = "1"
 serde = { version = "1", features = ["derive"] }
-toml_edit = "0.22.6"
+toml = "0.8.10"
 
 [dev-dependencies]
 pretty_assertions = "1.3.0"

--- a/pkgs/crane-utils/default.nix
+++ b/pkgs/crane-utils/default.nix
@@ -8,5 +8,5 @@ rustPlatform.buildRustPackage {
 
   src = lib.sourceFilesBySuffices ./. [ ".rs" ".toml" ".lock" ];
 
-  cargoSha256 = "sha256-sRVk7OrdIYaNBU6gA1etLTVWQvS+HW5DwJaa2xbNqiA=";
+  cargoHash = "sha256-ZP8rFMuW6W+KSdU5OZviCcaZf3uAJZ8ie7ZNOhlZf4c=";
 }


### PR DESCRIPTION
## Motivation
Currently `toml_edit` is used to resolve `Cargo.toml`s from workspace crates. This was fine but I recently ran into https://github.com/toml-rs/toml/issues/691 which made it impossible for me to compile my project. I thought of trying to fix `toml_edit`, but then I thought to myself that realistically there's very little gain in trying to preserve the comments and order in `Cargo.toml` files which the user won't even see unless, as it was in my case, there's a bug and cargo fails while reading it.

It turned out to be very easy to replace `toml_edit` with `toml`, while also making the code shorter, and (in my opinion) a bit cleaner.

## Checklist
- [x] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [ ] updated `docs/API.md` (or general documentation) with changes
- [x] updated `CHANGELOG.md`
