### PR TITLE
fix: allow registries in vendorMultipleCargoDeps as documented

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Fixed:
+* `vendorMultipleCargoDeps` correctly lists `registries` as an optional
+  parameter
+
 ## [0.16.2] - 2024-02-21
 
 ### Changed

--- a/lib/vendorMultipleCargoDeps.nix
+++ b/lib/vendorMultipleCargoDeps.nix
@@ -32,7 +32,8 @@ in
 , cargoLockList ? [ ]
 , cargoLockParsedList ? [ ]
 , outputHashes ? { }
-}@args:
+, registries ? null
+}:
 let
   cargoLocksParsed = (map fromTOML ((map readFile cargoLockList) ++ cargoLockContentsList))
     ++ cargoLockParsedList;
@@ -59,7 +60,7 @@ let
 
   vendoredRegistries = vendorCargoRegistries ({
     inherit cargoConfigs lockPackages;
-  } // optionalAttrs (args ? registries) { inherit (args) registries; });
+  } // optionalAttrs (registries != null) { inherit registries; });
 
   vendoredGit = vendorGitDeps {
     inherit lockPackages outputHashes;


### PR DESCRIPTION
## Motivation
<!--
Thank you for your contribution! Please add a brief description below about the change and what is the motivation
behind it.
-->
The docs state that you can use `registries` in `vendorMultipleCargoDeps`. The code does support that. However, it was missed that you need to either allow `registries` directly as a keyword in the function parameters or you need to add a `, ...`. I don't know which version you would prefer, so I simply went with the more strict version for now. Let me know what changes I need to include or feel free to commit to my branch.

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [ ] updated `docs/API.md` (or general documentation) with changes
- [ ] updated `CHANGELOG.md`
