### PR TITLE
vendorMultipleCargoDeps: use backwards compatible groupBy (#545)

### DIFF
--- a/lib/vendorMultipleCargoDeps.nix
+++ b/lib/vendorMultipleCargoDeps.nix
@@ -12,12 +12,12 @@ let
     attrNames
     attrValues
     fromTOML
-    groupBy
     readFile;
 
   inherit (lib)
     concatMapStrings
-    escapeShellArg;
+    escapeShellArg
+    groupBy;
 
   inherit (lib.attrsets)
     filterAttrs


### PR DESCRIPTION
Fixes #545 

## Motivation
Using crane with nix versions prior to 2.5 (2.3 specifically in our case)

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [ ] updated `docs/API.md` (or general documentation) with changes
- [ ] updated `CHANGELOG.md`
