### PR TITLE
cargoNextest: support withLlvmCov

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Changed
+* `cargoNextest` now supports setting `withLlvmCov` which will automatically run
+  `cargo llvm-cov nextest`. Note that `withLlvmCov = true;` is (currently) only
+  supported when `partitions = 1;`
+
 ## [0.16.3] - 2024-03-19
 
 ### Changed

--- a/checks/default.nix
+++ b/checks/default.nix
@@ -57,15 +57,6 @@ in
     };
   };
 
-  cargoLlvmCovNextest = myLibLlvmTools.cargoLlvmCov {
-    src = ./simple;
-    cargoLlvmCovCommand = "nextest";
-    cargoArtifacts = myLib.buildDepsOnly {
-      src = ./simple;
-    };
-    nativeBuildInputs = [ pkgs.cargo-nextest ];
-  };
-
   # NB: explicitly using a github release (not crates.io release)
   # which lacks a Cargo.lock file, so we can test adding our own
   cargoLockOverride =
@@ -444,7 +435,9 @@ in
       doCheck = false;
     });
 
-  nextest = callPackage ./nextest.nix { };
+  nextest = callPackage ./nextest.nix {
+    inherit (myLibLlvmTools) cargoNextest;
+  };
 
   procMacro = myLib.buildPackage {
     src = myLib.cleanCargoSource ./proc-macro;

--- a/checks/nextest.nix
+++ b/checks/nextest.nix
@@ -1,44 +1,48 @@
 { cargoNextest
-, runCommand
+, lib
+, linkFarmFromDrvs
 }:
 
 let
-  nextestSimple = cargoNextest {
+  nextestSimple = withLlvmCov: cargoNextest {
+    inherit withLlvmCov;
     src = ./simple;
-    pname = "nextest-simple";
+    pname = "nextest-simple${lib.optionalString withLlvmCov "-llvm-cov"}";
     cargoArtifacts = null;
   };
 
-  nextestPartitionsCount = cargoNextest {
+  nextestPartitionsCount = withLlvmCov: cargoNextest {
+    inherit withLlvmCov;
     src = ./simple;
-    pname = "nextest-partitions-count";
+    pname = "nextest-partitions-count${lib.optionalString withLlvmCov "-llvm-cov"}";
     partitions = 4;
     partitionType = "count";
     cargoArtifacts = null;
   };
 
-  nextestPartitionsHash = cargoNextest {
+  nextestPartitionsHash = withLlvmCov: cargoNextest {
+    inherit withLlvmCov;
     src = ./simple;
-    pname = "nextest-partitions-hash";
+    pname = "nextest-partitions-hash${lib.optionalString withLlvmCov "-llvm-cov"}";
     partitions = 4;
     partitionType = "hash";
     cargoArtifacts = null;
   };
 
-  nextestProcMacro = cargoNextest {
+  nextestProcMacro = withLlvmCov: cargoNextest {
+    inherit withLlvmCov;
     src = ./proc-macro;
-    pname = "nextest-proc-macro";
+    pname = "nextest-proc-macro${lib.optionalString withLlvmCov "-llvm-cov"}";
     cargoArtifacts = null;
   };
 in
-runCommand "nextestTests"
-{
-  buildInputs = [
-    nextestSimple
-    nextestPartitionsCount
-    nextestPartitionsHash
-    nextestProcMacro
-  ];
-} ''
-  mkdir -p $out
-''
+linkFarmFromDrvs "nextestTests" [
+  (nextestSimple false)
+  (nextestSimple true)
+  (nextestPartitionsCount false)
+  (nextestPartitionsCount true)
+  (nextestPartitionsHash false)
+  #(nextestPartitionsHash true) # not yet supported
+  (nextestProcMacro false)
+  (nextestProcMacro true)
+]

--- a/docs/API.md
+++ b/docs/API.md
@@ -615,6 +615,9 @@ Except where noted below, all derivation attributes are delegated to
 * `cargoExtraArgs`: additional flags to be passed in the cargo invocation (e.g.
   enabling specific features)
   - Default value: `""`
+* `cargoLlvmCovExtraArgs`: additional flags to be passed in the cargo
+  llvm-cov invocation
+  - Default value: `"--lcov --output-path $out/coverage"`
 * `cargoNextestExtraArgs`: additional flags to be passed in the clippy invocation (e.g.
   deny specific lints)
   - Default value: `""`
@@ -625,6 +628,10 @@ Except where noted below, all derivation attributes are delegated to
 * `partitionType`: The kind of nextest partition to run (e.g. `"count"` or
   `"hash"` based).
   - Default value: `"count"`
+* `withLlvmCov`: Whether or not to run nextest through `cargo llvm-cov`
+  - Default value: `false`
+  - Note that setting `withLlvmCov = true;` is not currently supported if
+    `partitions > 1`.
 
 #### Native build dependencies
 The `cargo-nextest` package is automatically appended as a native build input to any
@@ -636,9 +643,11 @@ The following attributes will be removed before being lowered to
 environment variables during the build, you can bring them back via
 `.overrideAttrs`.
 * `cargoExtraArgs`
+* `cargoLlvmCovExtraArgs`
 * `cargoNextestExtraArgs`
 * `partitions`
 * `partitionType`
+* `withLlvmCov`
 
 ### `craneLib.cargoTarpaulin`
 


### PR DESCRIPTION


## Motivation
* This adds a convenience method of running `nextest` within `cargo llvm-cov` without having to wire up the internal details manually

Fixes #559 

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [x] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [x] updated `docs/API.md` (or general documentation) with changes
- [x] updated `CHANGELOG.md`
