### PR TITLE
Update doc for unfriendly build scripts

### DIFF
--- a/docs/faq/sandbox-unfriendly-build-scripts.md
+++ b/docs/faq/sandbox-unfriendly-build-scripts.md
@@ -27,7 +27,8 @@ buildPackage {
   # other attributes omitted
   postPatch = ''
     mkdir -p "$TMPDIR/nix-vendor"
-    cp -r "$cargoVendorDir" -T "$TMPDIR/nix-vendor"
+    cp -Lr "$cargoVendorDir" -T "$TMPDIR/nix-vendor"
+    sed -i "s|$cargoVendorDir|$TMPDIR/nix-vendor/|g" "$TMPDIR/nix-vendor/config.toml"
     chmod -R +w "$TMPDIR/nix-vendor"
     cargoVendorDir="$TMPDIR/nix-vendor"
   '';


### PR DESCRIPTION
## Motivation
I've updated postPatch script, so that it follows symlinks to nix store and does deep copy of all dependencies.

Also we need to completely remove references to nix store from our config.toml in case we use patches or git repositories

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [x] added tests to verify new behavior
- [x] added an example template or updated an existing one
- [x] updated `docs/API.md` (or general documentation) with changes
- [x] updated `CHANGELOG.md`
