### PR TITLE
Fix bug with comment for inline table key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   handle the case when `CARGO_TARGET_DIR` is set to a nested directory
 * Dependency vendoring now correctly takes unused patch dependencies into
   account
+* Workspace inheritance for git dependencies now ignores (removes) all comments
+  around dependency declarations to work around a mangling bug in `toml_edit`
+  (see https://github.com/ipetkov/crane/issues/527 and
+  https://github.com/toml-rs/toml/issues/691)
 
 ## [0.16.3] - 2024-03-19
 

--- a/pkgs/crane-utils/src/bin/crane-resolve-workspace-inheritance.rs
+++ b/pkgs/crane-utils/src/bin/crane-resolve-workspace-inheritance.rs
@@ -200,10 +200,11 @@ where
 {
     use toml_edit::Value;
 
-    cargo_toml.iter_mut().for_each(|(k, v)| {
+    cargo_toml.iter_mut().for_each(|(mut k, v)| {
         // Bail if:
         // - cargo_toml isn't a table (otherwise `workspace = true` can't show up
         // - the workspace root doesn't have this key
+        k.leaf_decor_mut().clear();
         let (t, root_val) = match try_as_table_like_mut(&mut *v).zip(root.get(&k)) {
             Some((t, root_val)) => (t, root_val),
             _ => return,
@@ -490,21 +491,21 @@ version = "some version"
 foo = { version = "foo-vers" }
 bar = { version = "bar-vers", default-features = false }
 baz = { version = "baz-vers", features = ["baz-feat", "baz-feat2"] }
-            qux = { version = "qux-vers", features = ["qux-feat","qux-additional"] }
-            corge = { version = "corge-vers-override" , features = ["qux-feat"] }
-            grault = { version = "grault-vers" }
-            garply = "garply-vers"
-            waldo = "waldo-vers"
+qux = { version = "qux-vers", features = ["qux-feat","qux-additional"] }
+corge = { version = "corge-vers-override" , features = ["qux-feat"] }
+grault = { version = "grault-vers" }
+garply = "garply-vers"
+waldo = "waldo-vers"
 
 [dependencies.fred]
 version = "0.1.3"
 
-[            dependencies.plugh ]
+[dependencies.plugh]
 version = "0.2.4"
 optional = true 
 
             [target.'cfg(unix)'.dependencies]
-            unix = { version = "unix-vers" , features = ["some"] }
+unix = { version = "unix-vers" , features = ["some"] }
 
             [lints.rust]
             unused_extern_crates = 'warn'
@@ -513,11 +514,11 @@ optional = true
 foo = { version = "foo-vers" }
 bar = { version = "bar-vers", default-features = false }
 baz = { version = "baz-vers", features = ["baz-feat", "baz-feat2"] }
-            qux = { version = "qux-vers", features = ["qux-feat","qux-additional"] }
-            corge = { version = "corge-vers-override" , features = ["qux-feat"] }
-            grault = { version = "grault-vers" }
-            garply = "garply-vers"
-            waldo = "waldo-vers"
+qux = { version = "qux-vers", features = ["qux-feat","qux-additional"] }
+corge = { version = "corge-vers-override" , features = ["qux-feat"] }
+grault = { version = "grault-vers" }
+garply = "garply-vers"
+waldo = "waldo-vers"
 
             [lints.clippy]
             all = 'allow'
@@ -526,11 +527,11 @@ baz = { version = "baz-vers", features = ["baz-feat", "baz-feat2"] }
 foo = { version = "foo-vers" }
 bar = { version = "bar-vers", default-features = false }
 baz = { version = "baz-vers", features = ["baz-feat", "baz-feat2"] }
-            qux = { version = "qux-vers", features = ["qux-feat","qux-additional"] }
-            corge = { version = "corge-vers-override" , features = ["qux-feat"] }
-            grault = { version = "grault-vers" }
-            garply = "garply-vers"
-            waldo = "waldo-vers"
+qux = { version = "qux-vers", features = ["qux-feat","qux-additional"] }
+corge = { version = "corge-vers-override" , features = ["qux-feat"] }
+grault = { version = "grault-vers" }
+garply = "garply-vers"
+waldo = "waldo-vers"
 
             [features]
             # this feature is a demonstration that comments are preserved
@@ -569,7 +570,19 @@ baz = { version = "baz-vers", features = ["baz-feat", "baz-feat2"] }
         .unwrap();
 
         let expected_toml_str = r#"
-               add me later
+            [package]
+            name = "alloy-consensus"
+
+            [dependencies]
+
+[dependencies.thiserror]
+version = "1.0"
+optional = true 
+
+[dependencies.arbitrary]
+version = "1.3"
+features = ["derive"]
+optional = true 
         "#;
 
         super::merge(&mut cargo_toml, &root_toml);

--- a/pkgs/crane-utils/src/bin/crane-resolve-workspace-inheritance.rs
+++ b/pkgs/crane-utils/src/bin/crane-resolve-workspace-inheritance.rs
@@ -552,7 +552,7 @@ waldo = "waldo-vers"
     // https://github.com/ipetkov/crane/pull/583
     #[test]
     fn dependency_comments_ignored() {
-        let mut cargo_toml = toml_edit::Document::from_str(
+        let mut cargo_toml = toml_edit::DocumentMut::from_str(
             r#"
             [package]
             name = "alloy-consensus"
@@ -567,7 +567,7 @@ waldo = "waldo-vers"
         )
         .unwrap();
 
-        let root_toml = toml_edit::Document::from_str(
+        let root_toml = toml_edit::DocumentMut::from_str(
             r#"
             [workspace.dependencies]
             thiserror = "1.0"

--- a/pkgs/crane-utils/src/bin/crane-resolve-workspace-inheritance.rs
+++ b/pkgs/crane-utils/src/bin/crane-resolve-workspace-inheritance.rs
@@ -541,4 +541,39 @@ baz = { version = "baz-vers", features = ["baz-feat", "baz-feat2"] }
 
         assert_eq!(expected_toml_str, cargo_toml.to_string());
     }
+
+    #[test]
+    fn alloy_workspace_bug() {
+        let mut cargo_toml = toml_edit::Document::from_str(
+            r#"
+            [package]
+            name = "alloy-consensus"
+
+            [dependencies]
+            # kzg
+            thiserror = { workspace = true, optional = true }
+
+            # arbitrary
+            arbitrary = { workspace = true, features = ["derive"], optional = true }
+        "#,
+        )
+        .unwrap();
+
+        let root_toml = toml_edit::Document::from_str(
+            r#"
+            [workspace.dependencies]
+            thiserror = "1.0"
+            arbitrary = "1.3"
+        "#,
+        )
+        .unwrap();
+
+        let expected_toml_str = r#"
+               add me later
+        "#;
+
+        super::merge(&mut cargo_toml, &root_toml);
+
+        assert_eq!(expected_toml_str, cargo_toml.to_string());
+    }
 }


### PR DESCRIPTION
## Motivation
If workspace features dependency and workspace crate uses it, it is always gets merged as regular table (not inline one) so comments ends up in the following position:
```
[
            # arbitrary
            dependencies.arbitrary ]
```

Take a look at the test for more info.

Fixes https://github.com/ipetkov/crane/issues/527

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [x] added tests to verify new behavior
- [x] added an example template or updated an existing one
- [x] updated `docs/API.md` (or general documentation) with changes
- [x] updated `CHANGELOG.md`
