### PR TITLE
mkDummySrc: ignore clippy warnings in dummyrs

### DIFF
--- a/checks/clippy/default.nix
+++ b/checks/clippy/default.nix
@@ -1,6 +1,8 @@
 { buildDepsOnly
 , cargoClippy
+, crateNameFromCargoToml
 , linkFarmFromDrvs
+, mkDummySrc
 }:
 
 let
@@ -13,6 +15,13 @@ linkFarmFromDrvs "clippy-tests" (builtins.attrValues {
   clippytest = cargoClippy {
     inherit cargoArtifacts src;
   };
+
+  dummySrc = cargoClippy ((crateNameFromCargoToml { inherit src; }) // {
+    cargoArtifacts = null;
+    src = mkDummySrc {
+      inherit src;
+    };
+  });
 
   checkWarnings = cargoClippy {
     inherit cargoArtifacts src;

--- a/checks/mkDummySrcTests/customized/expected/benches/bench1.rs
+++ b/checks/mkDummySrcTests/customized/expected/benches/bench1.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::all)]
 #![allow(dead_code)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_std)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_main)]

--- a/checks/mkDummySrcTests/customized/expected/benches/custom.rs
+++ b/checks/mkDummySrcTests/customized/expected/benches/custom.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::all)]
 #![allow(dead_code)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_std)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_main)]

--- a/checks/mkDummySrcTests/customized/expected/examples/custom.rs
+++ b/checks/mkDummySrcTests/customized/expected/examples/custom.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::all)]
 #![allow(dead_code)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_std)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_main)]

--- a/checks/mkDummySrcTests/customized/expected/examples/example1.rs
+++ b/checks/mkDummySrcTests/customized/expected/examples/example1.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::all)]
 #![allow(dead_code)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_std)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_main)]

--- a/checks/mkDummySrcTests/customized/expected/src/bin/bin1.rs
+++ b/checks/mkDummySrcTests/customized/expected/src/bin/bin1.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::all)]
 #![allow(dead_code)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_std)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_main)]

--- a/checks/mkDummySrcTests/customized/expected/src/bin/crane-dummy-mkDummySrcSimple/main.rs
+++ b/checks/mkDummySrcTests/customized/expected/src/bin/crane-dummy-mkDummySrcSimple/main.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::all)]
 #![allow(dead_code)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_std)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_main)]

--- a/checks/mkDummySrcTests/customized/expected/src/bin/custom.rs
+++ b/checks/mkDummySrcTests/customized/expected/src/bin/custom.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::all)]
 #![allow(dead_code)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_std)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_main)]

--- a/checks/mkDummySrcTests/customized/expected/src/lib.rs
+++ b/checks/mkDummySrcTests/customized/expected/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::all)]
 #![allow(dead_code)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_std)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_main)]

--- a/checks/mkDummySrcTests/customized/expected/tests/custom.rs
+++ b/checks/mkDummySrcTests/customized/expected/tests/custom.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::all)]
 #![allow(dead_code)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_std)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_main)]

--- a/checks/mkDummySrcTests/customized/expected/tests/test1.rs
+++ b/checks/mkDummySrcTests/customized/expected/tests/test1.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::all)]
 #![allow(dead_code)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_std)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_main)]

--- a/checks/mkDummySrcTests/single-alt/expected/src/bin/crane-dummy-mkDummySrcSimple/main.rs
+++ b/checks/mkDummySrcTests/single-alt/expected/src/bin/crane-dummy-mkDummySrcSimple/main.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::all)]
 #![allow(dead_code)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_std)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_main)]

--- a/checks/mkDummySrcTests/single-alt/expected/src/custom.rs
+++ b/checks/mkDummySrcTests/single-alt/expected/src/custom.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::all)]
 #![allow(dead_code)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_std)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_main)]

--- a/checks/mkDummySrcTests/single-alt/expected/src/lib.rs
+++ b/checks/mkDummySrcTests/single-alt/expected/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::all)]
 #![allow(dead_code)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_std)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_main)]

--- a/checks/mkDummySrcTests/single/expected/benches/bench1.rs
+++ b/checks/mkDummySrcTests/single/expected/benches/bench1.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::all)]
 #![allow(dead_code)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_std)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_main)]

--- a/checks/mkDummySrcTests/single/expected/benches/custom.rs
+++ b/checks/mkDummySrcTests/single/expected/benches/custom.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::all)]
 #![allow(dead_code)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_std)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_main)]

--- a/checks/mkDummySrcTests/single/expected/examples/custom.rs
+++ b/checks/mkDummySrcTests/single/expected/examples/custom.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::all)]
 #![allow(dead_code)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_std)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_main)]

--- a/checks/mkDummySrcTests/single/expected/examples/example1.rs
+++ b/checks/mkDummySrcTests/single/expected/examples/example1.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::all)]
 #![allow(dead_code)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_std)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_main)]

--- a/checks/mkDummySrcTests/single/expected/src/bin/bin1.rs
+++ b/checks/mkDummySrcTests/single/expected/src/bin/bin1.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::all)]
 #![allow(dead_code)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_std)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_main)]

--- a/checks/mkDummySrcTests/single/expected/src/bin/crane-dummy-mkDummySrcSimple/main.rs
+++ b/checks/mkDummySrcTests/single/expected/src/bin/crane-dummy-mkDummySrcSimple/main.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::all)]
 #![allow(dead_code)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_std)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_main)]

--- a/checks/mkDummySrcTests/single/expected/src/bin/custom.rs
+++ b/checks/mkDummySrcTests/single/expected/src/bin/custom.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::all)]
 #![allow(dead_code)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_std)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_main)]

--- a/checks/mkDummySrcTests/single/expected/src/lib.rs
+++ b/checks/mkDummySrcTests/single/expected/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::all)]
 #![allow(dead_code)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_std)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_main)]

--- a/checks/mkDummySrcTests/single/expected/tests/custom.rs
+++ b/checks/mkDummySrcTests/single/expected/tests/custom.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::all)]
 #![allow(dead_code)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_std)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_main)]

--- a/checks/mkDummySrcTests/single/expected/tests/test1.rs
+++ b/checks/mkDummySrcTests/single/expected/tests/test1.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::all)]
 #![allow(dead_code)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_std)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_main)]

--- a/checks/mkDummySrcTests/workspace-bindeps/expected/foo/src/bin/crane-dummy-foo/main.rs
+++ b/checks/mkDummySrcTests/workspace-bindeps/expected/foo/src/bin/crane-dummy-foo/main.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::all)]
 #![allow(dead_code)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_std)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_main)]

--- a/checks/mkDummySrcTests/workspace-bindeps/expected/foo/src/lib.rs
+++ b/checks/mkDummySrcTests/workspace-bindeps/expected/foo/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::all)]
 #![allow(dead_code)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_std)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_main)]

--- a/checks/mkDummySrcTests/workspace-bindeps/expected/src/bin/crane-dummy-workspace-bindeps/main.rs
+++ b/checks/mkDummySrcTests/workspace-bindeps/expected/src/bin/crane-dummy-workspace-bindeps/main.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::all)]
 #![allow(dead_code)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_std)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_main)]

--- a/checks/mkDummySrcTests/workspace-bindeps/expected/src/lib.rs
+++ b/checks/mkDummySrcTests/workspace-bindeps/expected/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::all)]
 #![allow(dead_code)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_std)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_main)]

--- a/checks/mkDummySrcTests/workspace-inheritance/expected/hello/src/bin/crane-dummy-hello/main.rs
+++ b/checks/mkDummySrcTests/workspace-inheritance/expected/hello/src/bin/crane-dummy-hello/main.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::all)]
 #![allow(dead_code)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_std)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_main)]

--- a/checks/mkDummySrcTests/workspace-inheritance/expected/hello/src/lib.rs
+++ b/checks/mkDummySrcTests/workspace-inheritance/expected/hello/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::all)]
 #![allow(dead_code)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_std)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_main)]

--- a/checks/mkDummySrcTests/workspace-inheritance/expected/print/src/bin/crane-dummy-print/main.rs
+++ b/checks/mkDummySrcTests/workspace-inheritance/expected/print/src/bin/crane-dummy-print/main.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::all)]
 #![allow(dead_code)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_std)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_main)]

--- a/checks/mkDummySrcTests/workspace-inheritance/expected/print/src/lib.rs
+++ b/checks/mkDummySrcTests/workspace-inheritance/expected/print/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::all)]
 #![allow(dead_code)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_std)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_main)]

--- a/checks/mkDummySrcTests/workspace-inheritance/expected/world/src/bin/crane-dummy-world/main.rs
+++ b/checks/mkDummySrcTests/workspace-inheritance/expected/world/src/bin/crane-dummy-world/main.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::all)]
 #![allow(dead_code)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_std)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_main)]

--- a/checks/mkDummySrcTests/workspace-inheritance/expected/world/src/lib.rs
+++ b/checks/mkDummySrcTests/workspace-inheritance/expected/world/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::all)]
 #![allow(dead_code)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_std)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_main)]

--- a/checks/mkDummySrcTests/workspace/expected/member/foo/bar/baz/benches/bench1.rs
+++ b/checks/mkDummySrcTests/workspace/expected/member/foo/bar/baz/benches/bench1.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::all)]
 #![allow(dead_code)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_std)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_main)]

--- a/checks/mkDummySrcTests/workspace/expected/member/foo/bar/baz/benches/custom.rs
+++ b/checks/mkDummySrcTests/workspace/expected/member/foo/bar/baz/benches/custom.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::all)]
 #![allow(dead_code)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_std)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_main)]

--- a/checks/mkDummySrcTests/workspace/expected/member/foo/bar/baz/examples/custom.rs
+++ b/checks/mkDummySrcTests/workspace/expected/member/foo/bar/baz/examples/custom.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::all)]
 #![allow(dead_code)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_std)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_main)]

--- a/checks/mkDummySrcTests/workspace/expected/member/foo/bar/baz/examples/example1.rs
+++ b/checks/mkDummySrcTests/workspace/expected/member/foo/bar/baz/examples/example1.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::all)]
 #![allow(dead_code)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_std)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_main)]

--- a/checks/mkDummySrcTests/workspace/expected/member/foo/bar/baz/src/bin/bin1.rs
+++ b/checks/mkDummySrcTests/workspace/expected/member/foo/bar/baz/src/bin/bin1.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::all)]
 #![allow(dead_code)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_std)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_main)]

--- a/checks/mkDummySrcTests/workspace/expected/member/foo/bar/baz/src/bin/crane-dummy-bar/main.rs
+++ b/checks/mkDummySrcTests/workspace/expected/member/foo/bar/baz/src/bin/crane-dummy-bar/main.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::all)]
 #![allow(dead_code)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_std)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_main)]

--- a/checks/mkDummySrcTests/workspace/expected/member/foo/bar/baz/src/bin/custom.rs
+++ b/checks/mkDummySrcTests/workspace/expected/member/foo/bar/baz/src/bin/custom.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::all)]
 #![allow(dead_code)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_std)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_main)]

--- a/checks/mkDummySrcTests/workspace/expected/member/foo/bar/baz/src/lib.rs
+++ b/checks/mkDummySrcTests/workspace/expected/member/foo/bar/baz/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::all)]
 #![allow(dead_code)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_std)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_main)]

--- a/checks/mkDummySrcTests/workspace/expected/member/foo/bar/baz/tests/custom.rs
+++ b/checks/mkDummySrcTests/workspace/expected/member/foo/bar/baz/tests/custom.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::all)]
 #![allow(dead_code)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_std)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_main)]

--- a/checks/mkDummySrcTests/workspace/expected/member/foo/bar/baz/tests/test1.rs
+++ b/checks/mkDummySrcTests/workspace/expected/member/foo/bar/baz/tests/test1.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::all)]
 #![allow(dead_code)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_std)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_main)]

--- a/checks/mkDummySrcTests/workspace/expected/member/qux/benches/bench1.rs
+++ b/checks/mkDummySrcTests/workspace/expected/member/qux/benches/bench1.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::all)]
 #![allow(dead_code)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_std)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_main)]

--- a/checks/mkDummySrcTests/workspace/expected/member/qux/benches/custom.rs
+++ b/checks/mkDummySrcTests/workspace/expected/member/qux/benches/custom.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::all)]
 #![allow(dead_code)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_std)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_main)]

--- a/checks/mkDummySrcTests/workspace/expected/member/qux/examples/custom.rs
+++ b/checks/mkDummySrcTests/workspace/expected/member/qux/examples/custom.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::all)]
 #![allow(dead_code)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_std)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_main)]

--- a/checks/mkDummySrcTests/workspace/expected/member/qux/examples/example1.rs
+++ b/checks/mkDummySrcTests/workspace/expected/member/qux/examples/example1.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::all)]
 #![allow(dead_code)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_std)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_main)]

--- a/checks/mkDummySrcTests/workspace/expected/member/qux/src/bin/bin1.rs
+++ b/checks/mkDummySrcTests/workspace/expected/member/qux/src/bin/bin1.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::all)]
 #![allow(dead_code)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_std)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_main)]

--- a/checks/mkDummySrcTests/workspace/expected/member/qux/src/bin/crane-dummy-qux/main.rs
+++ b/checks/mkDummySrcTests/workspace/expected/member/qux/src/bin/crane-dummy-qux/main.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::all)]
 #![allow(dead_code)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_std)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_main)]

--- a/checks/mkDummySrcTests/workspace/expected/member/qux/src/bin/custom.rs
+++ b/checks/mkDummySrcTests/workspace/expected/member/qux/src/bin/custom.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::all)]
 #![allow(dead_code)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_std)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_main)]

--- a/checks/mkDummySrcTests/workspace/expected/member/qux/src/lib.rs
+++ b/checks/mkDummySrcTests/workspace/expected/member/qux/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::all)]
 #![allow(dead_code)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_std)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_main)]

--- a/checks/mkDummySrcTests/workspace/expected/member/qux/tests/custom.rs
+++ b/checks/mkDummySrcTests/workspace/expected/member/qux/tests/custom.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::all)]
 #![allow(dead_code)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_std)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_main)]

--- a/checks/mkDummySrcTests/workspace/expected/member/qux/tests/test1.rs
+++ b/checks/mkDummySrcTests/workspace/expected/member/qux/tests/test1.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::all)]
 #![allow(dead_code)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_std)]
 #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_main)]

--- a/lib/mkDummySrc.nix
+++ b/lib/mkDummySrc.nix
@@ -131,6 +131,7 @@ let
     };
 
   dummyrs = args.dummyrs or (writeText "dummy.rs" ''
+    #![allow(clippy::all)]
     #![allow(dead_code)]
     #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_std)]
     #![cfg_attr(any(target_os = "none", target_os = "uefi"), no_main)]


### PR DESCRIPTION
## Motivation
<!--
Thank you for your contribution! Please add a brief description below about the change and what is the motivation
behind it.
-->

I'd like to be able to run `cargo clippy` in `buildDepsOnly` without it exiting early due to warnings/errors in the dummy file. The PR adds `#![allow(clippy::all)]` to the dummy file.

Why?

It can be tricky to get optimal cargo artifact cache reuse between a custom `mkCargoDerivation` and `buildDepsOnly`.  Especially when you're trying to hide the low level crane/nix details and expose a simple caching interface for CI.

What I've ended up doing is to simply run the exact same cargo command first in `buildDepsOnly` and then `mkCargoDerivation`. This guarantees that everything will be built the exact same way without having to keep all the flags (`--workspace`, `--all-targets`, `--features`, etc.) in sync between the `cargoArtifacts` and the final derivation.

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [ ] updated `docs/API.md` (or general documentation) with changes
- [ ] updated `CHANGELOG.md`
