### PR TITLE
Fix typo in `cargoNextestExtraArgs` docs

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -618,8 +618,8 @@ Except where noted below, all derivation attributes are delegated to
 * `cargoLlvmCovExtraArgs`: additional flags to be passed in the cargo
   llvm-cov invocation
   - Default value: `"--lcov --output-path $out/coverage"`
-* `cargoNextestExtraArgs`: additional flags to be passed in the clippy invocation (e.g.
-  deny specific lints)
+* `cargoNextestExtraArgs`: additional flags to be passed in the nextest invocation
+  (e.g. specifying a profile)
   - Default value: `""`
 * `partitions`: The number of separate nextest partitions to run. Useful if the
   test suite takes a long time and can be parallelized across multiple build


### PR DESCRIPTION
## Motivation
The API docs seem wrong here, copy-pasta probably.

## Checklist
- [x] updated `docs/API.md` (or general documentation) with changes
- [ ] updated `CHANGELOG.md`
