### PR TITLE
Remove cargoExtraArgs from cargoAudit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   around dependency declarations to work around a mangling bug in `toml_edit`
   (see https://github.com/ipetkov/crane/issues/527 and
   https://github.com/toml-rs/toml/issues/691)
+* removed `cargoExtraArgs` from `cargoAudit`
 
 ## [0.16.3] - 2024-03-19
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -318,8 +318,6 @@ Except where noted below, all derivation attributes are delegated to
 #### Optional attributes
 * `cargoAuditExtraArgs`: additional flags to be passed in the cargo-audit invocation
   - Default value: `"--ignore yanked"`
-* `cargoExtraArgs`: additional flags to be passed in the cargo invocation
-  - Default value: `""`
 * `pname`: the name of the derivation; will _not_ be introspected from a
   `Cargo.toml` file
   - Default value: `"crate"`
@@ -337,7 +335,6 @@ The following attributes will be removed before being lowered to
 environment variables during the build, you can bring them back via
 `.overrideAttrs`.
 * `cargoAuditExtraArgs`
-* `cargoExtraArgs`
 
 ### `craneLib.cargoDeny`
 `cargoDeny :: set -> drv`

--- a/lib/cargoAudit.nix
+++ b/lib/cargoAudit.nix
@@ -5,18 +5,16 @@
 
 { advisory-db
 , cargoAuditExtraArgs ? "--ignore yanked"
-, cargoExtraArgs ? ""
 , src
 , ...
 }@origArgs:
 let
   args = builtins.removeAttrs origArgs [
     "cargoAuditExtraArgs"
-    "cargoExtraArgs"
   ];
 in
 mkCargoDerivation (args // {
-  buildPhaseCargoCommand = "cargo audit ${cargoExtraArgs} -n -d ${advisory-db} ${cargoAuditExtraArgs}";
+  buildPhaseCargoCommand = "cargo audit -n -d ${advisory-db} ${cargoAuditExtraArgs}";
 
   src = lib.cleanSourceWith {
     inherit src;


### PR DESCRIPTION
## Motivation

It seems `cargo audit` does not inherit the rest of the cargo command line arguments, which means having `cargoExtraArgs` defined for it results in  errors like:  `error: unexpected argument '-F' found`.

The change removes the `cargoExtraArgs` from `cargoAudit.nix` to avoid mistakes.

## Checklist
Not sure how to best test it, feel free to point me in a direction and I'll implement something.

- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [x] updated `docs/API.md` (or general documentation) with changes
- [x] updated `CHANGELOG.md`

## Details

**cargo audit help**
```shell
 » cargo audit --version
cargo-audit-audit 0.20.0
 » cargo audit help
Audit Cargo.lock files for vulnerable crates

Usage: cargo audit [OPTIONS] [COMMAND]

Commands:
  bin   scan compiled binaries
  help  Print this message or the help of the given subcommand(s)

Options:
  -c, --color <COLOR>              color configuration: always, never (default: auto)
  -d, --db <DB>                    advisory database git repo path (default: ~/.cargo/advisory-db)
  -D, --deny <DENY>                exit with an error on: warnings (any), unmaintained, unsound, yanked
  -f, --file <FILE>                Cargo lockfile to inspect (or `-` for STDIN, default: Cargo.lock)
      --ignore <ADVISORY_ID>       Advisory id to ignore (can be specified multiple times)
      --ignore-source              Ignore sources of packages in Cargo.toml, matching advisories regardless of source
  -n, --no-fetch                   do not perform a git fetch on the advisory DB
      --stale                      allow stale database
      --target-arch <TARGET_ARCH>  filter vulnerabilities by CPU (default: no filter)
      --target-os <TARGET_OS>      filter vulnerabilities by OS (default: no filter)
  -u, --url <URL>                  URL for advisory database git repo
  -q, --quiet                      Avoid printing unnecessary information
      --json                       Output report in JSON format
  -h, --help                       Print help
  -V, --version                    Print version
```

**cargo doc help**

```shell
 » cargo doc --help
Build a package's documentation

Usage: cargo doc [OPTIONS]

Options:
      --open                    Opens the docs in a browser after the operation
      --no-deps                 Don't build documentation for dependencies
      --document-private-items  Document private items
      --ignore-rust-version     Ignore `rust-version` specification in packages
      --message-format <FMT>    Error format
  -q, --quiet                   Do not print cargo log messages
  -v, --verbose...              Use verbose output (-vv very verbose/build.rs output)
      --color <WHEN>            Coloring: auto, always, never
      --config <KEY=VALUE>      Override a configuration value
  -Z <FLAG>                     Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details
  -h, --help                    Print help

Package Selection:
  -p, --package [<SPEC>]  Package to document
      --workspace         Document all packages in the workspace
      --exclude <SPEC>    Exclude packages from the build
      --all               Alias for --workspace (deprecated)

Feature Selection:
  -F, --features <FEATURES>  Space or comma separated list of features to activate
      --all-features         Activate all available features
      --no-default-features  Do not activate the `default` feature

Target Selection:
      --lib               Document only this package's library
      --bins              Document all binaries
      --bin [<NAME>]      Document only the specified binary
      --examples          Document all examples
      --example [<NAME>]  Document only the specified example

Compilation Options:
  -j, --jobs <N>                Number of parallel jobs, defaults to # of CPUs.
      --keep-going              Do not abort the build as soon as there is an error
  -r, --release                 Build artifacts in release mode, with optimizations
      --profile <PROFILE-NAME>  Build artifacts with the specified profile
      --target [<TRIPLE>]       Build for the target triple
      --target-dir <DIRECTORY>  Directory for all generated artifacts
      --unit-graph              Output build graph in JSON (unstable)
      --timings[=<FMTS>]        Timing output formats (unstable) (comma separated): html, json

Manifest Options:
      --manifest-path <PATH>  Path to Cargo.toml
      --frozen                Require Cargo.lock and cache are up to date
      --locked                Require Cargo.lock is up to date
      --offline               Run without accessing the network

Run `cargo help doc` for more detailed information.
```