### PR TITLE
crateNameFromCargoToml: support selecting a name from `metadata`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,20 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   installed to `$out/share` (which can be useful when cross-compiling). By
   default `$CARGO_TARGET_DIR` and `$CARGO_BUILD_TARGET` (if set) will be taken
   into account
+* `crateNameFromCargoToml` now supports selecting a derivation name by setting
+  `package.metadata.crane.name` or `workspace.metadata.crane.name` in the root
+  `Cargo.toml`
 
 ### Changed
 * **Breaking** `cargoAudit` no longer accepts `cargoExtraArgs` (since it does
   not support the regular set of `cargo` flags like most cargo-commands do, it
   does not make much sense to propagate those flags through)
+
+### Deprecations
+* In the future, `crateNameFromCargoToml` will stop considering
+  `workspace.package.name` in the root `Cargo.toml` when determining the crate
+  name. This attribute is not recognized by cargo (which will emit its own
+  warnings about it) and should be avoided going forward.
 
 ## [0.16.6] - 2024-05-04
 

--- a/checks/cargoAudit.nix
+++ b/checks/cargoAudit.nix
@@ -5,8 +5,8 @@
 }:
 
 let
-  auditWith = pname: src: cargoAudit {
-    inherit src pname;
+  auditWith = src: cargoAudit {
+    inherit src;
     advisory-db = fetchFromGitHub {
       owner = "rustsec";
       repo = "advisory-db";
@@ -15,7 +15,7 @@ let
     };
   };
 
-  simpleWithAuditToml = (auditWith "simple-with-audit-toml" ./simple-with-audit-toml);
+  simpleWithAuditToml = (auditWith ./simple-with-audit-toml);
 
   containsAuditTomlInSrc = runCommand "containsAuditTomlInSrc" { } ''
     if [[ -f ${simpleWithAuditToml.src}/.cargo/audit.toml ]]; then
@@ -28,16 +28,16 @@ let
 in
 linkFarmFromDrvs "cleanCargoToml" [
   # Check against all different kinds of workspace types to make sure it works
-  (auditWith "simple" ./simple)
-  (auditWith "simple-git" ./simple-git)
+  (auditWith ./simple)
+  (auditWith ./simple-git)
 
   simpleWithAuditToml
   containsAuditTomlInSrc
 
-  (auditWith "gitRevNoRef" ./gitRevNoRef)
-  (auditWith "git-overlapping" ./git-overlapping)
+  (auditWith ./gitRevNoRef)
+  (auditWith ./git-overlapping)
 
-  (auditWith "workspace" ./workspace)
-  (auditWith "workspace-git" ./workspace-git)
-  (auditWith "workspace-root" ./workspace-root)
+  (auditWith ./workspace)
+  (auditWith ./workspace-git)
+  (auditWith ./workspace-root)
 ]

--- a/checks/default.nix
+++ b/checks/default.nix
@@ -321,8 +321,6 @@ in
 
   depsOnlyCargoDoc = myLib.buildDepsOnly {
     src = ./workspace;
-    version = "0.0.1";
-    pname = "workspace";
     buildPhaseCargoCommand = "cargo doc --workspace";
   };
 
@@ -353,15 +351,11 @@ in
   };
 
   illegalBin = myLib.buildPackage {
-    pname = "illegalBin";
-    version = "0.0.1";
     src = ./illegal-bin;
   };
 
   manyLibs = myLib.buildPackage {
     src = ./with-libs;
-    pname = "my-libs";
-    version = "0.0.1";
     cargoArtifacts = null;
   };
 
@@ -720,19 +714,14 @@ in
 
   workspace = myLib.buildPackage {
     src = myLib.cleanCargoSource ./workspace;
-    pname = "workspace";
-    version = "0.0.1";
   };
 
   workspaceHack = myLib.buildPackage {
     src = myLib.cleanCargoSource ./workspace-hack;
-    pname = "workspace-hack";
-    version = "0.0.1";
   };
 
   workspaceInheritance = myLib.buildPackage {
     src = myLib.cleanCargoSource ./workspace-inheritance;
-    pname = "workspace-inheritance";
   };
 
   # https://github.com/ipetkov/crane/issues/209
@@ -755,8 +744,6 @@ in
 
   workspaceGit = myLib.buildPackage {
     src = myLib.cleanCargoSource ./workspace-git;
-    pname = "workspace-git";
-    version = "0.0.1";
   };
 
   zstdNoChange =

--- a/checks/illegal-bin/Cargo.toml
+++ b/checks/illegal-bin/Cargo.toml
@@ -10,6 +10,8 @@
 # Instead we need to drop a dummy file at `src/lib.rs`, and this is a
 # regression test for that case.
 [workspace]
+package.version = "0.0.1"
+metadata.crane.name = "illegal-bin"
 members = [
   "examples",
 ]

--- a/checks/with-libs/Cargo.toml
+++ b/checks/with-libs/Cargo.toml
@@ -1,4 +1,6 @@
 [workspace]
+package.version = "0.0.1"
+metadata.crane.name = "with-libs"
 members = [
   "all-types",
   "only-cdylib",

--- a/checks/workspace-git/Cargo.toml
+++ b/checks/workspace-git/Cargo.toml
@@ -1,4 +1,6 @@
 [workspace]
+package.version = "0.0.1"
+metadata.crane.name = "workspace-git"
 members = [
   "foo",
   "bar",

--- a/checks/workspace-hack/Cargo.toml
+++ b/checks/workspace-hack/Cargo.toml
@@ -2,3 +2,5 @@
 # NB: hello and world are intentionally left out cargo will
 # promote them to members since they are listed as path deps
 members = ["my-workspace-hack","print"]
+package.version = "0.0.1"
+metadata.crane.name = "workspace-hack"

--- a/checks/workspace-inheritance/Cargo.toml
+++ b/checks/workspace-inheritance/Cargo.toml
@@ -2,6 +2,7 @@
 # NB: hello and world are intentionally left out cargo will
 # promote them to members since they are listed as path deps
 members = ["print"]
+metadata.crane.name = "workspace-inheritance"
 
 [workspace.package]
 edition = "2021"

--- a/checks/workspace/Cargo.toml
+++ b/checks/workspace/Cargo.toml
@@ -2,6 +2,8 @@
 # NB: hello and world are intentionally left out cargo will
 # promote them to members since they are listed as path deps
 members = ["print"]
+package.version = "0.1.0"
+metadata.crane.name = "workspace"
 
 [workspace.lints.rust]
 rust_2018_idioms = "deny"

--- a/docs/API.md
+++ b/docs/API.md
@@ -778,16 +778,20 @@ raised during evaluation.
 Extract a crate's name and version from its Cargo.toml file.
 
 The resulting `pname` attribute will be populated with the value of the
-Cargo.toml's (top-level) `package.name` attribute, if present and if the
-value is a string. Otherwise `workspace.package.name` will be used if it is
-present _and_ the value is a string. Otherwise a placeholder version field will
-be used.
+Cargo.toml's (top-level) attributes in the following order, where the first
+attribute (with a string value) will be chosen:
+1. `package.metadata.crane.name`
+1. `package.name`
+1. `workspace.metadata.crane.name`
+1. (Deprecated) `workspace.package.name`
+1. Otherwise a placeholder name will be used
 
 The resulting `version` attribute will be populated with the value of the
-Cargo.toml's (top-level) `package.version` attribute, if present and if the
-value is a string. Otherwise `workspace.package.version` will be used if it is
-present _and_ the value is a string. Otherwise a placeholder version field will
-be used.
+Cargo.toml's (top-level) attributes in the following order, where the first
+attribute (with a string value) will be chosen:
+1. `package.version`
+1. `workspace.package.version`
+1. Otherwise a placeholder version will be used
 
 Note that *only the root `Cargo.toml` of the specified source will be checked*.
 Directories **will not be crawled** to resolve potential workspace inheritance.

--- a/examples/end-to-end-testing/Cargo.toml
+++ b/examples/end-to-end-testing/Cargo.toml
@@ -4,3 +4,10 @@ members = [
     "server",
     "e2e_tests",
 ]
+
+[workspace.package]
+version = "0.1.0"
+edition = "2021"
+
+[workspace.metadata.crane]
+name = "example-e2e"

--- a/examples/end-to-end-testing/e2e_tests/Cargo.toml
+++ b/examples/end-to-end-testing/e2e_tests/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "e2e_tests"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/examples/end-to-end-testing/flake.nix
+++ b/examples/end-to-end-testing/flake.nix
@@ -33,8 +33,6 @@
 
         workspace = craneLib.buildPackage {
           inherit src;
-          pname = "example-e2e";
-          version = "0.1";
           doCheck = false;
           nativeBuildInputs = lib.optionals pkgs.stdenv.isDarwin
             (with pkgs.darwin.apple_sdk.frameworks; [

--- a/examples/end-to-end-testing/server/Cargo.toml
+++ b/examples/end-to-end-testing/server/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "server"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 
 [dependencies]
 axum = "0.7"

--- a/examples/quick-start-workspace/Cargo.toml
+++ b/examples/quick-start-workspace/Cargo.toml
@@ -8,3 +8,6 @@ members = [
 [workspace.package]
 version = "0.1.0"
 edition = "2021"
+
+[workspace.metadata.crane]
+name = "my-workspace"

--- a/examples/trunk-workspace/Cargo.toml
+++ b/examples/trunk-workspace/Cargo.toml
@@ -4,3 +4,10 @@ members = [
   "client",
   "server",
 ]
+
+[workspace.package]
+version = "0.1.0"
+edition = "2021"
+
+[workspace.metadata.crane]
+name = "trunk-workspace"

--- a/examples/trunk-workspace/client/Cargo.toml
+++ b/examples/trunk-workspace/client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "client"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/examples/trunk-workspace/flake.nix
+++ b/examples/trunk-workspace/flake.nix
@@ -64,8 +64,6 @@
         # to set "pname" and "version".
         commonArgs = {
           inherit src;
-          pname = "trunk-workspace";
-          version = "0.1.0";
           strictDeps = true;
 
           buildInputs = [

--- a/examples/trunk-workspace/server/Cargo.toml
+++ b/examples/trunk-workspace/server/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "server"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/examples/trunk-workspace/shared/Cargo.toml
+++ b/examples/trunk-workspace/shared/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "shared"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/lib/crateNameFromCargoToml.nix
+++ b/lib/crateNameFromCargoToml.nix
@@ -13,7 +13,7 @@ let
   '';
 
   src = args.src or throwMsg;
-  cargoToml = args.cargoToml or (args.src + "/Cargo.toml");
+  cargoToml = args.cargoToml or (src + "/Cargo.toml");
   cargoTomlContents = args.cargoTomlContents or (
     if builtins.pathExists cargoToml
     then builtins.readFile cargoToml
@@ -33,19 +33,24 @@ let
     `NIX_ABORT_ON_WARN=1 nix --option pure-eval false --show-trace ...`
   '';
 
-  traceMsg = tomlName: drvName: placeholder: lib.flip lib.trivial.warn placeholder ''
+  traceMsg = tomlName: drvName: placeholder: workspaceHints: lib.flip lib.trivial.warn placeholder ''
     crane will use a placeholder value since `${tomlName}` cannot be found in ${debugPath}
     to silence this warning consider one of the following:
     - setting `${drvName} = "...";` in the derivation arguments explicitly
-    - setting `package.${tomlName} = "..."` or `workspace.package.${tomlName} = "..."` in the root Cargo.toml
+    - setting `package.${tomlName} = "..."` or ${lib.concatStringsSep " or " workspaceHints} in the root Cargo.toml
     - explicitly looking up the values from a different Cargo.toml via 
       `craneLib.crateNameFromCargoToml { cargoToml = ./path/to/Cargo.toml; }`
     ${hint}
   '';
 
-  internalName = internalCrateNameFromCargoToml toml;
+  internalName = internalCrateNameFromCargoToml toml debugPath;
 in
 {
-  pname = internalName.pname or (traceMsg "name" "pname" "cargo-package");
-  version = internalName.version or (traceMsg "version" "version" "0.0.1");
+  pname = internalName.pname or (traceMsg "name" "pname" "cargo-package" [
+    ''`package.metadata.crane.name` = "..."''
+    ''`workspace.metadata.crane.name` = "..."''
+  ]);
+  version = internalName.version or (traceMsg "version" "version" "0.0.1" [
+    ''`workspace.package.version` = "..."''
+  ]);
 }

--- a/lib/internalCrateNameFromCargoToml.nix
+++ b/lib/internalCrateNameFromCargoToml.nix
@@ -1,22 +1,29 @@
 { lib
 }:
 
-toml:
+let
+  firstNonNull = lib.lists.findFirst lib.isString null;
+  wpnDeprecated = val: debugPath: lib.warnIf
+    (val != null)
+    "`workspace.package.name` is deprecated, please use `workspace.metadata.crane.name` in ${debugPath}"
+    val;
+in
+toml: debugPath:
 lib.filterAttrs (_: v: v != null) {
   # Now that cargo supports workspace inheritance we attempt to select a name
   # with the following priorities:
+  # - choose `[package.metadata.crane.name]` if the value is present and a string
   # - choose `[package.name]` if the value is present and a string
   #   (i.e. it isn't `[package.name] = { workspace = "true" }`)
+  # - choose `[workspace.metadata.crane.name]` if the value is present and a string
   # - choose `[workspace.package.name]` if it is present (and a string for good measure)
   # - otherwise, fall back to a placeholder
-  pname =
-    let
-      packageName = toml.package.name or null;
-      workspacePackageName = toml.workspace.package.name or null;
-    in
-    if lib.isString packageName then packageName
-    else if lib.isString workspacePackageName then workspacePackageName
-    else null;
+  pname = firstNonNull [
+    (toml.package.metadata.crane.name or null)
+    (toml.package.name or null)
+    (toml.workspace.metadata.crane.name or null)
+    (wpnDeprecated (toml.workspace.package.name or null) debugPath)
+  ];
 
   # Now that cargo supports workspace inheritance we attempt to select a version
   # string with the following priorities:
@@ -24,12 +31,8 @@ lib.filterAttrs (_: v: v != null) {
   #   (i.e. it isn't `[package.version] = { workspace = "true" }`)
   # - choose `[workspace.package.version]` if it is present (and a string for good measure)
   # - otherwise, fall back to a placeholder
-  version =
-    let
-      packageVersion = toml.package.version or null;
-      workspacePackageVersion = toml.workspace.package.version or null;
-    in
-    if lib.isString packageVersion then packageVersion
-    else if lib.isString workspacePackageVersion then workspacePackageVersion
-    else null;
+  version = firstNonNull [
+    (toml.package.version or null)
+    (toml.workspace.package.version or null)
+  ];
 }


### PR DESCRIPTION
## Motivation

`crateNameFromCargoToml` now supports choosing a derivation name from `{package,workspace}.metadata.crane.name`. Choosing a name from `workspace.package.name` is now deprecated and will be removed in a future version

Fixes https://github.com/ipetkov/crane/issues/584

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [x] updated `docs/API.md` (or general documentation) with changes
- [x] updated `CHANGELOG.md`
