### PR TITLE
Use resolver = 2 in all Cargo.tomls

### DIFF
--- a/checks/bindeps/Cargo.toml
+++ b/checks/bindeps/Cargo.toml
@@ -6,5 +6,7 @@ edition = "2021"
 [dependencies]
 foo = { workspace = true }
 
+[workspace]
+resolver = "2"
 [workspace.dependencies]
 foo = { path = "./foo", target = "wasm32-unknown-unknown", artifact = ["bin", "cdylib", "staticlib"] }

--- a/checks/cleanCargoTomlTests/complex/Cargo.toml
+++ b/checks/cleanCargoTomlTests/complex/Cargo.toml
@@ -201,6 +201,7 @@ opt-level = 2
 overflow-checks = true
 
 [workspace]
+resolver = "2"
 members = ["member1", "path/to/member2", "crates/*"]
 default-members = ["path/to/member2", "path/to/member3/foo"]
 exclude = ["crates/foo", "path/to/other"]

--- a/checks/cleanCargoTomlTests/complex/expected.toml
+++ b/checks/cleanCargoTomlTests/complex/expected.toml
@@ -111,6 +111,7 @@ garply = "8"
 grault = "7"
 
 [workspace]
+resolver = "2"
 default-members = ["path/to/member2", "path/to/member3/foo"]
 exclude = ["crates/foo", "path/to/other"]
 members = ["member1", "path/to/member2", "crates/*"]

--- a/checks/dependencyBuildScriptPerms/Cargo.toml
+++ b/checks/dependencyBuildScriptPerms/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.2.0"
 edition = "2021"
 
 [workspace]
+resolver = "2"
 members = ["inner"]
 
 [dependencies]

--- a/checks/illegal-bin/Cargo.toml
+++ b/checks/illegal-bin/Cargo.toml
@@ -10,6 +10,7 @@
 # Instead we need to drop a dummy file at `src/lib.rs`, and this is a
 # regression test for that case.
 [workspace]
+resolver = "2"
 package.version = "0.0.1"
 metadata.crane.name = "illegal-bin"
 members = [

--- a/checks/mkDummySrcTests/workspace-bindeps/expected/Cargo.toml
+++ b/checks/mkDummySrcTests/workspace-bindeps/expected/Cargo.toml
@@ -6,6 +6,8 @@ build = "cranespecific-dummy.rs"
 name = "workspace-bindeps"
 version = "0.1.0"
 
+[workspace]
+resolver = "2"
 [workspace.dependencies.foo]
 artifact = "cdylib"
 path = "./foo"

--- a/checks/mkDummySrcTests/workspace-bindeps/input/Cargo.toml
+++ b/checks/mkDummySrcTests/workspace-bindeps/input/Cargo.toml
@@ -5,6 +5,8 @@ version = "0.1.0"
 [dependencies]
 foo = { workspace = true }
 
+[workspace]
+resolver = "2"
 [workspace.dependencies]
 foo = { path = "./foo", target = "wasm32-unknown-unknown", artifact = "cdylib" }
 

--- a/checks/mkDummySrcTests/workspace-inheritance/expected/Cargo.toml
+++ b/checks/mkDummySrcTests/workspace-inheritance/expected/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = ["print"]
 
 [workspace.package]

--- a/checks/mkDummySrcTests/workspace-inheritance/input/Cargo.toml
+++ b/checks/mkDummySrcTests/workspace-inheritance/input/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 # NB: hello and world are intentionally left out cargo will
 # promote them to members since they are listed as path deps
 members = ["print"]

--- a/checks/mkDummySrcTests/workspace/expected/Cargo.toml
+++ b/checks/mkDummySrcTests/workspace/expected/Cargo.toml
@@ -1,2 +1,3 @@
 [workspace]
+resolver = "2"
 members = ["./member/qux"]

--- a/checks/mkDummySrcTests/workspace/input/Cargo.toml
+++ b/checks/mkDummySrcTests/workspace/input/Cargo.toml
@@ -1,2 +1,3 @@
 [workspace]
+resolver = "2"
 members = ["./member/qux"]

--- a/checks/with-libs/Cargo.toml
+++ b/checks/with-libs/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 package.version = "0.0.1"
 metadata.crane.name = "with-libs"
 members = [

--- a/checks/workspace-git/Cargo.toml
+++ b/checks/workspace-git/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 package.version = "0.0.1"
 metadata.crane.name = "workspace-git"
 members = [

--- a/checks/workspace-hack/Cargo.toml
+++ b/checks/workspace-hack/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 # NB: hello and world are intentionally left out cargo will
 # promote them to members since they are listed as path deps
 members = ["my-workspace-hack","print"]

--- a/checks/workspace-inheritance/Cargo.toml
+++ b/checks/workspace-inheritance/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 # NB: hello and world are intentionally left out cargo will
 # promote them to members since they are listed as path deps
 members = ["print"]

--- a/checks/workspace-not-at-root/workspace/Cargo.toml
+++ b/checks/workspace-not-at-root/workspace/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 # NB: hello and world are intentionally left out cargo will
 # promote them to members since they are listed as path deps
 members = ["print"]

--- a/checks/workspace-root/Cargo.toml
+++ b/checks/workspace-root/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 
 [package]
 name = "print"

--- a/checks/workspace/Cargo.toml
+++ b/checks/workspace/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 # NB: hello and world are intentionally left out cargo will
 # promote them to members since they are listed as path deps
 members = ["print"]

--- a/examples/trunk-workspace/Cargo.toml
+++ b/examples/trunk-workspace/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = [
   "shared",
   "client",


### PR DESCRIPTION
## Motivation

Cargo warns about workspaces not using `resolver = "2"` so we might as well be consistent everywhere

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [ ] updated `docs/API.md` (or general documentation) with changes
- [ ] updated `CHANGELOG.md`
