### PR TITLE
vendorCargoDeps: allow arbitrary overrides when vendoring sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * `crateNameFromCargoToml` now supports selecting a derivation name by setting
   `package.metadata.crane.name` or `workspace.metadata.crane.name` in the root
   `Cargo.toml`
+* `vendorCargoDeps`, `vendorCargoRegistries`, `vendorGitDeps`, and
+  `vendorMultipleCargoDeps` now support arbitrary overrides (i.e. patching) at
+  the individual crate/repo level when vendoring sources.
 
 ### Changed
 * **Breaking** `cargoAudit` no longer accepts `cargoExtraArgs` (since it does

--- a/checks/cratePatching/0001-patch-test-repo.patch
+++ b/checks/cratePatching/0001-patch-test-repo.patch
@@ -1,0 +1,24 @@
+diff --git a/hello/src/lib.rs b/hello/src/lib.rs
+index 8fd0518..d9a3c40 100644
+--- a/hello/src/lib.rs
++++ b/hello/src/lib.rs
+@@ -1,3 +1,3 @@
+ pub fn hello() -> &'static str {
+-    "hello"
++    byteorder::patched_hello()
+ }
+diff --git a/world/src/common.txt b/world/src/common.txt
+deleted file mode 120000
+index 0f27b3e..0000000
+--- a/world/src/common.txt
++++ /dev/null
+@@ -1 +0,0 @@
+-../../common.txt
+\ No newline at end of file
+diff --git a/world/src/common.txt b/world/src/common.txt
+new file mode 100644
+index 0000000..e79a719
+--- /dev/null
++++ b/world/src/common.txt
+@@ -0,0 +1 @@
++crane!

--- a/checks/cratePatching/0002-patch-byteorder.patch
+++ b/checks/cratePatching/0002-patch-byteorder.patch
@@ -1,0 +1,16 @@
+diff --git a/src/lib.rs b/src/lib.rs
+index cc37cca..ed2d091 100644
+--- a/src/lib.rs
++++ b/src/lib.rs
+@@ -70,6 +70,11 @@ cases.
+ #![deny(missing_docs)]
+ #![cfg_attr(not(feature = "std"), no_std)]
+ 
++/// A patched hello :)
++pub fn patched_hello() -> &'static str {
++    "greetings"
++}
++
+ use core::{
+     convert::TryInto, fmt::Debug, hash::Hash, ptr::copy_nonoverlapping, slice,
+ };

--- a/checks/cratePatching/default.nix
+++ b/checks/cratePatching/default.nix
@@ -1,0 +1,43 @@
+{ buildPackage
+, cleanCargoSource
+, lib
+, vendorCargoDeps
+, runCommand
+}:
+
+let
+  src = cleanCargoSource ../simple-git-workspace-inheritance;
+
+  isCraneTestRepo = lib.any (p: lib.hasPrefix "git+https://github.com/ipetkov/crane-test-repo.git#" p.source);
+  bin = buildPackage {
+    inherit src;
+    cargoVendorDir = vendorCargoDeps {
+      inherit src;
+      overrideVendorGitCheckout = ps: drv:
+        if isCraneTestRepo ps then
+          drv.overrideAttrs
+            (_old: {
+              patches = [
+                ./0001-patch-test-repo.patch
+              ];
+            })
+        else
+          drv;
+
+      overrideVendorCargoPackage = p: drv:
+        if p.name == "byteorder" then
+          drv.overrideAttrs
+            (_old: {
+              patches = [
+                ./0002-patch-byteorder.patch
+              ];
+            })
+        else
+          drv;
+    };
+  };
+in
+runCommand "runPatchedBin" { } ''
+  diff <(echo -e 'greetings, crane!\n') <(${bin}/bin/simple-git-workspace-inheritance)
+  touch $out
+''

--- a/checks/default.nix
+++ b/checks/default.nix
@@ -242,6 +242,8 @@ in
       })
     ];
 
+  cratePatching = callPackage ./cratePatching { };
+
   customCargoTargetDirectory =
     let
       simple = self.simple.overrideAttrs (_old: {
@@ -612,7 +614,7 @@ in
     inherit myLib;
   };
 
-  vendorCargoDeps =
+  vendorCargoDepsCombinations =
     let
       src = ./workspace;
       cargoLock = ./workspace/Cargo.lock;

--- a/docs/API.md
+++ b/docs/API.md
@@ -899,6 +899,21 @@ registry's API if necessary.
 * `source`: the source key recorded in the Cargo.lock file
 * `version`: the version of the crate
 
+#### Attributes of the vendor-prep derivation
+* `dontBuild`: `true`
+* `dontConfigure`: `true`
+* `pname`: `"cargo-package-"` suffixed by the package name in `Cargo.lock`
+* `version`: inherited from the package version in `Cargo.lock`
+* `unpackPhase`: This phase will:
+   1. run the `preUnpack` hook
+   1. unpack the crate's tarball to the current directory
+   1. run the `postUnpack` hook
+* `installPhase`: This phase will:
+   1. run the `preInstall` hook
+   1. move the contents of the current directory to `$out`
+   1. populate `$out/.cargo-checksum.json`
+   1. run the `postInstall` hook
+
 ### `craneLib.downloadCargoPackageFromGit`
 
 `downloadCargoPackageFromGit :: set -> drv`

--- a/docs/API.md
+++ b/docs/API.md
@@ -1360,6 +1360,24 @@ raised during evaluation.
 * `outputHashes`: a mapping of package-source to the sha256 of the (unpacked)
   download. Useful for supporting fully offline evaluations.
   - Default value: `[]`
+* `overrideVendorCargoPackage`: a function that will be called on every crate
+  vendored from a cargo registry, which allows for modifying the derivation
+  which will unpack the cargo tarball (e.g. to patch the crate source).
+  It will be called with the following parameters:
+  1. The `Cargo.lock` entry for that package (to allow conditional overrides
+     based on the package name/version/source, etc.)
+  1. The default `downloadCargoPackage` derivation
+  - Default value: `_p: drv: drv`
+* `overrideVendorGitCheckout`: a function that will be called on every unique
+  checkout vendored from a git repository, which allows for modifying the
+  derivation which will unpack the cargo crates found in the checkout (e.g. to
+  patch the crate sources). It will be called with the following
+  parameters:
+  1. A list of the `Cargo.lock` entries for each package which shares the same
+     repo URL and revision to checkout (to allow conditional overrides based on
+     the repo/checkout etc.)
+  1. The default `downloadCargoPackageFromGit` derivation
+  - Default value: `_ps: drv: drv`
 
 ### `craneLib.vendorCargoRegistries`
 
@@ -1377,6 +1395,14 @@ cargo can use for subsequent builds without needing network access.
 * `cargoConfigs`: a list of paths to all `.cargo/config.toml` files which may
   appear in the project. Ignored if `registries` is set.
   - Default value: `[]`
+* `overrideVendorCargoPackage`: a function that will be called on every crate
+  vendored from a cargo registry, which allows for modifying the derivation
+  which will unpack the cargo tarball (e.g. to patch the crate source).
+  It will be called with the following parameters:
+  1. The `Cargo.lock` entry for that package (to allow conditional overrides
+     based on the package name/version/source, etc.)
+  1. The default `downloadCargoPackage` derivation
+  - Default value: `_p: drv: drv`
 * `registries`: an attrset of registry names to their index URL. The default
   ("crates-io") registry need not be specified, as it will automatically be
   available, but it can be overridden if required.
@@ -1406,6 +1432,16 @@ access.
 * `outputHashes`: a mapping of package-source to the sha256 of the (unpacked)
   download. Useful for supporting fully offline evaluations.
   - Default value: `[]`
+* `overrideVendorGitCheckout`: a function that will be called on every unique
+  checkout vendored from a git repository, which allows for modifying the
+  derivation which will unpack the cargo crates found in the checkout (e.g. to
+  patch the crate sources). It will be called with the following
+  parameters:
+  1. A list of the `Cargo.lock` entries for each package which shares the same
+     repo URL and revision to checkout (to allow conditional overrides based on
+     the repo/checkout etc.)
+  1. The default `downloadCargoPackageFromGit` derivation
+  - Default value: `_ps: drv: drv`
 
 #### Output attributes
 * `config`: the configuration entires needed to point cargo to the vendored
@@ -1446,6 +1482,24 @@ the vendored directories (i.e. this configuration can be appended to the
 * `outputHashes`: a mapping of package-source to the sha256 of the (unpacked)
   download. Useful for supporting fully offline evaluations.
   - Default value: `[]`
+* `overrideVendorCargoPackage`: a function that will be called on every crate
+  vendored from a cargo registry, which allows for modifying the derivation
+  which will unpack the cargo tarball (e.g. to patch the crate source).
+  It will be called with the following parameters:
+  1. The `Cargo.lock` entry for that package (to allow conditional overrides
+     based on the package name/version/source, etc.)
+  1. The default `downloadCargoPackage` derivation
+  - Default value: `_p: drv: drv`
+* `overrideVendorGitCheckout`: a function that will be called on every unique
+  checkout vendored from a git repository, which allows for modifying the
+  derivation which will unpack the cargo crates found in the checkout (e.g. to
+  patch the crate sources). It will be called with the following
+  parameters:
+  1. A list of the `Cargo.lock` entries for each package which shares the same
+     repo URL and revision to checkout (to allow conditional overrides based on
+     the repo/checkout etc.)
+  1. The default `downloadCargoPackageFromGit` derivation
+  - Default value: `_ps: drv: drv`
 * `registries`: an attrset of registry names to their index URL. The default
   ("crates-io") registry need not be specified, as it will automatically be
   available, but it can be overridden if required.

--- a/docs/API.md
+++ b/docs/API.md
@@ -937,6 +937,23 @@ any crates it contains for vendoring.
   (instead of `builtins.fetchGit`) which allows for offline evaluations.
   - Default value: `null`
 
+#### Attributes of the vendor-prep derivation
+* `dontBuild`: `true`
+* `dontConfigure`: `true`
+* `installPhase`: This phase will:
+   1. run the `preInstall` hook
+   1. Prepare the current directory for vendoring by:
+      - Searching for all `Cargo.toml` files
+      - Copying their parent directory to `$out/$crate` (where `$crate` is the
+        package name and version as defined in `Cargo.toml`)
+      - Populating `.cargo-checksum.json`
+      - Running `crane-resolve-workspace-inheritance` on the `Cargo.toml`
+      - Note that duplicate crates (whose name and version collide) are ignored
+   1. run the `postInstall` hook
+* `nativeBuildInputs`: A list of the `cargo`, `craneUtils`, and `jq` packages
+* `name`: set to `"cargo-git"`
+* `src`: the git repo checkout, as determined by the input parameters
+
 ### `craneLib.findCargoFiles`
 
 `findCargoFiles :: path -> set of lists`

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -26,6 +26,7 @@
 * [Custom cargo commands](./custom_cargo_commands.md)
 * [Customizing builds](./customizing_builds.md)
 * [Overriding derivations after the fact](./overriding_derivations.md)
+* [Patching sources of dependencies](./patching_dependency_sources.md)
 ---
 - [API Reference](./API.md)
 ---

--- a/docs/patching_dependency_sources.md
+++ b/docs/patching_dependency_sources.md
@@ -1,0 +1,71 @@
+## Patching sources of dependency crates
+
+Sometimes it is useful to patch the sources of dependency crates without needing
+to wait for an upstream release to include a necessary change, or without
+needing to use a custom git fork.
+
+The `vendorCargoDeps`, `vendorCargoRegistries`, `vendorGitDeps`, and
+`vendorMultipleCargoDeps` APIs support arbitrary overrides (i.e. patching) at
+the individual crate/repo level when vendoring sources. Checkout their
+respective API documentation for more details, but below is a short quick start
+example:
+
+```nix
+let
+  baseArgs = {
+    src = craneLib.cleanCargoSource ./.;
+  };
+
+  isNumCpusRepo = p: lib.hasPrefix
+      "git+https://github.com/seanmonstar/num_cpus.git"
+      p.source;
+  isTag1_13_1 = p: lib.hasInfix
+      "tag=v1.13.1"
+      p.source;
+
+  cargoVendorDir = craneLib.vendorCargoDeps (baseArgs // {
+    # Use this function to override crates coming from git dependencies
+    overrideVendorGitCheckout = ps: drv:
+      # For example, patch a specific repository and tag, in this case num_cpus-1.13.1
+      if lib.any (p: (isNumCpusRepo p) && (isTag1_13_1 p)) ps then
+        drv.overrideAttrs (_old: {
+          # Specifying an arbitrary patch to apply
+          patches = [
+            ./0001-patch-num-cpus.patch
+          ];
+
+          # Similarly we can also run additional hooks to make changes
+          postPatch = ''
+            echo running some arbitrary command to make modifications
+          '';
+        })
+      else
+        # Nothing to change, leave the derivations as is
+        drv;
+
+    # Use this function to override crates coming from any registry checkout
+    overrideVendorCargoPackage = p: drv:
+      # For example, patch a specific crate, in this case byteorder-1.5.0
+      if p.name == "byteorder" && p.version == "1.5.0" then
+        drv.overrideAttrs (_old: {
+          # Specifying an arbitrary patch to apply
+          patches = [
+            ./0001-patch-byteorder.patch
+          ];
+
+          # Similarly we can also run additional hooks to make changes
+          postPatch = ''
+            echo running some arbitrary command to make modifications
+          '';
+        })
+      else
+        # Nothing to change, leave the derivations as is
+        drv;
+  });
+
+  commonArgs = baseArgs // {
+    inherit cargoVendorDir;
+  };
+in
+craneLib.buildPackage commonArgs
+```

--- a/lib/downloadCargoPackage.nix
+++ b/lib/downloadCargoPackage.nix
@@ -5,7 +5,7 @@
 let
   inherit (pkgsBuildBuild)
     fetchurl
-    runCommand;
+    stdenv;
 in
 { name
 , version
@@ -20,8 +20,25 @@ let
     sha256 = checksum;
   });
 in
-runCommand "cargo-package-${name}-${version}" { } ''
-  mkdir -p $out
-  tar -xzf ${tarball} -C $out --strip-components=1
-  echo '{"files":{}, "package":"${checksum}"}' > $out/.cargo-checksum.json
-''
+stdenv.mkDerivation {
+  inherit version;
+  pname = "cargo-package-${name}";
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  unpackPhase = ''
+    runHook preUnpack
+    mkdir -p crate
+    tar -xzf ${tarball} --strip-components=1
+    runHook postUnpack
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out
+    cp -r -t $out .
+    echo '{"files":{}, "package":"${checksum}"}' > $out/.cargo-checksum.json
+    runHook postInstall
+  '';
+}

--- a/lib/vendorCargoDeps.nix
+++ b/lib/vendorCargoDeps.nix
@@ -42,4 +42,6 @@ vendorMultipleCargoDeps ({
   inherit cargoConfigs;
   cargoLockParsedList = [ lock ];
   outputHashes = args.outputHashes or { };
+  overrideVendorCargoPackage = args.overrideVendorCargoPackage or (_: drv: drv);
+  overrideVendorGitCheckout = args.overrideVendorGitCheckout or (_: drv: drv);
 } // optionalAttrs (args ? registries) { inherit (args) registries; })

--- a/lib/vendorCargoRegistries.nix
+++ b/lib/vendorCargoRegistries.nix
@@ -38,6 +38,7 @@ let
 in
 { cargoConfigs ? [ ]
 , lockPackages
+, overrideVendorCargoPackage ? _: drv: drv
 , ...
 }@args:
 let
@@ -48,10 +49,11 @@ let
     lockPackages;
   lockedRegistryGroups = groupBy (p: p.source) lockedPackagesFromRegistry;
 
+  vendorCrate = p: overrideVendorCargoPackage p (downloadCargoPackage p);
   vendorSingleRegistry = packages: runCommandLocal "vendor-registry" { } ''
     mkdir -p $out
     ${concatMapStrings (p: ''
-      ln -s ${escapeShellArg (downloadCargoPackage p)} $out/${escapeShellArg "${p.name}-${p.version}"}
+      ln -s ${escapeShellArg (vendorCrate p)} $out/${escapeShellArg "${p.name}-${p.version}"}
     '') packages}
   '';
 

--- a/lib/vendorMultipleCargoDeps.nix
+++ b/lib/vendorMultipleCargoDeps.nix
@@ -32,6 +32,8 @@ in
 , cargoLockList ? [ ]
 , cargoLockParsedList ? [ ]
 , outputHashes ? { }
+, overrideVendorCargoPackage ? _: drv: drv
+, overrideVendorGitCheckout ? _: drv: drv
 , registries ? null
 }:
 let
@@ -59,11 +61,11 @@ let
   )));
 
   vendoredRegistries = vendorCargoRegistries ({
-    inherit cargoConfigs lockPackages;
+    inherit cargoConfigs lockPackages overrideVendorCargoPackage;
   } // optionalAttrs (registries != null) { inherit registries; });
 
   vendoredGit = vendorGitDeps {
-    inherit lockPackages outputHashes;
+    inherit lockPackages outputHashes overrideVendorGitCheckout;
   };
 
   linkSources = sources: concatMapStrings


### PR DESCRIPTION
## Motivation

This change adds support to `vendorCargoDeps` (and friends) to allow overriding (i.e. patching) any arbitrary crate's sources, whether they are being vendored from a cargo registry or from a git repo

Fixes https://github.com/ipetkov/crane/issues/473

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [x] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [x] updated `docs/API.md` (or general documentation) with changes
- [x] updated `CHANGELOG.md`
