### PR TITLE
buildTrunkPackage: disable version checks by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * **Breaking** `cargoAudit` no longer accepts `cargoExtraArgs` (since it does
   not support the regular set of `cargo` flags like most cargo-commands do, it
   does not make much sense to propagate those flags through)
+* `buildTrunkPackage` now sets `env.TRUNK_SKIP_VERSION_CHECK = "true";` if not
+  specified
 
 ### Deprecations
 * In the future, `crateNameFromCargoToml` will stop considering

--- a/checks/trunk-outdated-bindgen/index.html
+++ b/checks/trunk-outdated-bindgen/index.html
@@ -4,4 +4,7 @@
     <meta charset="utf-8" />
     <title>Trunk App</title>
   </head>
+  <body>
+    <p>Hello world!</p>
+  </body>
 </html>

--- a/checks/trunk/index.html
+++ b/checks/trunk/index.html
@@ -5,4 +5,7 @@
     <title>Trunk App</title>
     <link data-trunk rel="scss" href="./main.scss" />
   </head>
+  <body>
+    <p>Hello world!</p>
+  </body>
 </html>

--- a/examples/trunk-workspace/client/index.html
+++ b/examples/trunk-workspace/client/index.html
@@ -5,4 +5,7 @@
     <title>Trunk App</title>
     <link data-trunk rel="scss" href="./main.scss" />
   </head>
+  <body>
+    <p>Hello world!</p>
+  </body>
 </html>

--- a/examples/trunk/index.html
+++ b/examples/trunk/index.html
@@ -5,4 +5,7 @@
     <title>Trunk App</title>
     <link data-trunk rel="scss" href="./main.scss" />
   </head>
+  <body>
+    <p>Hello world!</p>
+  </body>
 </html>

--- a/lib/buildTrunkPackage.nix
+++ b/lib/buildTrunkPackage.nix
@@ -63,6 +63,8 @@ mkCargoDerivation (args // {
     doCheck = args.doCheck or false;
   }));
 
+  env.TRUNK_SKIP_VERSION_CHECK = args.env.TRUNK_SKIP_VERSION_CHECK or "true";
+
   # Force trunk to not download dependencies, but set the version with
   # whatever tools actually make it into the builder's PATH
   preConfigure = ''


### PR DESCRIPTION
## Motivation

Looks like the latest `trunk` version crashes if the network is inaccessible and version checks aren't disabled

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [ ] updated `docs/API.md` (or general documentation) with changes
- [x] updated `CHANGELOG.md`
