### PR TITLE
flake: deprecate crane.lib.${system}

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   `workspace.package.name` in the root `Cargo.toml` when determining the crate
   name. This attribute is not recognized by cargo (which will emit its own
   warnings about it) and should be avoided going forward.
+* In the future, `crane.lib.${system}` will be removed. Please switch to using
+  `(crane.mkLib nixpkgs.lib.${system})` as an equivalent alternative.
 
 ## [0.16.6] - 2024-05-04
 

--- a/docs/faq/custom-nixpkgs.md
+++ b/docs/faq/custom-nixpkgs.md
@@ -40,7 +40,7 @@ docs](../API.md) for `mkLib`/`overrideToolchain`, or checkout the
 [custom-toolchain](../../examples/custom-toolchain) example.
 
 ```nix
-crane.lib.${system}.overrideScope (final: prev: {
+(crane.mkLib pkgs).overrideScope (final: prev: {
   cargo-tarpaulin = myCustomCargoTarpaulinVersion;
 })
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -46,7 +46,8 @@ following contents at the root of your cargo workspace:
   outputs = { self, nixpkgs, crane, flake-utils, ... }:
     flake-utils.lib.eachDefaultSystem (system:
       let
-        craneLib = crane.lib.${system};
+        pkgs = nixpkgs.legacyPackages.${system};
+        craneLib = crane.mkLib pkgs;
       in
     {
       packages.default = craneLib.buildPackage {

--- a/docs/introduction/artifact-reuse.md
+++ b/docs/introduction/artifact-reuse.md
@@ -27,11 +27,8 @@ Here's how we can set up our flake to achieve our goals:
   outputs = { self, nixpkgs, crane, flake-utils, ... }:
     flake-utils.lib.eachDefaultSystem (system:
       let
-        pkgs = import nixpkgs {
-          inherit system;
-        };
-
-        craneLib = crane.lib.${system};
+        pkgs = nixpkgs.legacyPackages.${system};
+        craneLib = crane.mkLib pkgs;
 
         # Common derivation arguments used for all builds
         commonArgs = {

--- a/docs/introduction/sequential-builds.md
+++ b/docs/introduction/sequential-builds.md
@@ -19,11 +19,9 @@ build.
   outputs = { self, nixpkgs, crane, flake-utils, ... }:
     flake-utils.lib.eachDefaultSystem (system:
       let
-        pkgs = import nixpkgs {
-          inherit system;
-        };
+        pkgs = nixpkgs.legacyPackages.${system};
+        craneLib = crane.mkLib pkgs;
 
-        craneLib = crane.lib.${system};
         # Common derivation arguments used for all builds
         commonArgs = {
           src = craneLib.cleanCargoSource (craneLib.path ./.);

--- a/docs/local_development.md
+++ b/docs/local_development.md
@@ -30,11 +30,9 @@ Sample `flake.nix`:
   outputs = { self, nixpkgs, crane, flake-utils, ... }:
     flake-utils.lib.eachDefaultSystem (system:
       let
-        pkgs = import nixpkgs {
-          inherit system;
-        };
+        pkgs = nixpkgs.legacyPackages.${system};
+        craneLib = crane.mkLib pkgs;
 
-        craneLib = crane.lib.${system};
         my-crate = craneLib.buildPackage {
           src = craneLib.cleanCargoSource (craneLib.path ./.);
 

--- a/examples/alt-registry/flake.nix
+++ b/examples/alt-registry/flake.nix
@@ -19,7 +19,7 @@
       let
         pkgs = nixpkgs.legacyPackages.${system};
 
-        craneLibOrig = crane.lib.${system};
+        craneLibOrig = crane.mkLib pkgs;
         craneLib = craneLibOrig.appendCrateRegistries [
           # Automatically infer the download URL from the registry's index
           #

--- a/examples/quick-start-simple/flake.nix
+++ b/examples/quick-start-simple/flake.nix
@@ -17,7 +17,7 @@
       let
         pkgs = nixpkgs.legacyPackages.${system};
 
-        craneLib = crane.lib.${system};
+        craneLib = crane.mkLib pkgs;
 
         # Common arguments can be set here to avoid repeating them later
         # Note: changes here will rebuild all dependency crates

--- a/examples/quick-start-workspace/flake.nix
+++ b/examples/quick-start-workspace/flake.nix
@@ -30,7 +30,7 @@
 
         inherit (pkgs) lib;
 
-        craneLib = crane.lib.${system};
+        craneLib = crane.mkLib pkgs;
         src = craneLib.cleanCargoSource (craneLib.path ./.);
 
         # Common arguments can be set here to avoid repeating them later

--- a/examples/quick-start/flake.nix
+++ b/examples/quick-start/flake.nix
@@ -30,7 +30,7 @@
 
         inherit (pkgs) lib;
 
-        craneLib = crane.lib.${system};
+        craneLib = crane.mkLib pkgs;
         src = craneLib.cleanCargoSource (craneLib.path ./.);
 
         # Common arguments can be set here to avoid repeating them later

--- a/examples/sqlx/flake.nix
+++ b/examples/sqlx/flake.nix
@@ -19,7 +19,7 @@
 
         inherit (pkgs) lib;
 
-        craneLib = crane.lib.${system};
+        craneLib = crane.mkLib pkgs;
 
         sqlFilter = path: _type: null != builtins.match ".*sql$" path;
         sqlOrCargo = path: type: (sqlFilter path type) || (craneLib.filterCargoSources path type);

--- a/extra-tests/alt-store/flake.nix
+++ b/extra-tests/alt-store/flake.nix
@@ -5,9 +5,10 @@
     flake-utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = { flake-utils, crane, ... }: flake-utils.lib.eachDefaultSystem (system:
+  outputs = { nixpkgs, flake-utils, crane, ... }: flake-utils.lib.eachDefaultSystem (system:
     let
-      craneLib = crane.lib.${system};
+      pkgs = nixpkgs.legacyPackages.${system};
+      craneLib = crane.mkLib pkgs;
     in
     {
       # https://github.com/ipetkov/crane/issues/446

--- a/extra-tests/dummy-does-not-depend-on-flake-source-via-path/flake.nix
+++ b/extra-tests/dummy-does-not-depend-on-flake-source-via-path/flake.nix
@@ -5,9 +5,13 @@
     flake-utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = { flake-utils, crane, ... }: flake-utils.lib.eachDefaultSystem
-    (system: {
-      packages.dummy = crane.lib.${system}.mkDummySrc {
+  outputs = { nixpkgs, flake-utils, crane, ... }: flake-utils.lib.eachDefaultSystem (system:
+    let
+      pkgs = nixpkgs.legacyPackages.${system};
+      craneLib = crane.mkLib pkgs;
+    in
+    {
+      packages.dummy = craneLib.mkDummySrc {
         src = ./.;
       };
     });

--- a/extra-tests/dummy-does-not-depend-on-flake-source-via-self/flake.nix
+++ b/extra-tests/dummy-does-not-depend-on-flake-source-via-self/flake.nix
@@ -5,9 +5,13 @@
     flake-utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = { self, flake-utils, crane, ... }: flake-utils.lib.eachDefaultSystem
-    (system: {
-      packages.dummy = crane.lib.${system}.mkDummySrc {
+  outputs = { self, nixpkgs, flake-utils, crane, ... }: flake-utils.lib.eachDefaultSystem (system:
+    let
+      pkgs = nixpkgs.legacyPackages.${system};
+      craneLib = crane.mkLib pkgs;
+    in
+    {
+      packages.dummy = craneLib.mkDummySrc {
         src = self;
       };
     });

--- a/extra-tests/fetch-cargo-git/flake.nix
+++ b/extra-tests/fetch-cargo-git/flake.nix
@@ -1,12 +1,13 @@
 {
   inputs = {
     crane.url = "github:ipetkov/crane";
+    nixpkgs.follows = "crane/nixpkgs";
     flake-utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = { flake-utils, crane, ... }: flake-utils.lib.eachDefaultSystem
-    (_: {
-      packages.cargo-git = crane.lib.x86_64-linux.downloadCargoPackageFromGit {
+  outputs = { nixpkgs, flake-utils, crane, ... }: flake-utils.lib.eachDefaultSystem
+    (system: {
+      packages.cargo-git = (crane.mkLib nixpkgs.legacyPackages.${system}).downloadCargoPackageFromGit {
         git = "https://github.com/rust-lang/cargo";
         rev = "17f8088d6eafd82349630a8de8cc6efe03abf5fb";
       };

--- a/flake.nix
+++ b/flake.nix
@@ -115,7 +115,9 @@
         pkgs = nixpkgs.legacyPackages.${system};
 
         # To override do: lib.overrideScope (self: super: { ... });
-        lib = mkLib pkgs;
+        lib = pkgs.lib.warn
+          "`crane.lib.\${system}` is deprecated. please use `(crane.mkLib nixpkgs.legacyPackages.\${system})` instead"
+          (mkLib pkgs);
 
         checks =
           let


### PR DESCRIPTION
## Motivation

Most of our examples already indicate using `crane.mkLib` since that's the _generally correct_ thing to do regardless of whether `nixpkgs.legacyPackages` is what the caller wants or if they want to customize their `pkgs` instantiation (with overlays, or a cross build system, or both).

Not to mention that `crane.lib.${system}` is a bit of a footgun if you forget to set `crane.inputs.nixpkgs.follows = "nixpkgs"`. Although we have automation in place to keep the flake.lock updated, it's still possible to land in a confusing situation unless you are intimately familiar with how all your flake's inputs are wrangled...

I think long term it makes the most sense/least confusion to stick with a bring-your-own-nixpkgs workflow

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [ ] added tests to verify new behavior
- [x] added an example template or updated an existing one
- [ ] updated `docs/API.md` (or general documentation) with changes
- [x] updated `CHANGELOG.md`
