### PR TITLE
Parallelize removeReferencesToVendoredSources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Added
+* `removeReferencesToVendoredSourcesHook` now processes multiple files in
+  parallel, speeding up builds
+
 ## [0.17.1] - 2024-05-19
 
 ### Fixed

--- a/lib/setupHooks/removeReferencesToVendoredSources.nix
+++ b/lib/setupHooks/removeReferencesToVendoredSources.nix
@@ -2,6 +2,7 @@
 , makeSetupHook
 , pkgsBuildBuild
 , stdenv
+, parallel
 }:
 
 let
@@ -10,6 +11,7 @@ in
 makeSetupHook
 {
   name = "removeReferencesToVendoredSourcesHook";
+  propagatedBuildInputs = [parallel];
   substitutions = {
     storeDir = builtins.storeDir;
     sourceSigningUtils = lib.optionalString darwinCodeSign ''

--- a/lib/setupHooks/removeReferencesToVendoredSourcesHook.sh
+++ b/lib/setupHooks/removeReferencesToVendoredSourcesHook.sh
@@ -4,8 +4,10 @@ removeReferencesToVendoredSources() {
   local installLocation="${1:-${out:?not defined}}"
   local vendoredDir="${2:-${cargoVendorDir:?not defined}}"
 
-  local installedFile
-  while read installedFile; do
+  removeReferencesInOneFile() {
+    local vendoredDir="${1}"
+    local installedFile="${2}"
+
     echo stripping references to cargoVendorDir from "${installedFile}"
     time sed -i'' "${installedFile}" -f <(
       echo -n 's!@storeDir@/\(eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee'
@@ -28,7 +30,12 @@ removeReferencesToVendoredSources() {
     )
 
     @signIfRequired@
-  done < <(find "${installLocation}" -type f)
+  }
+
+  # Allow GNU parallel to see the function
+  export -f removeReferencesInOneFile
+
+  find "${installLocation}" -type f | parallel removeReferencesInOneFile "${vendoredDir}"
 }
 
 @sourceSigningUtils@


### PR DESCRIPTION
## Motivation
Closes #620 by using GNU `parallel` to remove references to vendored sources in multiple files at once.

## Checklist
- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [ ] updated `docs/API.md` (or general documentation) with changes
- [X] updated `CHANGELOG.md`