### PR TITLE
removeReferencesToVendoredSources: cache vendorDir crawling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Fixed
+* `removeReferencesToVendoredSources` has been optimzed to search for source
+  references only once. For derivations which install many files, this phase can
+  run up to 99% faster than before.
+
 ## [0.17.1] - 2024-05-19
 
 ### Fixed

--- a/lib/setupHooks/removeReferencesToVendoredSources.nix
+++ b/lib/setupHooks/removeReferencesToVendoredSources.nix
@@ -17,9 +17,17 @@ makeSetupHook
     '';
     signIfRequired = lib.optionalString darwinCodeSign ''
       if [ -n "''${doNotSign-}" ]; then
-        echo "not signing ''${installedFile} as requested";
+        echo "not signing as requested";
       else
-        signIfRequired "''${installedFile}"
+        (
+          exec 3>&1
+          echo signing files:
+          find "''${installLocation}" -type f |
+            sort |
+            tee -a /dev/fd/3 |
+            xargs --no-run-if-empty signIfRequired
+          echo signing done
+        )
       fi
     '';
   };

--- a/lib/setupHooks/removeReferencesToVendoredSourcesHook.sh
+++ b/lib/setupHooks/removeReferencesToVendoredSourcesHook.sh
@@ -4,34 +4,32 @@ removeReferencesToVendoredSources() {
   local installLocation="${1:-${out:?not defined}}"
   local vendoredDir="${2:-${cargoVendorDir:?not defined}}"
 
-  local sedScript="$(mktemp removeReferencesScriptXXXX)"
-  (
-    echo -n 's!@storeDir@/\(eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee'
-
-    (
-      # Include the root of the vendor dir itself
-      echo "${vendoredDir}"
-
-      # Include the individual crates themselves in case
-      # something else slips in a reference to them
-      find -L "${vendoredDir}" -mindepth 1 -maxdepth 1 -type d | \
-        xargs -I DIR find -H DIR -type l -exec readlink '{}' \;
-    ) |
-      grep --only-matching '@storeDir@/[a-z0-9]\{32\}' |
-      while read crateSource; do
-        echo -n '\|'"${crateSource#@storeDir@/}";
-      done
-
-    echo -n '\)!@storeDir@/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee!g'
-  ) >"${sedScript}"
-
   (
     exec 3>&1
     echo stripping references to cargoVendorDir from:
     find "${installLocation}" -type f |
       sort |
       tee -a /dev/fd/3 |
-      xargs --no-run-if-empty sed -i'' -f "${sedScript}"
+      xargs --no-run-if-empty sed -i'' -f <(
+        echo -n 's!@storeDir@/\(eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee'
+
+        (
+          # Include the root of the vendor dir itself
+          echo "${vendoredDir}"
+
+          # Include the individual crates themselves in case
+          # something else slips in a reference to them
+          find -L "${vendoredDir}" -mindepth 1 -maxdepth 1 -type d | \
+            xargs -I DIR find -H DIR -type l -exec readlink '{}' \;
+        ) |
+          grep --only-matching '@storeDir@/[a-z0-9]\{32\}' |
+          while read crateSource; do
+            echo -n '\|'"${crateSource#@storeDir@/}";
+          done
+
+        echo -n '\)!@storeDir@/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee!g'
+      )
+
     echo stripping references done
   )
 

--- a/lib/setupHooks/removeReferencesToVendoredSourcesHook.sh
+++ b/lib/setupHooks/removeReferencesToVendoredSourcesHook.sh
@@ -4,31 +4,34 @@ removeReferencesToVendoredSources() {
   local installLocation="${1:-${out:?not defined}}"
   local vendoredDir="${2:-${cargoVendorDir:?not defined}}"
 
-  local installedFile
-  while read installedFile; do
-    echo stripping references to cargoVendorDir from "${installedFile}"
-    time sed -i'' "${installedFile}" -f <(
-      echo -n 's!@storeDir@/\(eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee'
+  local sedScript="$(mktemp removeReferencesScriptXXXX)"
+  (
+    echo -n 's!@storeDir@/\(eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee'
 
+    (
+      # Include the root of the vendor dir itself
+      echo "${vendoredDir}"
+
+      # Include the individual crates themselves in case
+      # something else slips in a reference to them
+      find -L "${vendoredDir}" -mindepth 1 -maxdepth 1 -type d | \
+        xargs -I DIR find -H DIR -type l -exec readlink '{}' \;
+    ) |
+      grep --only-matching '@storeDir@/[a-z0-9]\{32\}' |
       while read crateSource; do
         echo -n '\|'"${crateSource#@storeDir@/}";
-      done < <(
-        (
-          # Include the root of the vendor dir itself
-          echo "${vendoredDir}"
+      done
 
-          # Include the individual crates themselves in case
-          # something else slips in a reference to them
-          find -L "${vendoredDir}" -mindepth 1 -maxdepth 1 -type d | \
-            xargs -I DIR find -H DIR -type l -exec readlink '{}' \;
-        ) | grep --only-matching '@storeDir@/[a-z0-9]\{32\}'
-      )
+    echo -n '\)!@storeDir@/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee!g'
+  ) >"${sedScript}"
 
-      echo -n '\)!@storeDir@/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee!g'
-    )
+  local installedFile
+  find "${installLocation}" -type f | while read installedFile; do
+    echo stripping references to cargoVendorDir from "${installedFile}"
+    sed -i'' "${installedFile}" -f "${sedScript}"
 
     @signIfRequired@
-  done < <(find "${installLocation}" -type f)
+  done
 }
 
 @sourceSigningUtils@

--- a/lib/setupHooks/removeReferencesToVendoredSourcesHook.sh
+++ b/lib/setupHooks/removeReferencesToVendoredSourcesHook.sh
@@ -25,13 +25,17 @@ removeReferencesToVendoredSources() {
     echo -n '\)!@storeDir@/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee!g'
   ) >"${sedScript}"
 
-  local installedFile
-  find "${installLocation}" -type f | while read installedFile; do
-    echo stripping references to cargoVendorDir from "${installedFile}"
-    sed -i'' "${installedFile}" -f "${sedScript}"
+  (
+    exec 3>&1
+    echo stripping references to cargoVendorDir from:
+    find "${installLocation}" -type f |
+      sort |
+      tee -a /dev/fd/3 |
+      xargs --no-run-if-empty sed -i'' -f "${sedScript}"
+    echo stripping references done
+  )
 
-    @signIfRequired@
-  done
+  @signIfRequired@
 }
 
 @sourceSigningUtils@


### PR DESCRIPTION
## Motivation
There is no reason to repeatedly crawl the vendor directories for each installed file, we can easily cache the results once up front.

Fixes https://github.com/ipetkov/crane/issues/620

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [ ] updated `docs/API.md` (or general documentation) with changes
- [x] updated `CHANGELOG.md`
