### PR TITLE
Fix `xargs signIfRequired`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Fixed
+* `removeReferencesToVendoredSources` correctly signs aarch64-darwin builds
+  (which was accidentally broken in 0.17.2)
+
 ## [0.17.2] - 2024-05-26
 
 ### Fixed

--- a/lib/setupHooks/removeReferencesToVendoredSources.nix
+++ b/lib/setupHooks/removeReferencesToVendoredSources.nix
@@ -22,10 +22,10 @@ makeSetupHook
         (
           exec 3>&1
           echo signing files:
-          find "''${installLocation}" -type f |
-            sort |
-            tee -a /dev/fd/3 |
-            xargs --no-run-if-empty signIfRequired
+          while IFS= read -r -d $'\0' file; do
+            echo "signing: $file"
+            signIfRequired "$file"
+          done < <(find "''${installLocation}" -type f -print0)
           echo signing done
         )
       fi

--- a/lib/setupHooks/removeReferencesToVendoredSources.nix
+++ b/lib/setupHooks/removeReferencesToVendoredSources.nix
@@ -19,15 +19,12 @@ makeSetupHook
       if [ -n "''${doNotSign-}" ]; then
         echo "not signing as requested";
       else
-        (
-          exec 3>&1
-          echo signing files:
-          while IFS= read -r -d $'\0' file; do
-            echo "signing: $file"
-            signIfRequired "$file"
-          done < <(find "''${installLocation}" -type f -print0)
-          echo signing done
-        )
+        echo signing files:
+        while IFS= read -r -d $'\0' file; do
+          echo "signing: $file"
+          signIfRequired "$file"
+        done < <(find "''${installLocation}" -type f -print0)
+        echo signing done
       fi
     '';
   };


### PR DESCRIPTION
## Motivation

Fixes a bug introduced with #625.

`signIfRequired` is a shell function, not an executable, so we can't call it with `xargs`.

https://github.com/NixOS/nixpkgs/blob/7187b3ee8e2687106e8982b02d2890689471579e/pkgs/os-specific/darwin/signing-utils/utils.sh#L38-L43

```
xargs: signIfRequired: No such file or directory
```

Uses this approach:

https://github.com/NixOS/nixpkgs/blob/7187b3ee8e2687106e8982b02d2890689471579e/pkgs/os-specific/darwin/signing-utils/auto-sign-hook.sh#L19-L21

Tested locally with my build.

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [ ] updated `docs/API.md` (or general documentation) with changes
- [ ] updated `CHANGELOG.md`
