### PR TITLE
lib: use makeScopeWithSplicing' instead of makeScope

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,5 +1,13 @@
 { pkgs ? import <nixpkgs> { } }:
 
 import ./lib {
-  inherit (pkgs) lib newScope;
+  inherit (pkgs) lib makeScopeWithSplicing';
+  otherSplices = {
+    selfBuildBuild = pkgs.pkgsBuildBuild;
+    selfBuildHost = pkgs.pkgsBuildHost;
+    selfBuildTarget = pkgs.pkgsBuildTarget;
+    selfHostHost = pkgs.pkgsHostHost;
+    selfHostTarget = pkgs.pkgsHostTarget;
+    selfTargetTarget = pkgs.pkgsTargetTarget;
+  };
 }

--- a/examples/cross-rust-overlay/flake.nix
+++ b/examples/cross-rust-overlay/flake.nix
@@ -75,6 +75,7 @@
             # overridden above.
             nativeBuildInputs = [
               pkg-config
+              stdenv.cc
             ] ++ lib.optionals stdenv.buildPlatform.isDarwin [
               libiconv
             ];

--- a/flake.nix
+++ b/flake.nix
@@ -10,10 +10,9 @@
 
   outputs = { nixpkgs, ... }:
     let
-      mkLib = pkgs: import ./lib {
-        inherit (pkgs) lib newScope;
+      mkLib = pkgs: import ./default.nix {
+        inherit pkgs;
       };
-
       nodes = (builtins.fromJSON (builtins.readFile ./test/flake.lock)).nodes;
       inputFromLock = name:
         let

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -1,5 +1,6 @@
 { lib
-, newScope
+, makeScopeWithSplicing'
+, otherSplices
 }:
 
 let
@@ -7,8 +8,12 @@ let
   current = lib.concatStringsSep "." (lib.lists.sublist 0 2 (lib.splitVersion lib.version));
   isUnsupported = lib.versionOlder current minSupported;
   msg = "crane requires at least nixpkgs-${minSupported}, supplied nixpkgs-${current}";
+
+  mySplice = f: makeScopeWithSplicing' {
+    inherit otherSplices f;
+  };
 in
-lib.warnIf isUnsupported msg (lib.makeScope newScope (self:
+lib.warnIf isUnsupported msg (mySplice (self:
 let
   inherit (self) callPackage;
 

--- a/lib/downloadCargoPackageFromGit.nix
+++ b/lib/downloadCargoPackageFromGit.nix
@@ -1,12 +1,12 @@
 { lib
+, cargo
+, jq
 , pkgsBuildBuild
 }:
 
 let
   inherit (pkgsBuildBuild)
-    cargo
     fetchgit
-    jq
     stdenv;
 
   craneUtils = pkgsBuildBuild.callPackage ../pkgs/crane-utils { };
@@ -42,7 +42,7 @@ stdenv.mkDerivation {
   dontBuild = true;
   dontFixup = true;
 
-  nativeBuildInputs = [
+  depsBuildBuild = [
     cargo
     craneUtils
     jq


### PR DESCRIPTION
## Motivation

Use a spliced scope that better allows for (more correctly) controlling what tools are used where when cross compiling.

Fixes https://github.com/ipetkov/crane/issues/628
Possibly related to https://github.com/ipetkov/crane/issues/551, though I still could not resolve that one yet

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [ ] updated `docs/API.md` (or general documentation) with changes
- [ ] updated `CHANGELOG.md`
