### PR TITLE
Drop support for nixpkgs-23.11

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,8 +32,8 @@ jobs:
         include:
             # Latest and greatest release of Nix
           - install_url: https://nixos.org/nix/install
-            # The 23.11 branch ships with Nix 2.18.1
-          - install_url: https://releases.nixos.org/nix/nix-2.18.1/install
+            # The 24.05 branch ships with Nix 2.18.2
+          - install_url: https://releases.nixos.org/nix/nix-2.18.2/install
             nixpkgs-override: "--override-input nixpkgs $(./ci/ref-from-lock.sh ./test#nixpkgs)"
     runs-on: ubuntu-latest
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Changed
+* **Breaking**: dropped compatibility for Nix versions below 2.18.2
+* **Breaking**: dropped compatibility for nixpkgs-23.11.
+
 ## [0.17.3] - 2024-06-02
 
 ### Fixed

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -4,7 +4,7 @@
 }:
 
 let
-  minSupported = "23.11";
+  minSupported = "24.05";
   current = lib.concatStringsSep "." (lib.lists.sublist 0 2 (lib.splitVersion lib.version));
   isUnsupported = lib.versionOlder current minSupported;
   msg = "crane requires at least nixpkgs-${minSupported}, supplied nixpkgs-${current}";

--- a/test/flake.lock
+++ b/test/flake.lock
@@ -93,32 +93,32 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1716563126,
-        "narHash": "sha256-Gf/ATUZ2Oa9GaAZADTIa6brhO55WKOuca+e3eLyMQ6M=",
+        "lastModified": 1717362802,
+        "narHash": "sha256-E2fIxlfUVjxJM+Rm7Y9c0xQjpzbCTTGgvViHy3tF7N8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8f2fa4e35c0257d5961ca0705a3d23ccdfc19e20",
+        "rev": "4e08cafd686c7b2a191a82e593762c3a095f88eb",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "release-23.11",
+        "ref": "release-24.05",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "nixpkgs-darwin": {
       "locked": {
-        "lastModified": 1716455754,
-        "narHash": "sha256-4A3/4reuRNe5n4X4foQfb1PTx+rdd4X5dmI8Mpv1UB0=",
+        "lastModified": 1717100421,
+        "narHash": "sha256-T+0Q1QHBDCoa4yBJrY7cG3vDEhqm4PwOLmNI6mzEwVc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bea35f40af16d5d5697a1733b91958596f0fad94",
+        "rev": "75000c2cf4422c8a1776284314921ac1289c02c9",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixpkgs-23.11-darwin",
+        "ref": "nixpkgs-24.05-darwin",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/test/flake.nix
+++ b/test/flake.nix
@@ -1,8 +1,8 @@
 {
   inputs = {
     # NB: nixpkgs-unstable testing will come from the root flake
-    nixpkgs.url = "github:NixOS/nixpkgs/release-23.11";
-    nixpkgs-darwin.url = "github:NixOS/nixpkgs/nixpkgs-23.11-darwin";
+    nixpkgs.url = "github:NixOS/nixpkgs/release-24.05";
+    nixpkgs-darwin.url = "github:NixOS/nixpkgs/nixpkgs-24.05-darwin";
 
     # The version of wasm-bindgen-cli needs to match the version in Cargo.lock
     # Update this to include the version you need


### PR DESCRIPTION
## Motivation
24.05 was recently released, 23.11 is deprecated and upstream support will be dropped soon

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [ ] updated `docs/API.md` (or general documentation) with changes
- [x] updated `CHANGELOG.md`
