### PR TITLE
Try to avoid IFD in `vendorCargoDeps` and `crateNameFromCargoToml`; also avoid recommending nesting `cleanCargoSource` and `path`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 * **Breaking**: dropped compatibility for Nix versions below 2.18.2
 * **Breaking**: dropped compatibility for nixpkgs-23.11.
+* The guidance around using (both) `cleanCargoSource` and `path` has been
+  updated. Namely, it is no longer necessary to call both (e.g.
+  `craneLib.cleanCargoSource (craneLib.path ./.)`): it is recommended to either
+  use `craneLib.cleanCargoSource ./.` directly (if the default source cleaning
+  is desired) or `craneLib.path ./.` (if not).
 
 ### Fixed
 * The cross compilation example also hows how to set the `TARGET_CC` environment

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 * The cross compilation example also hows how to set the `TARGET_CC` environment
   variable which may be required by some build scripts to function properly
+* `vendorCargoDeps` and `crateNameFromCargoToml` do their best to avoid IFD when
+  `src` is the result of `lib.cleanSourceWith` (and by extension
+  `cleanCargoSource`)
 
 ## [0.17.3] - 2024-06-02
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -741,7 +741,7 @@ written (which may want to also call `craneLib.filterCargoSources`) to achieve t
 desired behavior.
 
 ```nix
-craneLib.cleanCargoSource (craneLib.path ./.)
+craneLib.cleanCargoSource ./.
 ```
 
 ### `craneLib.cleanCargoToml`
@@ -983,8 +983,9 @@ will retain the following files from a given source:
 
 ```nix
 cleanSourceWith {
-  src = craneLib.path ./.;
+  src = ./.;
   filter = craneLib.filterCargoSources;
+  name = "source"; # Be reproducible, regardless of the directory name
 }
 ```
 
@@ -999,8 +1000,9 @@ let
     (markdownFilter path type) || (craneLib.filterCargoSources path type);
 in
 cleanSourceWith {
-  src = craneLib.path ./.;
+  src = ./.;
   filter = markdownOrCargo;
+  name = "source"; # Be reproducible, regardless of the directory name
 }
 ```
 

--- a/docs/advanced/overriding-function-behavior.md
+++ b/docs/advanced/overriding-function-behavior.md
@@ -31,11 +31,11 @@ in
     # Build two different workspaces with the modified behavior above
 
     foo = craneLib.buildPackage {
-      src = craneLib.cleanCargoSource (craneLib.path ./foo);
+      src = craneLib.cleanCargoSource ./foo;
     };
 
     bar = craneLib.buildPackage {
-      src = craneLib.cleanCargoSource (craneLib.path ./bar);
+      src = craneLib.cleanCargoSource ./bar;
     };
 }
 ```

--- a/docs/custom_cargo_commands.md
+++ b/docs/custom_cargo_commands.md
@@ -46,6 +46,6 @@ let
   });
 in
 cargoAwesome {
-  src = craneLib.cleanCargoSource (craneLib.path ./.);
+  src = craneLib.cleanCargoSource ./.;
 }
 ```

--- a/docs/customizing_builds.md
+++ b/docs/customizing_builds.md
@@ -34,7 +34,7 @@ and hooks to customize a particular build:
 
 ```nix
 craneLib.buildPackage {
-  src = craneLib.cleanCargoSource (craneLib.path ./.);
+  src = craneLib.cleanCargoSource ./.;
 
   # Define a list of function names to execute before the `configurePhase` runs
   preConfigurePhases = [

--- a/docs/faq/patching-cargo-lock.md
+++ b/docs/faq/patching-cargo-lock.md
@@ -29,7 +29,7 @@ craneLib.buildPackage {
     src = patchedCargoLock;
   };
 
-  src = craneLib.cleanCargoSource (craneLib.path ./.);
+  src = craneLib.cleanCargoSource ./.;
 
   patches = [
     ./update-cargo-lock.patch

--- a/docs/faq/workspace-not-at-source-root.md
+++ b/docs/faq/workspace-not-at-source-root.md
@@ -13,7 +13,7 @@ deeper directory:
 # ./nested/Cargo.lock
 # ./nested/src/*.rs
 craneLib.buildPackage {
- src = myLib.cleanCargoSource (craneLib.path ./.);
+ src = myLib.cleanCargoSource ./.;
  cargoLock = ./nested/Cargo.lock;
  cargoToml = ./nested/Cargo.toml;
  # Use a postUnpack hook to jump into our nested directory. This will work

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -51,7 +51,7 @@ following contents at the root of your cargo workspace:
       in
     {
       packages.default = craneLib.buildPackage {
-        src = craneLib.cleanCargoSource (craneLib.path ./.);
+        src = craneLib.cleanCargoSource ./.;
 
         # Add extra inputs here or any other derivation settings
         # doCheck = true;

--- a/docs/introduction/artifact-reuse.md
+++ b/docs/introduction/artifact-reuse.md
@@ -32,7 +32,7 @@ Here's how we can set up our flake to achieve our goals:
 
         # Common derivation arguments used for all builds
         commonArgs = {
-          src = craneLib.cleanCargoSource (craneLib.path ./.);
+          src = craneLib.cleanCargoSource ./.;
           strictDeps = true;
 
           buildInputs = with pkgs; [

--- a/docs/introduction/sequential-builds.md
+++ b/docs/introduction/sequential-builds.md
@@ -24,7 +24,7 @@ build.
 
         # Common derivation arguments used for all builds
         commonArgs = {
-          src = craneLib.cleanCargoSource (craneLib.path ./.);
+          src = craneLib.cleanCargoSource ./.;
           strictDeps = true;
 
           buildInputs = with pkgs; [

--- a/docs/local_development.md
+++ b/docs/local_development.md
@@ -34,7 +34,7 @@ Sample `flake.nix`:
         craneLib = crane.mkLib pkgs;
 
         my-crate = craneLib.buildPackage {
-          src = craneLib.cleanCargoSource (craneLib.path ./.);
+          src = craneLib.cleanCargoSource ./.;
 
           buildInputs = [
             # Add additional build inputs here

--- a/docs/overriding_derivations.md
+++ b/docs/overriding_derivations.md
@@ -25,7 +25,7 @@ does not alter the derivation's attributes_ directly:
 }:
 
 craneLib.buildPackage {
-  src = craneLib.cleanCargoSource (craneLib.path ./..);
+  src = craneLib.cleanCargoSource ./..;
   strictDeps = true;
   cargoExtraArgs =
       (lib.optionalString withFoo "--features foo") +
@@ -123,7 +123,7 @@ If you need to change behavior that way, consider using a combination of
 
         craneLib = crane.mkLib pkgs;
         my-crate = craneLib.buildPackage {
-          src = craneLib.cleanCargoSource (craneLib.path ./.);
+          src = craneLib.cleanCargoSource ./.;
           strictDeps = true;
         };
       in

--- a/docs/source-filtering.md
+++ b/docs/source-filtering.md
@@ -17,7 +17,7 @@ non-Rust/non-cargo related files. It can be used like so:
 ```nix
 craneLib.buildPackage {
   # other attributes omitted
-  src = craneLib.cleanCargoSource (craneLib.path ./.);
+  src = craneLib.cleanCargoSource ./.;
 }
 ```
 
@@ -37,8 +37,9 @@ in
 craneLib.buildPackage {
   # other attributes omitted
   src = lib.cleanSourceWith {
-    src = craneLib.path ./.; # The original, unfiltered source
+    src = ./.; # The original, unfiltered source
     filter = markdownOrCargo;
+    name = "source"; # Be reproducible, regardless of the directory name
   };
 }
 ```

--- a/examples/alt-registry/flake.nix
+++ b/examples/alt-registry/flake.nix
@@ -60,7 +60,7 @@
         ];
 
         my-crate = craneLib.buildPackage {
-          src = craneLib.cleanCargoSource (craneLib.path ./.);
+          src = craneLib.cleanCargoSource ./.;
           strictDeps = true;
 
           buildInputs = [

--- a/examples/build-std/flake.nix
+++ b/examples/build-std/flake.nix
@@ -39,7 +39,7 @@
         # our specific toolchain there.
         craneLib = (crane.mkLib pkgs).overrideToolchain rustToolchain;
 
-        src = craneLib.cleanCargoSource (craneLib.path ./.);
+        src = craneLib.cleanCargoSource ./.;
 
         my-crate = craneLib.buildPackage {
           inherit src;

--- a/examples/cross-musl/flake.nix
+++ b/examples/cross-musl/flake.nix
@@ -35,7 +35,7 @@
         craneLib = (crane.mkLib pkgs).overrideToolchain rustToolchain;
 
         my-crate = craneLib.buildPackage {
-          src = craneLib.cleanCargoSource (craneLib.path ./.);
+          src = craneLib.cleanCargoSource ./.;
           strictDeps = true;
 
           CARGO_BUILD_TARGET = "x86_64-unknown-linux-musl";

--- a/examples/cross-rust-overlay/flake.nix
+++ b/examples/cross-rust-overlay/flake.nix
@@ -55,7 +55,7 @@
           , stdenv
           }:
           craneLib.buildPackage {
-            src = craneLib.cleanCargoSource (craneLib.path ./.);
+            src = craneLib.cleanCargoSource ./.;
             strictDeps = true;
 
             # Build-time tools which are target agnostic. build = host = target = your-machine.

--- a/examples/cross-windows/flake.nix
+++ b/examples/cross-windows/flake.nix
@@ -32,7 +32,7 @@
         craneLib = (crane.mkLib pkgs).overrideToolchain toolchain;
 
         my-crate = craneLib.buildPackage {
-          src = craneLib.cleanCargoSource (craneLib.path ./.);
+          src = craneLib.cleanCargoSource ./.;
 
           strictDeps = true;
           doCheck = false;

--- a/examples/custom-toolchain/flake.nix
+++ b/examples/custom-toolchain/flake.nix
@@ -39,7 +39,7 @@
         craneLib = (crane.mkLib pkgs).overrideToolchain rustWithWasiTarget;
 
         my-crate = craneLib.buildPackage {
-          src = craneLib.cleanCargoSource (craneLib.path ./.);
+          src = craneLib.cleanCargoSource ./.;
           strictDeps = true;
 
           cargoExtraArgs = "--target wasm32-wasi";

--- a/examples/end-to-end-testing/flake.nix
+++ b/examples/end-to-end-testing/flake.nix
@@ -29,7 +29,7 @@
 
         rustToolchain = pkgs.rust-bin.stable.latest.default;
         craneLib = (crane.mkLib pkgs).overrideToolchain rustToolchain;
-        src = craneLib.cleanCargoSource (craneLib.path ./.);
+        src = craneLib.cleanCargoSource ./.;
 
         workspace = craneLib.buildPackage {
           inherit src;

--- a/examples/quick-start-simple/flake.nix
+++ b/examples/quick-start-simple/flake.nix
@@ -22,7 +22,7 @@
         # Common arguments can be set here to avoid repeating them later
         # Note: changes here will rebuild all dependency crates
         commonArgs = {
-          src = craneLib.cleanCargoSource (craneLib.path ./.);
+          src = craneLib.cleanCargoSource ./.;
           strictDeps = true;
 
           buildInputs = [

--- a/examples/quick-start-workspace/flake.nix
+++ b/examples/quick-start-workspace/flake.nix
@@ -31,7 +31,7 @@
         inherit (pkgs) lib;
 
         craneLib = crane.mkLib pkgs;
-        src = craneLib.cleanCargoSource (craneLib.path ./.);
+        src = craneLib.cleanCargoSource ./.;
 
         # Common arguments can be set here to avoid repeating them later
         commonArgs = {

--- a/examples/quick-start/flake.nix
+++ b/examples/quick-start/flake.nix
@@ -31,7 +31,7 @@
         inherit (pkgs) lib;
 
         craneLib = crane.mkLib pkgs;
-        src = craneLib.cleanCargoSource (craneLib.path ./.);
+        src = craneLib.cleanCargoSource ./.;
 
         # Common arguments can be set here to avoid repeating them later
         commonArgs = {

--- a/examples/sqlx/flake.nix
+++ b/examples/sqlx/flake.nix
@@ -25,8 +25,9 @@
         sqlOrCargo = path: type: (sqlFilter path type) || (craneLib.filterCargoSources path type);
 
         src = lib.cleanSourceWith {
-          src = craneLib.path ./.; # The original, unfiltered source
+          src = ./.; # The original, unfiltered source
           filter = sqlOrCargo;
+          name = "source"; # Be reproducible, regardless of the directory name
         };
 
         # Common arguments can be set here to avoid repeating them later

--- a/extra-tests/alt-store/flake.nix
+++ b/extra-tests/alt-store/flake.nix
@@ -13,7 +13,7 @@
     {
       # https://github.com/ipetkov/crane/issues/446
       packages.default = craneLib.buildPackage {
-        src = craneLib.cleanCargoSource (craneLib.path ../../checks/simple);
+        src = craneLib.cleanCargoSource ../../checks/simple;
       };
     });
 }

--- a/lib/cleanCargoSource.nix
+++ b/lib/cleanCargoSource.nix
@@ -1,4 +1,5 @@
 { filterCargoSources
+, internalCrateNameForCleanSource
 , lib
 }:
 
@@ -8,4 +9,6 @@ src: lib.cleanSourceWith {
 
   # Then add our own filter on top
   filter = filterCargoSources;
+
+  name = internalCrateNameForCleanSource src;
 }

--- a/lib/crateNameFromCargoToml.nix
+++ b/lib/crateNameFromCargoToml.nix
@@ -12,7 +12,12 @@ let
     - `pname` and `version` are explicitly set 
   '';
 
-  src = args.src or throwMsg;
+  origSrc = src:
+    if src ? _isLibCleanSourceWith
+    then src.origSrc
+    else src;
+
+  src = origSrc (args.src or throwMsg);
   cargoToml = args.cargoToml or (src + "/Cargo.toml");
   cargoTomlContents = args.cargoTomlContents or (
     if builtins.pathExists cargoToml

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -18,6 +18,9 @@ let
   inherit (self) callPackage;
 
   internalCrateNameFromCargoToml = callPackage ./internalCrateNameFromCargoToml.nix { };
+  internalCrateNameForCleanSource = callPackage ./internalCrateNameForCleanSource.nix {
+    inherit internalCrateNameFromCargoToml;
+  };
 in
 {
   appendCrateRegistries = input: self.overrideScope (_final: prev: {
@@ -38,7 +41,9 @@ in
   cargoNextest = callPackage ./cargoNextest.nix { };
   cargoTarpaulin = callPackage ./cargoTarpaulin.nix { };
   cargoTest = callPackage ./cargoTest.nix { };
-  cleanCargoSource = callPackage ./cleanCargoSource.nix { };
+  cleanCargoSource = callPackage ./cleanCargoSource.nix {
+    inherit internalCrateNameForCleanSource;
+  };
   cleanCargoToml = callPackage ./cleanCargoToml.nix { };
   configureCargoCommonVarsHook = callPackage ./setupHooks/configureCargoCommonVars.nix { };
   configureCargoVendoredDepsHook = callPackage ./setupHooks/configureCargoVendoredDeps.nix { };
@@ -71,7 +76,7 @@ in
   });
 
   path = callPackage ./path.nix {
-    inherit internalCrateNameFromCargoToml;
+    inherit internalCrateNameForCleanSource;
   };
 
   registryFromDownloadUrl = callPackage ./registryFromDownloadUrl.nix { };

--- a/lib/internalCrateNameForCleanSource.nix
+++ b/lib/internalCrateNameForCleanSource.nix
@@ -1,0 +1,26 @@
+{ internalCrateNameFromCargoToml
+, lib
+}:
+
+src:
+let
+  origSrc =
+    if src ? _isLibCleanSourceWith
+    then src.origSrc
+    else src;
+
+  cargoTomlContents =
+    let
+      emptyToml = { };
+      cargoToml = origSrc + "/Cargo.toml";
+      cargoTomlContents = builtins.readFile cargoToml;
+      toml = builtins.tryEval (builtins.fromTOML cargoTomlContents);
+    in
+    if builtins.pathExists cargoToml
+    then
+      if toml.success then toml.value else emptyToml
+    else
+      emptyToml;
+in
+  (internalCrateNameFromCargoToml cargoTomlContents).pname or "source"
+

--- a/lib/path.nix
+++ b/lib/path.nix
@@ -1,24 +1,14 @@
-{ internalCrateNameFromCargoToml
+{ internalCrateNameForCleanSource
 , lib
 }:
 
 input:
 let
-  pathArgs = if lib.isAttrs input then input else { path = input; };
+  inputIsAttrs = lib.isAttrs input;
+  name = input.name or (internalCrateNameForCleanSource (
+    if inputIsAttrs then input.path else input
+  ));
 
-  cargoTomlContents =
-    let
-      emptyToml = { };
-      cargoToml = pathArgs.path + "/Cargo.toml";
-      cargoTomlContents = builtins.readFile cargoToml;
-      toml = builtins.tryEval (builtins.fromTOML cargoTomlContents);
-    in
-    if builtins.pathExists cargoToml
-    then
-      if toml.success then toml.value else emptyToml
-    else
-      emptyToml;
-
-  name = (internalCrateNameFromCargoToml cargoTomlContents).pname or "source";
+  pathArgs = if inputIsAttrs then input else { path = input; };
 in
 builtins.path ({ inherit name; } // pathArgs)

--- a/lib/vendorCargoDeps.nix
+++ b/lib/vendorCargoDeps.nix
@@ -11,14 +11,19 @@ let
 
   inherit (lib.attrsets) optionalAttrs;
 
-  cargoConfigs = if args ? src then (findCargoFiles args.src).cargoConfigs else [ ];
+  origSrc = src:
+    if src ? _isLibCleanSourceWith
+    then src.origSrc
+    else src;
 
-  src = args.src or (throw ''
+  cargoConfigs = if args ? src then (findCargoFiles (origSrc args.src)).cargoConfigs else [ ];
+
+  src = origSrc (args.src or (throw ''
     unable to find `src` attribute. consider one of the following:
     - set `cargoVendorDir = vendorCargoDeps { cargoLock = ./some/path/to/Cargo.lock; }`
     - set `cargoVendorDir = vendorCargoDeps { src = ./src/containing/cargo/lock/file; }`
     - set `cargoVendorDir = null` to skip vendoring altogether
-  '');
+  ''));
 
   cargoLock = args.cargoLock or (src + "/Cargo.lock");
   cargoLockContents = args.cargoLockContents or (

--- a/lib/vendorCargoDeps.nix
+++ b/lib/vendorCargoDeps.nix
@@ -18,12 +18,14 @@ let
 
   cargoConfigs = if args ? src then (findCargoFiles (origSrc args.src)).cargoConfigs else [ ];
 
-  src = origSrc (args.src or (throw ''
-    unable to find `src` attribute. consider one of the following:
-    - set `cargoVendorDir = vendorCargoDeps { cargoLock = ./some/path/to/Cargo.lock; }`
-    - set `cargoVendorDir = vendorCargoDeps { src = ./src/containing/cargo/lock/file; }`
-    - set `cargoVendorDir = null` to skip vendoring altogether
-  ''));
+  src = origSrc (
+    args.src or (throw ''
+      unable to find `src` attribute. consider one of the following:
+      - set `cargoVendorDir = vendorCargoDeps { cargoLock = ./some/path/to/Cargo.lock; }`
+      - set `cargoVendorDir = vendorCargoDeps { src = ./src/containing/cargo/lock/file; }`
+      - set `cargoVendorDir = null` to skip vendoring altogether
+    '')
+  );
 
   cargoLock = args.cargoLock or (src + "/Cargo.lock");
   cargoLockContents = args.cargoLockContents or (


### PR DESCRIPTION
## Motivation

We don't need to nest `cleanCargoSource` and `path` just to populate a default value for `name`. As they both ultimately delegate to `builtins.path`, the nesting can lead to IFD in situations which are otherwise avoidable

Fixes https://github.com/ipetkov/crane/issues/612

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [ ] added tests to verify new behavior
- [x] added an example template or updated an existing one
- [x] updated `docs/API.md` (or general documentation) with changes
- [x] updated `CHANGELOG.md`
