### PR TITLE
ci: stick to nix 2.18.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,7 +76,9 @@ jobs:
     - uses: actions/checkout@v4
     - uses: cachix/install-nix-action@V27
       with:
-        install_url: https://nixos.org/nix/install
+        #install_url: https://nixos.org/nix/install
+        # The latest nix releases keep being broken, stick to what's in NixOS
+        install_url: https://releases.nixos.org/nix/nix-2.18.2/install
     - uses: cachix/cachix-action@v15
       with:
         name: crane
@@ -98,7 +100,9 @@ jobs:
     - uses: actions/checkout@v4
     - uses: cachix/install-nix-action@V27
       with:
-        install_url: https://nixos.org/nix/install
+        #install_url: https://nixos.org/nix/install
+        # The latest nix releases keep being broken, stick to what's in NixOS
+        install_url: https://releases.nixos.org/nix/nix-2.18.2/install
     - uses: cachix/cachix-action@v15
       with:
         name: crane

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,9 @@ jobs:
       matrix:
         include:
             # Latest and greatest release of Nix
-          - install_url: https://nixos.org/nix/install
+            #- install_url: https://nixos.org/nix/install
+            # The latest nix releases keep being broken, stick to what's in NixOS
+          - install_url: https://releases.nixos.org/nix/nix-2.18.2/install
             # The 24.05 branch ships with Nix 2.18.2
           - install_url: https://releases.nixos.org/nix/nix-2.18.2/install
             nixpkgs-override: "--override-input nixpkgs $(./ci/ref-from-lock.sh ./test#nixpkgs)"


### PR DESCRIPTION

## Motivation
Recent Nix releases keep being unstable or outright broken. Switch to using 2.18.2 (current version in nixos-unstable)


## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [ ] updated `docs/API.md` (or general documentation) with changes
- [ ] updated `CHANGELOG.md`
