### PR TITLE
Add build-std and quick-start-workspace as flake templates

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -94,6 +94,11 @@
           path = ./examples/quick-start-simple;
         };
 
+        quick-start-workspace = {
+          description = "Build a cargo workspace with hakari";
+          path = ./examples/quick-start-workspace;
+        };
+
         sqlx = {
           description = "Build a cargo project which uses SQLx";
           path = ./examples/sqlx;

--- a/flake.nix
+++ b/flake.nix
@@ -58,6 +58,11 @@
           path = ./examples/alt-registry;
         };
 
+        build-std = {
+          description = "Build a cargo project while also compiling the standard library";
+          path = ./examples/build-std;
+        };
+
         cross-musl = {
           description = "Building static binaries with musl";
           path = ./examples/cross-musl;


### PR DESCRIPTION
## Motivation

I'd like to use the workspace template as documented on https://crane.dev/examples/quick-start-workspace.html . Running the provided command fails with `error: flake 'github:ipetkov/crane' does not provide attribute 'templates.quick-start-workspace' or 'quick-start-workspace'`, I think because the example is missing from the flake.
<!--
Thank you for your contribution! Please add a brief description below about the change and what is the motivation
behind it.
-->

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [ ] updated `docs/API.md` (or general documentation) with changes
- [ ] updated `CHANGELOG.md`
