### PR TITLE
Add `taploFmt` TOML format function to `mkLib`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Added
+* `taploFmt` is now available for checking TOML formatting
+
 ### Changed
 * **Breaking** (technically): `buildPackage` no longer adds `jq` to
   `nativeBuildInputs` as doing so can result in rebuilding any `*-sys` crates

--- a/docs/API.md
+++ b/docs/API.md
@@ -539,6 +539,40 @@ environment variables during the build, you can bring them back via
 * `cargoExtraArgs`
 * `rustFmtExtraArgs`
 
+### `craneLib.taploFmt`
+
+`taploFmt :: set -> drv`
+
+Create a derivation which will run a `taplo fmt` invocation in a cargo
+workspace.
+
+Except where noted below, all derivation attributes are delegated to
+`mkCargoDerivation`, and can be used to influence its behavior.
+* `buildPhaseCargoCommand` will be set to run `taplo fmt` (in check mode) in the
+  workspace.
+* `cargoArtifacts` is disabled/cleared
+* `cargoVendorDir` is disabled/cleared
+* `pnameSuffix` will be set to `"-tomlfmt"`
+
+#### Optional attributes
+* `taploExtraArgs`: additional flags to be passed in the taplo invocation
+  - Default value: `""`
+
+`taplo` command line options for setting `taploExtraArgs` and configuration options
+for `taplo.toml` config files can be found in the _Command Line_ and _Configuration_
+sections of the [taplo documentation](https://taplo.tamasfe.dev/).
+
+#### Native build dependencies
+The `taplo` package is automatically appended as a native build input to any
+other `nativeBuildInputs` specified by the caller.
+
+#### Remove attributes
+The following attributes will be removed before being lowered to
+`mkCargoDerivation`. If you absolutely need these attributes present as
+environment variables during the build, you can bring them back via
+`.overrideAttrs`.
+* `taploExtraArgs`
+
 ### `craneLib.cargoLlvmCov`
 
 `cargoLlvmCov :: set -> drv`

--- a/examples/quick-start-workspace/.config/hakari.toml
+++ b/examples/quick-start-workspace/.config/hakari.toml
@@ -15,9 +15,9 @@ resolver = "2"
 # Add triples corresponding to platforms commonly used by developers here.
 # https://doc.rust-lang.org/rustc/platform-support.html
 platforms = [
-    # "x86_64-unknown-linux-gnu",
-    # "x86_64-apple-darwin",
-    # "x86_64-pc-windows-msvc",
+  # "x86_64-unknown-linux-gnu",
+  # "x86_64-apple-darwin",
+  # "x86_64-pc-windows-msvc",
 ]
 
 # Write out exact versions rather than a semver range. (Defaults to false.)

--- a/examples/quick-start-workspace/Cargo.toml
+++ b/examples/quick-start-workspace/Cargo.toml
@@ -1,9 +1,6 @@
 [workspace]
 resolver = "2"
-members = [
-  "my-*",
-  "my-workspace-hack",
-]
+members = ["my-*", "my-workspace-hack"]
 
 [workspace.package]
 version = "0.1.0"

--- a/examples/quick-start-workspace/deny.toml
+++ b/examples/quick-start-workspace/deny.toml
@@ -3,9 +3,4 @@ multiple-versions = 'allow'
 
 [licenses]
 private = { ignore = true }
-allow = [
-  "Apache-2.0",
-  "BSD-3-Clause",
-  "MIT",
-  "Unicode-DFS-2016",
-]
+allow = ["Apache-2.0", "BSD-3-Clause", "MIT", "Unicode-DFS-2016"]

--- a/examples/quick-start-workspace/flake.nix
+++ b/examples/quick-start-workspace/flake.nix
@@ -120,6 +120,11 @@
             inherit src;
           };
 
+          my-workspace-toml-fmt = craneLib.taploFmt {
+            inherit src;
+            taploExtraArgs = "--config ./taplo.toml";
+          };
+
           # Audit dependencies
           my-workspace-audit = craneLib.cargoAudit {
             inherit src advisory-db;

--- a/examples/quick-start-workspace/flake.nix
+++ b/examples/quick-start-workspace/flake.nix
@@ -121,7 +121,7 @@
           };
 
           my-workspace-toml-fmt = craneLib.taploFmt {
-            inherit src;
+            src = pkgs.lib.sources.sourceFilesBySuffices src [ ".toml" ];
             taploExtraArgs = "--config ./taplo.toml";
           };
 

--- a/examples/quick-start-workspace/flake.nix
+++ b/examples/quick-start-workspace/flake.nix
@@ -122,7 +122,8 @@
 
           my-workspace-toml-fmt = craneLib.taploFmt {
             src = pkgs.lib.sources.sourceFilesBySuffices src [ ".toml" ];
-            taploExtraArgs = "--config ./taplo.toml";
+            # taplo arguments can be further customized below as needed
+            # taploExtraArgs = "--config ./taplo.toml";
           };
 
           # Audit dependencies

--- a/examples/quick-start-workspace/taplo.toml
+++ b/examples/quick-start-workspace/taplo.toml
@@ -1,0 +1,13 @@
+# Sorts `Cargo.toml` dependencies. All other `.toml` files are formatted with the default config.
+#
+# https://taplo.tamasfe.dev/configuration/file.html#configuration-file
+
+[formatting]
+reorder_keys = false
+
+[[rule]]
+include = ["**/Cargo.toml"]
+keys = ["dependencies"]
+
+[rule.formatting]
+reorder_keys = true

--- a/examples/quick-start/deny.toml
+++ b/examples/quick-start/deny.toml
@@ -1,4 +1,2 @@
 [licenses]
-allow = [
-  "MIT"
-]
+allow = ["MIT"]

--- a/examples/quick-start/flake.nix
+++ b/examples/quick-start/flake.nix
@@ -93,7 +93,8 @@
 
           my-crate-toml-fmt = craneLib.taploFmt {
             src = pkgs.lib.sources.sourceFilesBySuffices src [ ".toml" ];
-            taploExtraArgs = "--config ./taplo.toml";
+            # taplo arguments can be further customized below as needed
+            # taploExtraArgs = "--config ./taplo.toml";
           };
 
           # Audit dependencies

--- a/examples/quick-start/flake.nix
+++ b/examples/quick-start/flake.nix
@@ -91,6 +91,11 @@
             inherit src;
           };
 
+          my-crate-toml-fmt = craneLib.taploFmt {
+            inherit src;
+            taploExtraArgs = "--config ./taplo.toml";
+          };
+
           # Audit dependencies
           my-crate-audit = craneLib.cargoAudit {
             inherit src advisory-db;

--- a/examples/quick-start/flake.nix
+++ b/examples/quick-start/flake.nix
@@ -92,7 +92,7 @@
           };
 
           my-crate-toml-fmt = craneLib.taploFmt {
-            inherit src;
+            src = pkgs.lib.sources.sourceFilesBySuffices src [ ".toml" ];
             taploExtraArgs = "--config ./taplo.toml";
           };
 

--- a/examples/quick-start/taplo.toml
+++ b/examples/quick-start/taplo.toml
@@ -1,0 +1,13 @@
+# Sorts `Cargo.toml` dependencies. All other `.toml` files are formatted with the default config.
+#
+# https://taplo.tamasfe.dev/configuration/file.html#configuration-file
+
+[formatting]
+reorder_keys = false
+
+[[rule]]
+include = ["**/Cargo.toml"]
+keys = ["dependencies"]
+
+[rule.formatting]
+reorder_keys = true

--- a/flake.nix
+++ b/flake.nix
@@ -162,6 +162,7 @@
             mdbook
             nix-eval-jobs
             nixpkgs-fmt
+            taplo
           ];
         };
       });

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -119,6 +119,7 @@ let
       registryFromSparse = callPackage ./registryFromSparse.nix { };
       removeReferencesToVendoredSourcesHook = callPackage ./setupHooks/removeReferencesToVendoredSources.nix { };
       replaceCargoLockHook = callPackage ./setupHooks/replaceCargoLockHook.nix { };
+      taploFmt = callPackage ./taploFmt.nix { };
       urlForCargoPackage = callPackage ./urlForCargoPackage.nix { };
       vendorCargoDeps = callPackage ./vendorCargoDeps.nix { };
       vendorMultipleCargoDeps = callPackage ./vendorMultipleCargoDeps.nix { };

--- a/lib/taploFmt.nix
+++ b/lib/taploFmt.nix
@@ -1,0 +1,24 @@
+{ taplo
+, mkCargoDerivation
+}:
+
+{ taploExtraArgs ? ""
+, ...
+}@origArgs:
+let
+  args = builtins.removeAttrs origArgs [ "taploExtraArgs" ];
+in
+mkCargoDerivation (args // {
+  cargoArtifacts = null;
+  cargoVendorDir = null;
+  pnameSuffix = "-tomlfmt";
+
+  buildPhaseCargoCommand = "taplo fmt --check ${taploExtraArgs}";
+
+  nativeBuildInputs = (args.nativeBuildInputs or [ ]) ++ [ taplo ];
+
+  preInstallPhases = [ "ensureTargetDir" ] ++ (args.preInstallPhases or [ ]);
+  ensureTargetDir = ''
+    mkdir -p ''${CARGO_TARGET_DIR:-target}
+  '';
+})


### PR DESCRIPTION
## Motivation
<!--
Thank you for your contribution! Please add a brief description below about the change and what is the motivation
behind it.
-->
Closes #673 

Hello, this change adds a function to `mkLib` for checking formatting of TOML files. TOML files are extremely common, especially among Rust projects, and I find that in all of my use cases of `crane` between projects I am always manually adding checks for the formatting of `Cargo.toml` files, and other files such as `deny.toml`, `rust-toolchain.toml`, `rustfmt.toml` and so on.

I have a working copy of this on a local project, otherwise I wasn't sure how to add tests for it. I'm also sure that the copy-pasted code I took from `cargoFmt.nix` may include some things that don't belong, or may otherwise be going about it the wrong way. Regardless, this is what worked for me, please do instruct me on how to get this to a mergable state, I would greatly appreciate it!

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [x] added tests to verify new behavior (toml format is added to checks so it is already tested in CI)
- [x] added an example template or updated an existing one
- [x] updated `docs/API.md` (or general documentation) with changes
- [ ] updated `CHANGELOG.md`
