### PR TITLE
Fix deeply nested registries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Fixed
+* Fixed vendoring dependencies from an alternative registry which they
+  themselves have dependencies on crates from _other_ registries.
+
 ## [0.18.0] - 2024-07-05
 
 ### Changed


### PR DESCRIPTION
## Motivation
<!--
Thank you for your contribution! Please add a brief description below about the change and what is the motivation
behind it.
-->

This allows building packages with crates from custom registries that reference other custom registries.

It works by scanning packages from `Cargo.lock` and adding any missing registries to crane's generated `.cargo/config.toml`. This matches Cargo's behavior where the top level project doesn't necessarily have to explicitly define all transitive registries.

Fixes #456 

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [ ] updated `docs/API.md` (or general documentation) with changes
- [ ] updated `CHANGELOG.md`
