### PR TITLE
Cannot set cargoExtraArgs in craneLib.cargoNextest (#675)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Changed
+* Removed invalid `cargoExtraArgs` input attribute from `craneLib.cargoNextest`
+  in favor of `cargoNextestExtraArgs`.
+
 ## [0.18.0] - 2024-07-05
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
-### Changed
-* Removed invalid `cargoExtraArgs` input attribute from `craneLib.cargoNextest`
-  in favor of `cargoNextestExtraArgs`.
-
 ### Fixed
 * Fixed vendoring dependencies from an alternative registry which they
   themselves have dependencies on crates from _other_ registries.
+* Fixed `cargoNextest`'s positioning of `cargoExtraArgs` to form a valid command
+  invocation when specified.
 
 ## [0.18.0] - 2024-07-05
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -615,15 +615,13 @@ Except where noted below, all derivation attributes are delegated to
 
 #### Optional attributes
 * `buildPhaseCargoCommand`, unless specified, will be set to print the nextest version
-* `cargoExtraArgs`: additional flags to be passed in the cargo invocation (e.g.
-  enabling specific features)
-  - Default value: `""`
 * `cargoLlvmCovExtraArgs`: additional flags to be passed in the cargo
   llvm-cov invocation
   - Default value: `"--lcov --output-path $out/coverage"`
 * `cargoNextestExtraArgs`: additional flags to be passed in the nextest invocation
   (e.g. specifying a profile)
   - Default value: `""`
+  - Note that all flags from `cargo test` are supported.
 * `partitions`: The number of separate nextest partitions to run. Useful if the
   test suite takes a long time and can be parallelized across multiple build
   nodes.

--- a/docs/API.md
+++ b/docs/API.md
@@ -615,6 +615,9 @@ Except where noted below, all derivation attributes are delegated to
 
 #### Optional attributes
 * `buildPhaseCargoCommand`, unless specified, will be set to print the nextest version
+* `cargoExtraArgs`: additional flags to be passed in the cargo invocation (e.g.
+  enabling specific features)
+  - Default value: `""`
 * `cargoLlvmCovExtraArgs`: additional flags to be passed in the cargo
   llvm-cov invocation
   - Default value: `"--lcov --output-path $out/coverage"`

--- a/lib/cargoNextest.nix
+++ b/lib/cargoNextest.nix
@@ -25,7 +25,7 @@ let
     "withLlvmCov"
   ];
 
-  mkUpdatedArgs = { cmd ? lib.optionalString (!withLlvmCov) "run", extraSuffix ? "", moreArgs ? "", withLlvmCov }: args // {
+  mkUpdatedArgs = { cmd ? "run", extraSuffix ? "", moreArgs ? "", withLlvmCov }: args // {
     inherit cargoArtifacts;
     pnameSuffix = "-nextest${extraSuffix}";
     doCheck = args.doCheck or true;

--- a/lib/cargoNextest.nix
+++ b/lib/cargoNextest.nix
@@ -8,7 +8,6 @@
 }:
 
 { cargoArtifacts
-, cargoExtraArgs ? ""
 , cargoLlvmCovExtraArgs ? "--lcov --output-path $out/coverage"
 , cargoNextestExtraArgs ? ""
 , doInstallCargoArtifacts ? true
@@ -19,7 +18,6 @@
 }@origArgs:
 let
   args = builtins.removeAttrs origArgs [
-    "cargoExtraArgs"
     "cargoLlvmCovExtraArgs"
     "cargoNextestExtraArgs"
     "partitions"
@@ -44,10 +42,8 @@ let
     '';
 
     checkPhaseCargoCommand = ''
-      cargo ${cargoExtraArgs} \
-        ${lib.optionalString withLlvmCov "llvm-cov ${cargoLlvmCovExtraArgs}"} \
-        nextest ${cmd} ''${CARGO_PROFILE:+--cargo-profile $CARGO_PROFILE} \
-          ${cargoNextestExtraArgs} ${moreArgs}
+      ${if withLlvmCov then "cargo llvm-cov nextest ${cargoLlvmCovExtraArgs}" else "cargo nextest ${cmd}"} \
+      ''${CARGO_PROFILE:+--cargo-profile $CARGO_PROFILE} ${cargoNextestExtraArgs} ${moreArgs}
     '';
 
     nativeBuildInputs = (args.nativeBuildInputs or [ ])

--- a/lib/cargoNextest.nix
+++ b/lib/cargoNextest.nix
@@ -8,6 +8,7 @@
 }:
 
 { cargoArtifacts
+, cargoExtraArgs ? ""
 , cargoLlvmCovExtraArgs ? "--lcov --output-path $out/coverage"
 , cargoNextestExtraArgs ? ""
 , doInstallCargoArtifacts ? true
@@ -18,6 +19,7 @@
 }@origArgs:
 let
   args = builtins.removeAttrs origArgs [
+    "cargoExtraArgs"
     "cargoLlvmCovExtraArgs"
     "cargoNextestExtraArgs"
     "partitions"
@@ -42,8 +44,11 @@ let
     '';
 
     checkPhaseCargoCommand = ''
-      ${if withLlvmCov then "cargo llvm-cov nextest ${cargoLlvmCovExtraArgs}" else "cargo nextest ${cmd}"} \
-      ''${CARGO_PROFILE:+--cargo-profile $CARGO_PROFILE} ${cargoNextestExtraArgs} ${moreArgs}
+      ${if withLlvmCov
+        then "cargo llvm-cov nextest ${cargoLlvmCovExtraArgs}"
+        else "cargo nextest ${cmd}"} \
+      ''${CARGO_PROFILE:+--cargo-profile $CARGO_PROFILE} \
+      ${cargoExtraArgs} ${cargoNextestExtraArgs} ${moreArgs}
     '';
 
     nativeBuildInputs = (args.nativeBuildInputs or [ ])


### PR DESCRIPTION
## Motivation
<!--
Thank you for your contribution! Please add a brief description below about the change and what is the motivation
behind it.
-->
To resolve [issue (#675)](https://github.com/ipetkov/crane/issues/675) with the `cargoExtraArgs` attribute in `craneLib.cargoNextest` being placed in between `cargo <HERE> nextest` or `cargo <HERE> llvm-cov nextest` where there should be no options/flags.

Cargo flags cannot be used in this context. Only `cargo nextest run/archive` flags, which contain all the flags from `cargo test` (at least) are possible.

Sources I have checked:
* [cargo llvm-cov nextest](https://github.com/taiki-e/cargo-llvm-cov/blob/f349cb8b99c874a152a7605489b539764624867a/docs/cargo-llvm-cov-nextest.txt)
* [cargo nextest run](https://github.com/nextest-rs/nextest/blob/e70b4e645a0df7922e396e2bfe30f3e85abe1106/site/help-text/run-help.txt)
* [cargo nextest archive](https://github.com/nextest-rs/nextest/blob/e70b4e645a0df7922e396e2bfe30f3e85abe1106/site/help-text/archive-help.txt)

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [x] updated `docs/API.md` (or general documentation) with changes
- [x] updated `CHANGELOG.md`
