### PR TITLE
buildPackage: do not add `jq` to nativeBuildInputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Changed
+* **Breaking** (technically): `buildPackage` no longer adds `jq` to
+  `nativeBuildInputs` as doing so can result in rebuilding any `*-sys` crates
+  which rely on `PKG_CONFIG_PATH` remaining stable
+* `installFromCargoBuildLogHook` no longer assumes or requires that `jq` is
+  available on `$PATH` and will instead directly reference `pkgs.jq`
+
 ## [0.18.1] - 2024-08-22
 
 ### Fixed

--- a/docs/API.md
+++ b/docs/API.md
@@ -233,7 +233,6 @@ environment variables during the build, you can bring them back via
 #### Native build dependencies and included hooks
 The following hooks are automatically added as native build inputs:
 * `installFromCargoBuildLogHook`
-* `jq`
 * `removeReferencesToVendoredSourcesHook`
 
 ### `craneLib.buildTrunkPackage`
@@ -1703,7 +1702,7 @@ takes two positional arguments:
 
 **Automatic behavior:** none
 
-**Required nativeBuildInputs**: assumes `cargo` and `jq` are available on the `$PATH`
+**Required nativeBuildInputs**: assumes `cargo` is available on the `$PATH`
 
 ### `craneLib.removeReferencesToVendoredSourcesHook`
 

--- a/lib/buildPackage.nix
+++ b/lib/buildPackage.nix
@@ -77,8 +77,9 @@ mkCargoDerivation (cleanedArgs // memoizedArgs // {
   '';
 
   nativeBuildInputs = (args.nativeBuildInputs or [ ]) ++ [
+    # NB: avoid adding any non-hook packages here. Doing so will end up
+    # changing PKG_CONFIG_PATH and cause rebuilds of `*-sys` crates.
     installFromCargoBuildLogHook
-    jq
     removeReferencesToVendoredSourcesHook
   ];
 })

--- a/lib/setupHooks/installFromCargoBuildLog.nix
+++ b/lib/setupHooks/installFromCargoBuildLog.nix
@@ -1,7 +1,11 @@
 { makeSetupHook
+, pkgsBuildBuild
 }:
 
 makeSetupHook
 {
   name = "installFromCargoBuildLogHook";
+  substitutions = {
+    jq = "${pkgsBuildBuild.jq}/bin/jq";
+  };
 } ./installFromCargoBuildLogHook.sh

--- a/lib/setupHooks/installFromCargoBuildLogHook.sh
+++ b/lib/setupHooks/installFromCargoBuildLogHook.sh
@@ -10,7 +10,7 @@ function installFromCargoBuildLog() (
   echo searching for bins/libs to install from cargo build log at ${log}
 
   local logs
-  logs=$(jq -R 'fromjson?' <"${log}")
+  logs=$(@jq@ -R 'fromjson?' <"${log}")
 
   # We automatically ignore any bindeps artifacts as installation candidates.
   # Note that if the same binary is built both as a bindep artifact for something else and as a
@@ -19,7 +19,7 @@ function installFromCargoBuildLog() (
   local select_non_deps_artifact='select(contains("/deps/artifact/") | not)'
 
   # Only install binaries and libraries from the current workspace as a sanity check
-  local members="$(command cargo metadata --format-version 1 | jq -c '.workspace_members')"
+  local members="$(command cargo metadata --format-version 1 | @jq@ -c '.workspace_members')"
   local select_non_test_members='select(.reason == "compiler-artifact" and .profile.test == false)
     | select(.package_id as $pid
       | '"${members}"'
@@ -49,8 +49,8 @@ function installFromCargoBuildLog() (
     rmdir --ignore-fail-on-non-empty "${loc}"
   }
 
-  echo "${logs}" | jq -r "${select_lib_files}" | installArtifacts "${dest}/lib"
-  echo "${logs}" | jq -r "${select_bins}" | installArtifacts "${dest}/bin"
+  echo "${logs}" | @jq@ -r "${select_lib_files}" | installArtifacts "${dest}/lib"
+  echo "${logs}" | @jq@ -r "${select_bins}" | installArtifacts "${dest}/bin"
 
   echo searching for bins/libs complete
 )


### PR DESCRIPTION
## Motivation
Doing so ends up resulting in PKG_CONFIG_PATH changing which may result in various `*-sys` crates needing to be rebuilt

Fixes #684 

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [x] updated `docs/API.md` (or general documentation) with changes
- [x] updated `CHANGELOG.md`
