### PR TITLE
downloadCargoPackageFromGit: take `hash` instead of `sha256`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * **Breaking** (technically): `buildPackage` no longer adds `jq` to
   `nativeBuildInputs` as doing so can result in rebuilding any `*-sys` crates
   which rely on `PKG_CONFIG_PATH` remaining stable
+* **Breaking**: `downloadCargoPackageFromGit` now takes `hash` instead of
+  `sha256` when specifying an output hash for the download
 * `installFromCargoBuildLogHook` no longer assumes or requires that `jq` is
   available on `$PATH` and will instead directly reference `pkgs.jq`
 * `downloadCargoPackageFromGit` will now set `fetchLFS = true` when fetching git

--- a/docs/API.md
+++ b/docs/API.md
@@ -1369,8 +1369,8 @@ At least one of the above attributes must be specified, or an error will be
 raised during evaluation.
 
 #### Optional attributes
-* `outputHashes`: a mapping of package-source to the sha256 of the (unpacked)
-  download. Useful for supporting fully offline evaluations.
+* `outputHashes`: a mapping of package-source to the `hash` attribute of the
+  (unpacked) download. Useful for supporting fully offline evaluations.
   - Default value: `[]`
 * `overrideVendorCargoPackage`: a function that will be called on every crate
   vendored from a cargo registry, which allows for modifying the derivation
@@ -1441,8 +1441,8 @@ access.
   `Cargo.lock` file (parsed via `builtins.fromTOML`)
 
 #### Optional attributes
-* `outputHashes`: a mapping of package-source to the sha256 of the (unpacked)
-  download. Useful for supporting fully offline evaluations.
+* `outputHashes`: a mapping of package-source to the `hash` attribute of the
+  (unpacked) download. Useful for supporting fully offline evaluations.
   - Default value: `[]`
 * `overrideVendorGitCheckout`: a function that will be called on every unique
   checkout vendored from a git repository, which allows for modifying the
@@ -1491,8 +1491,8 @@ the vendored directories (i.e. this configuration can be appended to the
 * `cargoLockParsedList`: a list of attrsets representing the parsed contents of
   different `Cargo.lock` files to be included while vendoring.
   - Default value: `[]`
-* `outputHashes`: a mapping of package-source to the sha256 of the (unpacked)
-  download. Useful for supporting fully offline evaluations.
+* `outputHashes`: a mapping of package-source to the `hash` attribute of the
+  (unpacked) download. Useful for supporting fully offline evaluations.
   - Default value: `[]`
 * `overrideVendorCargoPackage`: a function that will be called on every crate
   vendored from a cargo registry, which allows for modifying the derivation

--- a/lib/downloadCargoPackageFromGit.nix
+++ b/lib/downloadCargoPackageFromGit.nix
@@ -13,13 +13,13 @@ in
 { git
 , rev
 , ref ? null
-, sha256 ? null
+, hash ? null
 , allRefs ? ref == null
 }:
 let
   maybeRef = lib.optionalAttrs (ref != null) { inherit ref; };
   repo =
-    if sha256 == null then
+    if hash == null then
       builtins.fetchGit
         (maybeRef // {
           inherit allRefs rev;
@@ -28,7 +28,7 @@ let
         })
     else
       fetchgit {
-        inherit rev sha256;
+        inherit rev hash;
         url = git;
         fetchSubmodules = true;
         fetchLFS = true;

--- a/lib/vendorGitDeps.nix
+++ b/lib/vendorGitDeps.nix
@@ -100,7 +100,7 @@ let
           inherit (p) git;
           inherit ref;
           rev = p.lockedRev;
-          sha256 = outputHashes.${p.package.source} or (lib.warnIf
+          hash = outputHashes.${p.package.source} or (lib.warnIf
             (outputHashes != { })
             "No output hash provided for ${p.package.source}"
             null


### PR DESCRIPTION
## Motivation
Match the idioms established by nixpkgs, namely preferring using `hash` (which is more future compatible) than using `sha256` explicitly

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [x] updated `docs/API.md` (or general documentation) with changes
- [x] updated `CHANGELOG.md`
