### PR TITLE
Drop dependency on nixpkgs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -89,7 +89,7 @@ jobs:
       # "opt-out" of our lockfile .gitignore
       run: |
         rm ./examples/.gitignore
-      nix develop .# --accept-flake-config --command ./ci/check-example.sh ./examples/${{ matrix.example }} "./test#nixpkgs"
+        nix develop .# --accept-flake-config --command ./ci/check-example.sh ./examples/${{ matrix.example }} "./test#nixpkgs"
 
   examples-darwin:
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
           - install_url: https://releases.nixos.org/nix/nix-2.18.2/install
             # The 24.05 branch ships with Nix 2.18.2
           - install_url: https://releases.nixos.org/nix/nix-2.18.2/install
-            nixpkgs-override: "--override-input nixpkgs $(./ci/ref-from-lock.sh ./test#nixpkgs)"
+            nixpkgs-override: "--override-input nixpkgs $(./ci/ref-from-lock.sh ./test#nixpkgs-latest-release)"
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -89,7 +89,7 @@ jobs:
       # "opt-out" of our lockfile .gitignore
       run: |
         rm ./examples/.gitignore
-        nix develop .# --accept-flake-config --command ./ci/check-example.sh ./examples/${{ matrix.example }} ".#nixpkgs"
+      nix develop .# --accept-flake-config --command ./ci/check-example.sh ./examples/${{ matrix.example }} "./test#nixpkgs"
 
   examples-darwin:
     strategy:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * `downloadCargoPackageFromGit` will now set `fetchLFS = true` when fetching git
   repos with defined output hashes
 
+### Removed
+* The deprecated top-level (flake) attribute `lib` no longer exists. Please use
+  `mkLib` with an instance of `pkgs` instead.
+
 ## [0.18.1] - 2024-08-22
 
 ### Fixed

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -39,7 +39,6 @@ following contents at the root of your cargo workspace:
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     crane.url = "github:ipetkov/crane";
-    crane.inputs.nixpkgs.follows = "nixpkgs";
     flake-utils.url = "github:numtide/flake-utils";
   };
 

--- a/docs/introduction/artifact-reuse.md
+++ b/docs/introduction/artifact-reuse.md
@@ -20,7 +20,6 @@ Here's how we can set up our flake to achieve our goals:
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     crane.url = "github:ipetkov/crane";
-    crane.inputs.nixpkgs.follows = "nixpkgs";
     flake-utils.url = "github:numtide/flake-utils";
   };
 

--- a/docs/introduction/sequential-builds.md
+++ b/docs/introduction/sequential-builds.md
@@ -12,7 +12,6 @@ build.
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     crane.url = "github:ipetkov/crane";
-    crane.inputs.nixpkgs.follows = "nixpkgs";
     flake-utils.url = "github:numtide/flake-utils";
   };
 

--- a/docs/local_development.md
+++ b/docs/local_development.md
@@ -19,10 +19,7 @@ Sample `flake.nix`:
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
 
-    crane = {
-      url = "github:ipetkov/crane";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
+    crane.url = "github:ipetkov/crane";
 
     flake-utils.url = "github:numtide/flake-utils";
   };

--- a/docs/overriding_derivations.md
+++ b/docs/overriding_derivations.md
@@ -39,10 +39,7 @@ craneLib.buildPackage {
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
 
-    crane = {
-      url = "github:ipetkov/crane";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
+    crane.url = "github:ipetkov/crane";
 
     rust-overlay = {
       url = "github:oxalica/rust-overlay";
@@ -107,10 +104,7 @@ If you need to change behavior that way, consider using a combination of
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
 
-    crane = {
-      url = "github:ipetkov/crane";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
+    crane.url = "github:ipetkov/crane";
   };
 
   outputs = { self, nixpkgs, crane, fenix, flake-utils, advisory-db, ... }:

--- a/examples/alt-registry/flake.nix
+++ b/examples/alt-registry/flake.nix
@@ -4,10 +4,7 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
 
-    crane = {
-      url = "github:ipetkov/crane";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
+    crane.url = "github:ipetkov/crane";
 
     flake-utils = {
       url = "github:numtide/flake-utils";

--- a/examples/build-std/flake.nix
+++ b/examples/build-std/flake.nix
@@ -4,10 +4,7 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
 
-    crane = {
-      url = "github:ipetkov/crane";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
+    crane.url = "github:ipetkov/crane";
 
     flake-utils.url = "github:numtide/flake-utils";
 

--- a/examples/cross-musl/flake.nix
+++ b/examples/cross-musl/flake.nix
@@ -4,10 +4,7 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
 
-    crane = {
-      url = "github:ipetkov/crane";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
+    crane.url = "github:ipetkov/crane";
 
     flake-utils.url = "github:numtide/flake-utils";
 

--- a/examples/cross-rust-overlay/flake.nix
+++ b/examples/cross-rust-overlay/flake.nix
@@ -4,10 +4,7 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
 
-    crane = {
-      url = "github:ipetkov/crane";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
+    crane.url = "github:ipetkov/crane";
 
     flake-utils.url = "github:numtide/flake-utils";
 

--- a/examples/cross-windows/flake.nix
+++ b/examples/cross-windows/flake.nix
@@ -4,10 +4,7 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
 
-    crane = {
-      url = "github:ipetkov/crane";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
+    crane.url = "github:ipetkov/crane";
 
     fenix = {
       url = "github:nix-community/fenix";

--- a/examples/custom-toolchain/flake.nix
+++ b/examples/custom-toolchain/flake.nix
@@ -4,10 +4,7 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
 
-    crane = {
-      url = "github:ipetkov/crane";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
+    crane.url = "github:ipetkov/crane";
 
     flake-utils.url = "github:numtide/flake-utils";
 

--- a/examples/end-to-end-testing/flake.nix
+++ b/examples/end-to-end-testing/flake.nix
@@ -3,10 +3,7 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
 
-    crane = {
-      url = "github:ipetkov/crane";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
+    crane.url = "github:ipetkov/crane";
 
     flake-utils.url = "github:numtide/flake-utils";
 

--- a/examples/quick-start-simple/flake.nix
+++ b/examples/quick-start-simple/flake.nix
@@ -4,10 +4,7 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
 
-    crane = {
-      url = "github:ipetkov/crane";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
+    crane.url = "github:ipetkov/crane";
 
     flake-utils.url = "github:numtide/flake-utils";
   };

--- a/examples/quick-start-workspace/flake.nix
+++ b/examples/quick-start-workspace/flake.nix
@@ -4,10 +4,7 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
 
-    crane = {
-      url = "github:ipetkov/crane";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
+    crane.url = "github:ipetkov/crane";
 
     fenix = {
       url = "github:nix-community/fenix";

--- a/examples/quick-start/flake.nix
+++ b/examples/quick-start/flake.nix
@@ -4,10 +4,7 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
 
-    crane = {
-      url = "github:ipetkov/crane";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
+    crane.url = "github:ipetkov/crane";
 
     fenix = {
       url = "github:nix-community/fenix";

--- a/examples/sqlx/flake.nix
+++ b/examples/sqlx/flake.nix
@@ -4,10 +4,7 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
 
-    crane = {
-      url = "github:ipetkov/crane";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
+    crane.url = "github:ipetkov/crane";
 
     flake-utils.url = "github:numtide/flake-utils";
   };

--- a/examples/trunk-workspace/flake.nix
+++ b/examples/trunk-workspace/flake.nix
@@ -8,10 +8,7 @@
     # Update this to include the version you need
     nixpkgs-for-wasm-bindgen.url = "github:NixOS/nixpkgs/4e6868b1aa3766ab1de169922bb3826143941973";
 
-    crane = {
-      url = "github:ipetkov/crane";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
+    crane.url = "github:ipetkov/crane";
 
     flake-utils.url = "github:numtide/flake-utils";
 

--- a/examples/trunk/flake.nix
+++ b/examples/trunk/flake.nix
@@ -8,10 +8,7 @@
     # Update this to include the version you need
     nixpkgs-for-wasm-bindgen.url = "github:NixOS/nixpkgs/4e6868b1aa3766ab1de169922bb3826143941973";
 
-    crane = {
-      url = "github:ipetkov/crane";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
+    crane.url = "github:ipetkov/crane";
 
     flake-utils.url = "github:numtide/flake-utils";
 

--- a/extra-tests/alt-store/flake.nix
+++ b/extra-tests/alt-store/flake.nix
@@ -1,7 +1,7 @@
 {
   inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     crane.url = "github:ipetkov/crane";
-    nixpkgs.follows = "crane/nixpkgs";
     flake-utils.url = "github:numtide/flake-utils";
   };
 

--- a/extra-tests/alt-store/test.sh
+++ b/extra-tests/alt-store/test.sh
@@ -5,11 +5,14 @@ set -eu
 scriptDir=$(dirname "$0")
 cd "${scriptDir}"
 
+nixpkgsOverride="$(../../ci/ref-from-lock.sh ../../test#nixpkgs)"
+craneOverride="--override-input crane ../.. --override-input nixpkgs ${nixpkgsOverride}"
+
 case "$(nix --version)" in
   "nix (Nix) 2.21.0" | "nix (Nix) 2.21.1")
     echo 'skipping test: https://github.com/NixOS/nix/issues/10267'
     ;;
 
-  *) nix build .#default --override-input crane ../.. --store $(pwd)/alt-store
+  *) nix build .#default ${craneOverride} --store $(pwd)/alt-store
     ;;
 esac

--- a/extra-tests/dummy-does-not-depend-on-flake-source-via-path/flake.nix
+++ b/extra-tests/dummy-does-not-depend-on-flake-source-via-path/flake.nix
@@ -1,7 +1,7 @@
 {
   inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     crane.url = "github:ipetkov/crane";
-    nixpkgs.follows = "crane/nixpkgs";
     flake-utils.url = "github:numtide/flake-utils";
   };
 

--- a/extra-tests/dummy-does-not-depend-on-flake-source-via-path/test.sh
+++ b/extra-tests/dummy-does-not-depend-on-flake-source-via-path/test.sh
@@ -5,7 +5,8 @@ set -eu
 scriptDir=$(dirname "$0")
 cd "${scriptDir}"
 
-craneOverride="--override-input crane ../.."
+nixpkgsOverride="$(../../ci/ref-from-lock.sh ../../test#nixpkgs)"
+craneOverride="--override-input crane ../.. --override-input nixpkgs ${nixpkgsOverride}"
 flakeSrc=$(nix flake metadata ${craneOverride} --json 2>/dev/null | jq -r '.path')
 
 # Get information about the default derivation

--- a/extra-tests/dummy-does-not-depend-on-flake-source-via-self/flake.nix
+++ b/extra-tests/dummy-does-not-depend-on-flake-source-via-self/flake.nix
@@ -1,7 +1,7 @@
 {
   inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     crane.url = "github:ipetkov/crane";
-    nixpkgs.follows = "crane/nixpkgs";
     flake-utils.url = "github:numtide/flake-utils";
   };
 

--- a/extra-tests/dummy-does-not-depend-on-flake-source-via-self/test.sh
+++ b/extra-tests/dummy-does-not-depend-on-flake-source-via-self/test.sh
@@ -5,7 +5,8 @@ set -eu
 scriptDir=$(dirname "$0")
 cd "${scriptDir}"
 
-craneOverride="--override-input crane ../.."
+nixpkgsOverride="$(../../ci/ref-from-lock.sh ../../test#nixpkgs)"
+craneOverride="--override-input crane ../.. --override-input nixpkgs ${nixpkgsOverride}"
 flakeSrc=$(nix flake metadata ${craneOverride} --json 2>/dev/null | jq -r '.path')
 
 # Get information about the default derivation

--- a/extra-tests/fetch-cargo-git/flake.nix
+++ b/extra-tests/fetch-cargo-git/flake.nix
@@ -1,7 +1,7 @@
 {
   inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     crane.url = "github:ipetkov/crane";
-    nixpkgs.follows = "crane/nixpkgs";
     flake-utils.url = "github:numtide/flake-utils";
   };
 

--- a/extra-tests/fetch-cargo-git/test.sh
+++ b/extra-tests/fetch-cargo-git/test.sh
@@ -5,7 +5,8 @@ set -eu
 scriptDir=$(dirname "$0")
 cd "${scriptDir}"
 
-craneOverride="--override-input crane ../.."
+nixpkgsOverride="$(../../ci/ref-from-lock.sh ../../test#nixpkgs)"
+craneOverride="--override-input crane ../.. --override-input nixpkgs ${nixpkgsOverride}"
 
 # Try fetching the git verision of cargo
 nix build ${craneOverride} .#cargo-git

--- a/flake.lock
+++ b/flake.lock
@@ -1,26 +1,6 @@
 {
   "nodes": {
-    "nixpkgs": {
-      "locked": {
-        "lastModified": 1724300212,
-        "narHash": "sha256-x3jl6OWTs+L9C7EtscuWZmGZWI0iSBDafvg3X7JMa1A=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "4de4818c1ffa76d57787af936e8a23648bda6be4",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "root": {
-      "inputs": {
-        "nixpkgs": "nixpkgs"
-      }
-    }
+    "root": {}
   },
   "root": "root",
   "version": 7

--- a/test/flake.lock
+++ b/test/flake.lock
@@ -93,16 +93,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1724490791,
-        "narHash": "sha256-Uw7NvIky7bzk3zBQgxUySyaKGrnmPtn8ZdCzDWbfByg=",
+        "lastModified": 1724300212,
+        "narHash": "sha256-x3jl6OWTs+L9C7EtscuWZmGZWI0iSBDafvg3X7JMa1A=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c7eb282d733ee64a11b9153b0e471413bd56776b",
+        "rev": "4de4818c1ffa76d57787af936e8a23648bda6be4",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "release-24.05",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -139,6 +139,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-latest-release": {
+      "locked": {
+        "lastModified": 1724490791,
+        "narHash": "sha256-Uw7NvIky7bzk3zBQgxUySyaKGrnmPtn8ZdCzDWbfByg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c7eb282d733ee64a11b9153b0e471413bd56776b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "release-24.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "advisory-db": "advisory-db",
@@ -149,6 +165,7 @@
         "nixpkgs": "nixpkgs",
         "nixpkgs-darwin": "nixpkgs-darwin",
         "nixpkgs-for-wasm-bindgen": "nixpkgs-for-wasm-bindgen",
+        "nixpkgs-latest-release": "nixpkgs-latest-release",
         "rust-overlay": "rust-overlay"
       }
     },

--- a/test/flake.nix
+++ b/test/flake.nix
@@ -14,10 +14,7 @@
       flake = false;
     };
 
-    crane = {
-      url = "github:ipetkov/crane";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
+    crane.url = "github:ipetkov/crane";
 
     fenix = {
       url = "github:nix-community/fenix";

--- a/test/flake.nix
+++ b/test/flake.nix
@@ -1,7 +1,8 @@
 {
   inputs = {
     # NB: nixpkgs-unstable testing will come from the root flake
-    nixpkgs.url = "github:NixOS/nixpkgs/release-24.05";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    nixpkgs-latest-release.url = "github:NixOS/nixpkgs/release-24.05";
     nixpkgs-darwin.url = "github:NixOS/nixpkgs/nixpkgs-24.05-darwin";
 
     # The version of wasm-bindgen-cli needs to match the version in Cargo.lock


### PR DESCRIPTION
## Motivation
`crane.lib.${system}` has been marked as deprecated for a while, so it's time to remove it. Downstream consumers should instead use `crane.mkLib pkgs`

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [ ] added tests to verify new behavior
- [x] added an example template or updated an existing one
- [ ] updated `docs/API.md` (or general documentation) with changes
- [x] updated `CHANGELOG.md`
