### PR TITLE
Automatically filter out empty directories in `cleanCargoSource`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Changed
+
+* `cleanCargoSource` will now automatically filter out empty directories to
+  avoid causing unnecessary rebuilds.
+
 ## [0.19.1] - 2024-10-12
 
 ### Added

--- a/lib/cleanCargoSource.nix
+++ b/lib/cleanCargoSource.nix
@@ -3,12 +3,17 @@
 , lib
 }:
 
-src: lib.cleanSourceWith {
-  # Apply the default source cleaning from nixpkgs
-  src = lib.cleanSource src;
+src: lib.fileset.toSource {
+  root = src;
 
-  # Then add our own filter on top
-  filter = filterCargoSources;
+  # Filter out empty directories by converting back and forth from a file set
+  fileset = lib.fileset.fromSource (lib.cleanSourceWith {
+    # Apply the default source cleaning from nixpkgs
+    src = lib.cleanSource src;
 
-  name = internalCrateNameForCleanSource src;
+    # Then add our own filter on top
+    filter = filterCargoSources;
+
+    name = internalCrateNameForCleanSource src;
+  });
 }


### PR DESCRIPTION
## Motivation
<!--
Thank you for your contribution! Please add a brief description below about the change and what is the motivation
behind it.
-->
Currently, the source filtering done by `cleanCargoSource` causes a lot of empty directories to be copied into the build when all the files in them are filtered out. For example, I noticed that the `/target` directory is copied by default, but it only contains other empty directories. This PR filters out all empty directories in `cleanCargoSource` to avoid unnecessary rebuilds.

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [ ] updated `docs/API.md` (or general documentation) with changes
- [x] updated `CHANGELOG.md`
