### PR TITLE
Add `cargoFileset`

### DIFF
--- a/checks/default.nix
+++ b/checks/default.nix
@@ -346,6 +346,42 @@ in
 
   features = callPackage ./features { };
 
+  fileset = myLib.buildPackage {
+    src = lib.fileset.toSource {
+      root = ./simple;
+      fileset = myLib.cargoFileset ./simple;
+    };
+  };
+
+  filesetBuildScript = myLib.buildPackage {
+    src = lib.fileset.toSource {
+      root = ./with-build-script;
+      fileset = myLib.cargoFileset ./with-build-script;
+    };
+  };
+
+  filesetWorkspace = myLib.buildPackage {
+    src = lib.fileset.toSource {
+      root = ./workspace;
+      fileset = myLib.cargoFileset ./workspace;
+    };
+  };
+
+  filesetWorkspaceInheritance = myLib.buildPackage {
+    src = lib.fileset.toSource {
+      root = ./workspace-inheritance;
+      fileset = myLib.cargoFileset ./workspace-inheritance;
+    };
+  };
+
+  filesetWorkspaceRoot = myLib.buildPackage {
+    src = lib.fileset.toSource {
+      root = ./workspace-root;
+      fileset = myLib.cargoFileset ./workspace-root;
+    };
+    pname = "workspace-root";
+  };
+
   gitOverlappingRepo = myLib.buildPackage {
     src = ./git-overlapping;
   };

--- a/lib/cargoFileset.nix
+++ b/lib/cargoFileset.nix
@@ -1,0 +1,10 @@
+{ lib }:
+# A fileset that includes the minimum files needed to build a Rust project with Cargo
+with lib.fileset;
+path: unions [
+  # Cargo files
+  (fileFilter (file: file.name == "Cargo.toml" || file.name == "Cargo.lock") path)
+  (maybeMissing (path + ./.cargo/config.toml))
+  # any Rust source files
+  (fileFilter (file: file.hasExt "rs") path)
+]

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -60,6 +60,7 @@ let
       cargoDeny = callPackage ./cargoDeny.nix { };
       cargoDoc = callPackage ./cargoDoc.nix { };
       cargoDocTest = callPackage ./cargoDocTest.nix { };
+      cargoFileset = callPackage ./cargoFileset.nix { };
       cargoFmt = callPackage ./cargoFmt.nix { };
       cargoHelperFunctionsHook = callPackage ./setupHooks/cargoHelperFunctions.nix { };
       cargoLlvmCov = callPackage ./cargoLlvmCov.nix { };


### PR DESCRIPTION
## Motivation
<!--
Thank you for your contribution! Please add a brief description below about the change and what is the motivation
behind it.
-->
This PR adds a `cargoFileset` function that includes the minimum files required to build. This allows using the new `lib.fileset` API for source filtering, which is much easier to use and automatically filters out empty directories (https://github.com/ipetkov/crane/pull/725).

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [x] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [ ] updated `docs/API.md` (or general documentation) with changes
- [ ] updated `CHANGELOG.md`
