### PR TITLE
removeReferencesToVendoredSourcesHook: dedup references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Fixed
+* `removeReferencesToVendoredSources` now deduplicates any found references to
+  avoid pathological memory usage before removing them.
+
 ## [0.19.3] - 2024-11-18
 A republish of 0.19.2 which was incorrectly tagged.
 

--- a/lib/setupHooks/removeReferencesToVendoredSourcesHook.sh
+++ b/lib/setupHooks/removeReferencesToVendoredSourcesHook.sh
@@ -23,6 +23,7 @@ removeReferencesToVendoredSources() {
             xargs -I DIR find -H DIR -type l -exec readlink '{}' \;
         ) |
           grep --only-matching '@storeDir@/[a-z0-9]\{32\}' |
+          sort -u |
           while read crateSource; do
             echo -n '\|'"${crateSource#@storeDir@/}";
           done || true # Handle if vendoredDir doesn't point to the store


### PR DESCRIPTION
## Motivation
Debug builds might have a ton of references to sources, and `sed` does not like it when we feed it a massive amount of duplicates

Fixes https://github.com/ipetkov/crane/issues/744

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [ ] updated `docs/API.md` (or general documentation) with changes
- [x] updated `CHANGELOG.md`
