### PR TITLE
nixpkgs: drop support for 24.05

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,11 +31,9 @@ jobs:
       matrix:
         include:
             # Latest and greatest release of Nix
-            #- install_url: https://nixos.org/nix/install
-            # The latest nix releases keep being broken, stick to what's in NixOS
-          - install_url: https://releases.nixos.org/nix/nix-2.18.2/install
-            # The 24.05 branch ships with Nix 2.18.2
-          - install_url: https://releases.nixos.org/nix/nix-2.18.2/install
+          - install_url: https://nixos.org/nix/install
+            # The 24.11 branch ships with Nix 2.24.10
+          - install_url: https://releases.nixos.org/nix/nix-2.24.10/install
             nixpkgs-override: "--override-input nixpkgs $(./ci/ref-from-lock.sh ./test#nixpkgs-latest-release)"
     runs-on: ubuntu-latest
     steps:
@@ -75,10 +73,6 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: cachix/install-nix-action@v30
-      with:
-        #install_url: https://nixos.org/nix/install
-        # The latest nix releases keep being broken, stick to what's in NixOS
-        install_url: https://releases.nixos.org/nix/nix-2.18.2/install
     - uses: cachix/cachix-action@v15
       with:
         name: crane
@@ -99,10 +93,6 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: cachix/install-nix-action@v30
-      with:
-        #install_url: https://nixos.org/nix/install
-        # The latest nix releases keep being broken, stick to what's in NixOS
-        install_url: https://releases.nixos.org/nix/nix-2.18.2/install
     - uses: cachix/cachix-action@v15
       with:
         name: crane

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Changed
+* **Breaking**: dropped compatibility for Nix versions below 2.24.10
+* **Breaking**: dropped compatibility for nixpkgs-23.11
+
 ## [0.19.4] - 2024-11-30
 
 ### Fixed

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -11,7 +11,7 @@
 }:
 
 let
-  minSupported = "24.05";
+  minSupported = "24.11";
   current = lib.concatStringsSep "." (lib.lists.sublist 0 2 (lib.splitVersion lib.version));
   isUnsupported = lib.versionOlder current minSupported;
   msg = "crane requires at least nixpkgs-${minSupported}, supplied nixpkgs-${current}";

--- a/test/flake.lock
+++ b/test/flake.lock
@@ -104,16 +104,16 @@
     },
     "nixpkgs-latest-release": {
       "locked": {
-        "lastModified": 1731954261,
-        "narHash": "sha256-xk83zrDElaMXiHI8DH6sLLTix5+ijPYmIusiQ16GDdc=",
+        "lastModified": 1732988994,
+        "narHash": "sha256-mg45yzpgvsoQKL5egbBCfq4BtpRxg2/RsE1TL60GdGI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ad2c28c6c5cc04e09bed68db46db5718d40b5b9e",
+        "rev": "ff5fd5aff0b38eca6461d9a4d64e3ea672077939",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "release-24.05",
+        "ref": "release-24.11",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/test/flake.nix
+++ b/test/flake.nix
@@ -1,8 +1,7 @@
 {
   inputs = {
-    # NB: nixpkgs-unstable testing will come from the root flake
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
-    nixpkgs-latest-release.url = "github:NixOS/nixpkgs/release-24.05";
+    nixpkgs-latest-release.url = "github:NixOS/nixpkgs/release-24.11";
 
     advisory-db = {
       url = "github:rustsec/advisory-db";


### PR DESCRIPTION
## Motivation
There's a new nixpkgs-stable release (24.11), so switch to testing with that

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [x] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [ ] updated `docs/API.md` (or general documentation) with changes
- [x] updated `CHANGELOG.md`
