### PR TITLE
Replace %2F with / in url for branch

### DIFF
--- a/lib/vendorGitDeps.nix
+++ b/lib/vendorGitDeps.nix
@@ -139,8 +139,12 @@ let
       let
         p = head ps;
         extractAttr = attr:
-          if p ? ${attr} then ''
-            ${attr} = "${p.${attr}}"
+          if p ? ${attr} then let
+            patchedAttr = if attr == "branch"
+            then builtins.replaceStrings ["%2F"] ["/"] "${p.${attr}}"
+            else "${p.${attr}}";
+          in ''
+            ${attr} = "${patchedAttr}"
           '' else "";
         sourceValues = concatMapStrings extractAttr ([ "git" ] ++ knownGitParams);
       in


### PR DESCRIPTION
## Motivation

I found that the URL encoding that is put into the `Cargo.lock` file by cargo does not work in a nix build using crane, because crane does not decode the url in the generated source replacement `config.toml`.

FWIW, I know that this patch cannot be the actual solution to the problem, but it is a proof of concept that this is the issue.

We (@TheNeikos and I) used this repository:

https://github.com/cloudroots/erased-serde

with this branch: `feature/make_make_serializer_public` in the repo where we encountered the issue (unfortunately, that repo is still proprietary and closed source).

In the `branch` setting in the generated source replacement `config.toml` is `branch = "feature%2Fmake_make_serializer_public"` - which does not work with cargo and results in cargo failing during buildtime (unfortunately with `Temporary failure in name resolution for github.com`, which is not really helping here).

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [ ] updated `docs/API.md` (or general documentation) with changes
- [ ] updated `CHANGELOG.md`
