### PR TITLE
cargoNextest: support passing extra args to each partition run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Added
+* `cargoNextest` now supports passing `cargoNextestPartitionsExtraArgs` to each
+  `cargo nextest` partition run.
+
 ## [0.20.0] - 2024-12-21
 
 ### Changed

--- a/checks/nextest.nix
+++ b/checks/nextest.nix
@@ -27,6 +27,7 @@ let
     partitions = 4;
     partitionType = "hash";
     cargoArtifacts = null;
+    cargoNextestPartitionsExtraArgs = "--no-tests=pass";
   };
 
   nextestProcMacro = withLlvmCov: cargoNextest {
@@ -34,6 +35,7 @@ let
     src = ./proc-macro;
     pname = "nextest-proc-macro${lib.optionalString withLlvmCov "-llvm-cov"}";
     cargoArtifacts = null;
+    cargoNextestExtraArgs = "--no-tests=pass";
   };
 in
 linkFarmFromDrvs "nextestTests" [

--- a/docs/API.md
+++ b/docs/API.md
@@ -690,6 +690,8 @@ Except where noted below, all derivation attributes are delegated to
   (e.g. specifying a profile)
   - Default value: `""`
   - Note that all flags from `cargo test` are supported.
+* `cargoNextestPartitionsExtraArgs`: additional flags to be passed in the nextest partition invocation
+  - Default value: `""`
 * `partitions`: The number of separate nextest partitions to run. Useful if the
   test suite takes a long time and can be parallelized across multiple build
   nodes.
@@ -714,6 +716,7 @@ environment variables during the build, you can bring them back via
 * `cargoExtraArgs`
 * `cargoLlvmCovExtraArgs`
 * `cargoNextestExtraArgs`
+* `cargoNextestPartitionsExtraArgs`
 * `partitions`
 * `partitionType`
 * `withLlvmCov`

--- a/examples/quick-start-workspace/flake.nix
+++ b/examples/quick-start-workspace/flake.nix
@@ -144,6 +144,7 @@
             inherit cargoArtifacts;
             partitions = 1;
             partitionType = "count";
+            cargoNextestPartitionsExtraArgs = "--no-tests=pass";
           });
 
           # Ensure that cargo-hakari is up to date

--- a/examples/quick-start/flake.nix
+++ b/examples/quick-start/flake.nix
@@ -111,6 +111,7 @@
             inherit cargoArtifacts;
             partitions = 1;
             partitionType = "count";
+            cargoNextestPartitionsExtraArgs = "--no-tests=pass";
           });
         };
 

--- a/lib/cargoNextest.nix
+++ b/lib/cargoNextest.nix
@@ -11,6 +11,7 @@
 , cargoExtraArgs ? ""
 , cargoLlvmCovExtraArgs ? "--lcov --output-path $out/coverage"
 , cargoNextestExtraArgs ? ""
+, cargoNextestPartitionsExtraArgs ? ""
 , doInstallCargoArtifacts ? true
 , partitions ? 1
 , partitionType ? "count"
@@ -22,6 +23,7 @@ let
     "cargoExtraArgs"
     "cargoLlvmCovExtraArgs"
     "cargoNextestExtraArgs"
+    "cargoNextestPartitionsExtraArgs"
     "partitions"
     "partitionType"
     "withLlvmCov"
@@ -75,11 +77,11 @@ else # First build the tests in one derivation, then run each partition in anoth
       mkCargoDerivation ((mkUpdatedArgs {
         inherit withLlvmCov;
         extraSuffix = "-p${toString n}";
-        moreArgs = builtins.concatStringsSep " " [
+        moreArgs = builtins.concatStringsSep " " ([
           "${mkArchiveArgs archive}"
           "--workspace-remap ."
           "--partition ${partitionType}:${n}/${toString partitions}"
-        ];
+        ] ++ lib.optional (cargoNextestPartitionsExtraArgs != "") cargoNextestPartitionsExtraArgs);
       }) // {
         # Everything we need is already in the archive
         cargoArtifacts = null;


### PR DESCRIPTION
## Motivation
Newer versions of `cargo nextest` will error out if a partition does not have any tests, so it can be useful to pass `--no-tests=pass` (for example) to those runs.

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [ ] added tests to verify new behavior
- [x] added an example template or updated an existing one
- [x] updated `docs/API.md` (or general documentation) with changes
- [x] updated `CHANGELOG.md`
