### PR TITLE
Add craneLib as self-reference to lib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 * `cargoNextest` now supports passing `cargoNextestPartitionsExtraArgs` to each
   `cargo nextest` partition run.
-* Add self-reference `craneLib` to crane lib.
+* Add self-reference `craneLib` to crane lib instance.
 
 ## [0.20.0] - 2024-12-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Added
 * `cargoNextest` now supports passing `cargoNextestPartitionsExtraArgs` to each
   `cargo nextest` partition run.
 * Add self-reference `craneLib` to crane lib instance.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+* Add self-reference `craneLib` to crane lib.
+
 ## [0.20.0] - 2024-12-21
 
 ### Changed

--- a/docs/API.md
+++ b/docs/API.md
@@ -1766,6 +1766,10 @@ directory of vendored crate sources. It takes two positional arguments:
 `configureCargoVendoredDeps "$cargoVendorDir" "$CARGO_HOME/config.toml"` will be
 run as a pre configure hook.
 
+### `craneLib.craneLib`
+
+A self-reference to the crane lib instance.
+
 ### `craneLib.inheritCargoArtifactsHook`
 
 Defines `inheritCargoArtifacts()` which will pre-populate cargo's artifact
@@ -1925,7 +1929,3 @@ Defines `replaceCargoLock()` which handles replacing or inserting a specified
 run as a pre patch hook.
 
 [fileset]: https://nixos.org/manual/nixpkgs/unstable/#sec-functions-library-fileset
-
-### `craneLib.craneLib`
-
-A self-reference to the crane lib instance.

--- a/docs/API.md
+++ b/docs/API.md
@@ -1922,3 +1922,7 @@ Defines `replaceCargoLock()` which handles replacing or inserting a specified
 run as a pre patch hook.
 
 [fileset]: https://nixos.org/manual/nixpkgs/unstable/#sec-functions-library-fileset
+
+### `craneLib.craneLib`
+
+A self-reference to the crane lib instance.

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -48,6 +48,8 @@ let
       internalPercentDecode = callPackage ./internalPercentDecode.nix { };
     in
     {
+      craneLib = self;
+
       appendCrateRegistries = input: self.overrideScope (_final: prev: {
         crateRegistries = prev.crateRegistries // (lib.foldl (a: b: a // b) { } input);
       });

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -48,8 +48,6 @@ let
       internalPercentDecode = callPackage ./internalPercentDecode.nix { };
     in
     {
-      craneLib = self;
-
       appendCrateRegistries = input: self.overrideScope (_final: prev: {
         crateRegistries = prev.crateRegistries // (lib.foldl (a: b: a // b) { } input);
       });
@@ -75,6 +73,7 @@ let
       cleanCargoToml = callPackage ./cleanCargoToml.nix { };
       configureCargoCommonVarsHook = callPackage ./setupHooks/configureCargoCommonVars.nix { };
       configureCargoVendoredDepsHook = callPackage ./setupHooks/configureCargoVendoredDeps.nix { };
+      craneLib = self;
       craneUtils = callPackage ../pkgs/crane-utils { };
 
       crateNameFromCargoToml = callPackage ./crateNameFromCargoToml.nix {


### PR DESCRIPTION
## Motivation
This just adds `self` as `craneLib` to the crane lib attrset.

Motivation here is to allow to `callPackage` other file and access the crane lib instance in there.

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [x] updated `docs/API.md` (or general documentation) with changes
- [x] updated `CHANGELOG.md`
