### PR TITLE
doc: fix fileset filtering

### DIFF
--- a/docs/source-filtering.md
+++ b/docs/source-filtering.md
@@ -57,7 +57,7 @@ let
       # Default files from crane (Rust and cargo files)
       (craneLib.fileset.commonCargoSources unfilteredRoot)
       # Also keep any markdown files
-      (lib.fileset.fileFilter (file: file.hasExt == "md") unfilteredRoot)
+      (lib.fileset.fileFilter (file: file.hasExt "md") unfilteredRoot)
       # Example of a folder for images, icons, etc
       (lib.fileset.maybeMissing ./assets)
     ];


### PR DESCRIPTION
`hasExt` only takes the extension as an argument

## Motivation
<!--
Thank you for your contribution! Please add a brief description below about the change and what is the motivation
behind it.
-->

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [ ] updated `docs/API.md` (or general documentation) with changes
- [ ] updated `CHANGELOG.md`
