### PR TITLE
crane-utils/buildRustPackage - useFetchCargoVendor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [0.20.2] - 2025-02-17
 
 ### Changed
-* `pkgs/crane-utils` using `useFetchCargoVendor` instead of `fetchCargoTarball` as it is now deprecated.
+* `craneUtils` (used internally for vendoring git dependencies) now uses
+  `importCargoLock` to fetch its own dependencies instead of the (now
+  deprecated) `fetchCargoTarball` method.
 
 ## [0.20.1] - 2025-02-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## [0.20.2] - 2025-02-17
+
+### Changed
+* `pkgs/crane-utils` using `useFetchCargoVendor` instead of `fetchCargoTarball` as it is now deprecated.
+
 ## [0.20.1] - 2025-02-08
 
 ### Added

--- a/pkgs/crane-utils/default.nix
+++ b/pkgs/crane-utils/default.nix
@@ -5,7 +5,6 @@
 rustPlatform.buildRustPackage {
   pname = "crane-utils";
   version = "0.0.1";
-  useFetchCargoVendor = true;
 
   src = lib.sourceFilesBySuffices ./. [ ".rs" ".toml" ".lock" ];
   cargoLock = { lockFile = ./Cargo.lock; };

--- a/pkgs/crane-utils/default.nix
+++ b/pkgs/crane-utils/default.nix
@@ -5,8 +5,8 @@
 rustPlatform.buildRustPackage {
   pname = "crane-utils";
   version = "0.0.1";
+  useFetchCargoVendor = true;
 
   src = lib.sourceFilesBySuffices ./. [ ".rs" ".toml" ".lock" ];
-
-  cargoHash = "sha256-yVe6BIUuZygz44GiPRWAjMCU9IbglyrS2RAuLcP+3Ls=";
+  cargoLock = { lockFile = ./Cargo.lock; };
 }

--- a/pkgs/crane-utils/default.nix
+++ b/pkgs/crane-utils/default.nix
@@ -7,5 +7,5 @@ rustPlatform.buildRustPackage {
   version = "0.0.1";
 
   src = lib.sourceFilesBySuffices ./. [ ".rs" ".toml" ".lock" ];
-  cargoLock = { lockFile = ./Cargo.lock; };
+  cargoLock.lockFile = ./Cargo.lock;
 }


### PR DESCRIPTION
## Motivation
https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2505.section.md

`rustPlatform.fetchCargoTarball` has been deprecated - replace with `useFetchCargoVendor`

Mainly tested this on some private repos which were failing after upgrading to latest version of rust (and throwing a deprecation warning).

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [ ] updated `docs/API.md` (or general documentation) with changes
- [x] updated `CHANGELOG.md`
