### PR TITLE
fix: Don't ignore installPhaseCommand in trunkBuildPackage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Fixed
+* `buildTrunkPackage` no longer ignores `installPhase` and `installPhaseCommand` args.
+
 ## [0.20.2] - 2025-02-17
 
 ### Changed

--- a/lib/buildTrunkPackage.nix
+++ b/lib/buildTrunkPackage.nix
@@ -39,8 +39,6 @@ in
 }@origArgs:
 let
   cleanedArgs = builtins.removeAttrs origArgs [
-    "installPhase"
-    "installPhaseCommand"
     "trunkExtraArgs"
     "trunkExtraBuildArgs"
     "trunkIndexPath"


### PR DESCRIPTION
## Motivation
`buildTrunkPackage` will attempt to read `installPhaseCommand` from the args, however we were stripping out `installPhaseCommand` from the args before we try to read it. This PR simply no longer strips `installPhaseCommand` from the args.

I also removed the filter for `installPhase` since it doesn't seem like there is really any need for it (even though users probably have no need to override `installPhase` if they can control `installPhaseCommand`)

## Checklist
- [x] added tests to verify new behavior
- [x] added an example template or updated an existing one
- [x] updated `docs/API.md` (or general documentation) with changes
- [x] updated `CHANGELOG.md`
