### PR TITLE
fix: `buildInputs` camel case

### DIFF
--- a/examples/end-to-end-testing/flake.nix
+++ b/examples/end-to-end-testing/flake.nix
@@ -84,7 +84,7 @@
         });
 
         devShells.default = pkgs.mkShell {
-          BuildInputs = with pkgs; [
+          buildInputs = with pkgs; [
             rustc
             cargo
           ] ++ (lib.optionals (!pkgs.stdenv.isDarwin) [


### PR DESCRIPTION
## Motivation
<!--
Thank you for your contribution! Please add a brief description below about the change and what is the motivation
behind it.
-->

The devshell is broken for `end-to-end-testing`. This changes `buildInputs` from pascal to camel case.

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [ ] updated `docs/API.md` (or general documentation) with changes
- [ ] updated `CHANGELOG.md`
