### PR TITLE
doc: Add fileset filtering in flake checks section to FAQ/troubleshooting

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -47,6 +47,7 @@
   * [Found invalid metadata files for crate error](./faq/invalid-metadata-files-for-crate.md)
   * [A git dependency fails to find a file by a relative path](./faq/git-dep-cannot-find-relative-path.md)
   * [Controlling whether or not hooks run during `buildDepsOnly`](./faq/control-when-hooks-run.md)
+  * [Missing files during `checks` when filtering with filesets](./faq/missing-files-during-checks.md)
 ---
 * [Advanced Techniques](./advanced/advanced.md)
   * [Overriding function behavior](./advanced/overriding-function-behavior.md)

--- a/docs/faq/missing-files-during-checks.md
+++ b/docs/faq/missing-files-during-checks.md
@@ -1,0 +1,41 @@
+## Missing files during `checks` when filtering with filesets
+
+One sanity check if you are running into `NotFound` errors for flake checks, is
+to double check that the derivations built in `checks` have the appropriate
+sources. Consider the following:
+
+The `checks` attribute, which may have a `my-workspace-nextest` attribute that
+runs `cargo-nextest`, for example, by default only needs the `commonArgs` and
+`cargoArtifacts` in order to run tests. However, in cases where tests rely on
+reading files, the `src` attribute can also be declared so that the files will
+be included when the tests are run. This could also be true for checks like
+`my-workspace-clippy`, if markdown files are included in rust doc comments.
+
+```nix
+checks.my-workspace-nextest =
+  let
+    workspace.root = ./.;
+    # Keep markdown files for doc generation, or compilation if using the
+    # `include` rust macro.
+    docSources = from: lib.fileset.fileFilter (file: file.hasExt "md") from;
+    # Keep json files for testing.
+    testDataSources = from: lib.fileset.fileFilter (file: file.hasExt "json") from;
+  in
+  craneLib.cargoNextest (buildArgs // {
+    inherit cargoArtifacts;
+    src = lib.fileset.toSource {
+      inherit (workspace) root;
+      fileset = lib.fileset.unions [
+        ./Cargo.toml
+        ./Cargo.lock
+        ./src
+        (craneLib.fileset.commonCargoSources workspace.root)
+        (docSources workspace.root)
+        (testDataSources workspace.root)
+      ];
+    };
+    partitions = 1;
+    partitionType = "count";
+    cargoNextestExtraArgs = "--no-tests=warn";
+  });
+```

--- a/docs/source-filtering.md
+++ b/docs/source-filtering.md
@@ -69,41 +69,4 @@ craneLib.buildPackage {
 }
 ```
 
-### Fileset filtering in flake checks
-
-One sanity check if you are running into `NotFound` errors for flake checks, is to double check that the derivations
-built in `checks` have the appropriate sources. Consider the following:
-
-The `checks` attribute, which may have a `my-workspace-nextest` attribute that runs `cargo-nextest`, for example,
-by default only needs the `commonArgs` and `cargoArtifacts` in order to run tests. However, in cases where tests rely on
-reading files, the `src` attribute can also be declared so that the files will be included when the tests are run. 
-This could also be true for checks like `my-workspace-clippy`, if markdown files are included in rust doc comments.
-```nix
-checks.my-workspace-nextest =
-  let
-    workspace.root = ./.;
-    # Keep markdown files for doc generation, or compilation if using the `include` rust macro.
-    docSources = from: lib.fileset.fileFilter (file: file.hasExt "md") from;
-    # Keep json files for testing.
-    testDataSources = from: lib.fileset.fileFilter (file: file.hasExt "json") from;
-  in
-  craneLib.cargoNextest (buildArgs // {
-    inherit cargoArtifacts;
-    src = lib.fileset.toSource {
-      inherit (workspace) root;
-      fileset = lib.fileset.unions [
-        ./Cargo.toml
-        ./Cargo.lock
-        ./src
-        (craneLib.fileset.commonCargoSources workspace.root)
-        (docSources workspace.root)
-        (testDataSources workspace.root)
-      ];
-    };
-    partitions = 1;
-    partitionType = "count";
-    cargoNextestExtraArgs = "--no-tests=warn";
-  });
-```
-
 [filesets]: https://nixos.org/manual/nixpkgs/unstable/#sec-functions-library-fileset

--- a/docs/source-filtering.md
+++ b/docs/source-filtering.md
@@ -69,4 +69,41 @@ craneLib.buildPackage {
 }
 ```
 
+### Fileset filtering in flake checks
+
+One sanity check if you are running into `NotFound` errors for flake checks, is to double check that the derivations
+built in `checks` have the appropriate sources. Consider the following:
+
+The `checks` attribute, which may have a `my-workspace-nextest` attribute that runs `cargo-nextest`, for example,
+by default only needs the `commonArgs` and `cargoArtifacts` in order to run tests. However, in cases where tests rely on
+reading files, the `src` attribute can also be declared so that the files will be included when the tests are run. 
+This could also be true for checks like `my-workspace-clippy`, if markdown files are included in rust doc comments.
+```nix
+checks.my-workspace-nextest =
+  let
+    workspace.root = ./.;
+    # Keep markdown files for doc generation, or compilation if using the `include` rust macro.
+    docSources = from: lib.fileset.fileFilter (file: file.hasExt "md") from;
+    # Keep json files for testing.
+    testDataSources = from: lib.fileset.fileFilter (file: file.hasExt "json") from;
+  in
+  craneLib.cargoNextest (buildArgs // {
+    inherit cargoArtifacts;
+    src = lib.fileset.toSource {
+      inherit (workspace) root;
+      fileset = lib.fileset.unions [
+        ./Cargo.toml
+        ./Cargo.lock
+        ./src
+        (craneLib.fileset.commonCargoSources workspace.root)
+        (docSources workspace.root)
+        (testDataSources workspace.root)
+      ];
+    };
+    partitions = 1;
+    partitionType = "count";
+    cargoNextestExtraArgs = "--no-tests=warn";
+  });
+```
+
 [filesets]: https://nixos.org/manual/nixpkgs/unstable/#sec-functions-library-fileset


### PR DESCRIPTION
## Motivation
<!--
Thank you for your contribution! Please add a brief description below about the change and what is the motivation
behind it.
-->
Closes #835 

Adds a section to `source-filtering.md` which explains how to handle extra file sources which may be needed by flake checks.

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [ ] updated `docs/API.md` (or general documentation) with changes
- [ ] updated `CHANGELOG.md`
