### PR TITLE
Drop support for nixpkgs-24.11

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,8 +31,8 @@ jobs:
         include:
             # Latest and greatest release of Nix
           - install_url: https://nixos.org/nix/install
-            # The 24.11 branch ships with Nix 2.24.10
-          - install_url: https://releases.nixos.org/nix/nix-2.24.10/install
+            # The 25.05 branch ships with Nix 2.28.3
+          - install_url: https://releases.nixos.org/nix/nix-2.28.3/install
             nixpkgs-override: "--override-input nixpkgs $(./ci/ref-from-lock.sh ./test#nixpkgs-latest-release)"
     runs-on: ubuntu-latest
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Changed
+* **Breaking**: dropped compatibility for Nix versions below 2.28.3
+* **Breaking**: dropped compatibility for nixpkgs-24.11
+
 ## [0.20.3] - 2025-04-23
 
 ### Added

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -12,7 +12,7 @@
 }:
 
 let
-  minSupported = "24.11";
+  minSupported = "25.05";
   current = lib.concatStringsSep "." (lib.lists.sublist 0 2 (lib.splitVersion lib.version));
   isUnsupported = lib.versionOlder current minSupported;
   msg = "crane requires at least nixpkgs-${minSupported}, supplied nixpkgs-${current}";

--- a/test/flake.lock
+++ b/test/flake.lock
@@ -104,16 +104,16 @@
     },
     "nixpkgs-latest-release": {
       "locked": {
-        "lastModified": 1747586396,
-        "narHash": "sha256-+Zrgnrkx7L/EAImu5/2XccK+cTr9cvREp8g8ZFm3LQ8=",
+        "lastModified": 1747953325,
+        "narHash": "sha256-y2ZtlIlNTuVJUZCqzZAhIw5rrKP4DOSklev6c8PyCkQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e25cc0d944da041b9e7a90057da3e7d52769e62c",
+        "rev": "55d1f923c480dadce40f5231feb472e81b0bab48",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "release-24.11",
+        "ref": "nixos-25.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/test/flake.nix
+++ b/test/flake.nix
@@ -6,7 +6,7 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
-    nixpkgs-latest-release.url = "github:NixOS/nixpkgs/release-24.11";
+    nixpkgs-latest-release.url = "github:NixOS/nixpkgs/nixos-25.05";
 
     advisory-db = {
       url = "github:rustsec/advisory-db";


### PR DESCRIPTION
## Motivation
With the release of NixOS 25.05 this bumps our minimum supported nixpkgs

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [ ] updated `docs/API.md` (or general documentation) with changes
- [ ] updated `CHANGELOG.md`
