### PR TITLE
Handling [patch] in Cargo workspaces

### DIFF
--- a/lib/vendorCargoDeps.nix
+++ b/lib/vendorCargoDeps.nix
@@ -44,10 +44,14 @@ let
     );
 
   lock = args.cargoLockParsed or (builtins.fromTOML cargoLockContents);
+
+  toml = builtins.fromTOML (readFile (src + "/Cargo.toml"));
+
+  patch = lib.attrsets.foldlAttrs (acc: registry: value: acc // value) {} (toml.patch or {});
 in
 vendorMultipleCargoDeps (
   {
-    inherit cargoConfigs;
+    inherit cargoConfigs patch src;
     cargoLockParsedList = [ lock ];
     outputHashes = args.outputHashes or { };
     overrideVendorCargoPackage = args.overrideVendorCargoPackage or (_: drv: drv);


### PR DESCRIPTION
That directive is used in Cargo to modify a dependency tree. It is especially useful for large projects where fixing the underlying crates is impractical or impossible. Unfortunately, Crane needs special handling of this case since the Cargo.lock resulting from such workspaces has no registry source nor hash for the patched dependencies.

Note that this departs from what `cargo vendor` does, since `cargo vendor` vendors the original dependency instead of the patched one. The reason we need to do this here is that while `cargo vendor` (as used e.g. in `buildRustPackage`) is used to build entire workspaces, including the vendored deps, but also the [patch] directive when compiling, Crane builds vendored dependencies together without first knowing about the patches.

## Motivation
<!--
Thank you for your contribution! Please add a brief description below about the change and what is the motivation
behind it.
-->

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [ ] updated `docs/API.md` (or general documentation) with changes
- [ ] updated `CHANGELOG.md`
