### PR TITLE
Always run checkPhase for cargoTest and cargoNextest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 * **Breaking**: dropped compatibility for Nix versions below 2.28.3
 * **Breaking**: dropped compatibility for nixpkgs-24.11
+* Always run tests when `cargoTest` or `cargoNextest` is used.
 * Windows cross builds provides pthreads as it is required for most crates.
 * `registryFromSparse` now passes `fetchurlExtraArgs` to the initial query for the
   registry's `config.json`

--- a/docs/API.md
+++ b/docs/API.md
@@ -659,7 +659,7 @@ environment variables during the build, you can bring them back via
 
 `cargoNextest :: set -> drv`
 
-Create a derivation which will run a `cargo nextest` invocation in a cargo
+Create a derivation which will always run a `cargo nextest` invocation in a cargo
 workspace. Note that [`cargo nextest` doesn't run
 doctests](https://github.com/nextest-rs/nextest/issues/16), so you may also
 want to build a `cargoDocTest` derivation.
@@ -771,7 +771,7 @@ environment variables during the build, you can bring them back via
 
 `cargoTest :: set -> drv`
 
-Create a derivation which will run a `cargo test` invocation in a cargo
+Create a derivation which will always run a `cargo test` invocation in a cargo
 workspace.
 
 Except where noted below, all derivation attributes are delegated to

--- a/lib/cargoNextest.nix
+++ b/lib/cargoNextest.nix
@@ -42,7 +42,7 @@ let
     // {
       inherit cargoArtifacts;
       pnameSuffix = "-nextest${extraSuffix}";
-      doCheck = args.doCheck or true;
+      doCheck = true;
 
       buildPhaseCargoCommand =
         args.buildPhaseCargoCommand or ''

--- a/lib/cargoTest.nix
+++ b/lib/cargoTest.nix
@@ -20,7 +20,7 @@ mkCargoDerivation (
   args
   // {
     inherit cargoArtifacts;
-    doCheck = args.doCheck or true;
+    doCheck = true;
 
     pnameSuffix = "-test";
     buildPhaseCargoCommand = "";


### PR DESCRIPTION
The outputs are not useful as they are just some
tarballs, so you cannot do something like
`nix run .#checks.tests`

## Motivation
<!--
Thank you for your contribution! Please add a brief description below about the change and what is the motivation
behind it.
-->

If a user uses the API `cargoTest` or `cargoNextest`, they probably want to run the tests. It is also a common pattern
in nix packages to set `doCheck = false`, then with a specific check output to override it to `doCheck = true` or something
similar.

So this leads to the patterns of:
```nix
let
commonArgs = {
  blah
  blah
  blah

  doCheck = false;
};
cargoArtifacts = craneLib.buildDepsOnly commonArgs;
in {
package = craneLib.buildPackages (commonArgs // { 
  inherit cargoArtifacts;
  blah
};

tests = craneLib.cargoTest (commonArgs 
  // { 
    inherit cargoArtifacts;
  });
}
```
Which when `tests` is run, it will silently pass. So if you are like me and just always run your tests in CI, you just see the green check and are happy. But in reality the tests are not running at all.

There is no reason not to run the tests because the output of these derivations are not useful for running the tests. The outputs
are just some tarballs. If the user explicitly uses `cargoTest` or `cargoNextest`, it should run the tests. 

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [x] updated `docs/API.md` (or general documentation) with changes
- [x] updated `CHANGELOG.md`
