### PR TITLE
cargoNextest: drop Darwin workaround

### DIFF
--- a/lib/cargoNextest.nix
+++ b/lib/cargoNextest.nix
@@ -51,13 +51,6 @@ let
           cargo nextest --version
         '';
 
-      # Work around Nextest bug: https://github.com/nextest-rs/nextest/issues/267
-      preCheck =
-        (args.preCheck or "")
-        + lib.optionalString stdenv.isDarwin ''
-          export DYLD_FALLBACK_LIBRARY_PATH=$(${rustc}/bin/rustc --print sysroot)/lib
-        '';
-
       checkPhaseCargoCommand = ''
         ${
           if withLlvmCov then "cargo llvm-cov nextest ${cargoLlvmCovExtraArgs}" else "cargo nextest ${cmd}"


### PR DESCRIPTION
## Motivation
This was fixed with 0.9.72, the latest NixOS stable branch has 0.9.95

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [ ] updated `docs/API.md` (or general documentation) with changes
- [ ] updated `CHANGELOG.md`
