### PR TITLE
mkDummySrc: also accept dummyBuildScript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
-### Fixed
+### Changed
+* `mkDummySrc` now accepts `dummyBuildrs` to customize the dummy source used for
+  build scripts specifically. If not specified, the value of `dummyrs` will be
+  used, otherwise, the existing default dummy build script will be used.
 
+### Fixed
 * Fix Windows pthreads being added to non-Windows platforms when cross compiling
 
 ## [0.21.1] - 2025-09-24

--- a/docs/API.md
+++ b/docs/API.md
@@ -1320,6 +1320,11 @@ build caches. More specifically:
   source files (e.g. enable certain lang features for a given target).
   - Default value: an empty `fn main` declaration and conditionally enabled
     `#![no_std]` if the `target_os` cfg is set to `"none"` or `"uefi"`.
+* `dummyBuildrs`: similar to `dummyrs` but will only be used in place of build
+  scripts
+  - Default value: `dummyrs`, if specified, otherwise, an empty `fn main`
+    declaration and conditionally enabled `#![no_std]` if the `target_os` cfg is
+    set to `"none"` or `"uefi"`.
 * `extraDummyScript`: additional shell script which will be run inside the builder
   verbatim. Useful for customizing what the dummy sources include by running any
   arbitrary commands.

--- a/lib/mkDummySrc.nix
+++ b/lib/mkDummySrc.nix
@@ -192,7 +192,7 @@ let
         dummyText = if isProcMacro cleanedCargoToml then dummyBase else dummyMain;
 
         dummyrs = args.dummyrs or (writeText "dummy.rs" dummyText);
-        dummyBuildScript = args.dummyrs or (writeText "dummyBuild.rs" dummyMain);
+        dummyBuildScript = args.dummyBuildrs or args.dummyrs or (writeText "dummyBuild.rs" dummyMain);
 
         cpDummy = prefix: path: ''
           mkdir -p ${prefix}/${dirOf path}


### PR DESCRIPTION
This allows for overriding the build script with a different value than the dummy lib.rs/main.rs files

## Motivation
Sometimes its useful to be able to use a real (or _more_ real) build script during `buildDepsOnly`. See https://github.com/ipetkov/crane/discussions/906

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [x] updated `docs/API.md` (or general documentation) with changes
- [x] updated `CHANGELOG.md`
