### PR TITLE
rebuilds-pyo3: Use python.interpreter alias

### DIFF
--- a/docs/faq/rebuilds-pyo3.md
+++ b/docs/faq/rebuilds-pyo3.md
@@ -15,7 +15,7 @@ let
   chosenPython = pkgs.python3;
 in
 craneLib.buildPackage {
-  env.PYO3_PYTHON = "${chosenPython}/bin/python";
+  env.PYO3_PYTHON = chosenPython.interpreter;
   nativeBuildInputs = [
     chosenPython
   ];


### PR DESCRIPTION
## Motivation
[python.interpreter](https://github.com/NixOS/nixpkgs/blob/1cac9ee600ce29c857bc5e9d5ac68b2572f13ff5/doc/languages-frameworks/python.section.md#attributes-on-interpreters-packages-attributes-on-interpreters-packages) gets the path to the python binary directly.

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [ ] updated `docs/API.md` (or general documentation) with changes
- [ ] updated `CHANGELOG.md`
