### PR TITLE
ci: pin Nix to 2.31.2 for now

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,8 +29,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # NB: current latest release of 2.33.0 has bugs
+          - install_url: https://releases.nixos.org/nix/nix-2.31.2/install
             # Latest and greatest release of Nix
-          - install_url: https://nixos.org/nix/install
+          #- install_url: https://nixos.org/nix/install
             # The 25.11 branch ships with Nix 2.31.2
           - install_url: https://releases.nixos.org/nix/nix-2.31.2/install
             nixpkgs-override: "--override-input nixpkgs $(./ci/ref-from-lock.sh ./test#nixpkgs-latest-release)"


### PR DESCRIPTION
## Motivation
Latest Nix installation url causes CI failures, looks like nixpkgs has patched various bugs in the nixpkgs-unstable branch, but there's no obvious way of telling `install-nix-action` to install Nix from there

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [ ] updated `docs/API.md` (or general documentation) with changes
- [ ] updated `CHANGELOG.md`
