### PR TITLE
remapPathPrefixHook: disable automatic path remapping on Darwin builders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 * **Breaking**: dropped compatibility for Nix versions below 2.31.2
 * **Breaking**: dropped compatibility for nixpkgs-25.05
+* `remapPathPrefixHook` is now do nothing when building on Darwin since the
+  current implementation results in validating build caches due to Nix behavior
+  differences between Linux and Darwin.
 
 ### Fixed
 * `mkCargoDerivation` will now set `noCompressDebugSectionsSet` to disable

--- a/docs/API.md
+++ b/docs/API.md
@@ -1940,6 +1940,8 @@ a temporary location defined by `$postBuildInstallFromCargoBuildLogOut`
 
 ### `craneLib.remapSourcePathPrefixHook`
 
+> Note: this hook is not supported when building on Darwin and will do nothing
+
 Defines `configureRustcRemapPathPrefix()` which can be used to set up a source
 map using the [`--remap-path-prefix`] option. The output of the derivation gains
 a dependency on the source code stored within the Nix store, but in return

--- a/lib/setupHooks/remapPathPrefixHook.nix
+++ b/lib/setupHooks/remapPathPrefixHook.nix
@@ -1,9 +1,27 @@
 {
+  lib,
   makeSetupHook,
+  stdenv,
 }:
 makeSetupHook {
   name = "remapPathPrefixHook";
   substitutions = {
     storeDir = builtins.storeDir;
+
+    # Unfortunately, we cannot support automatic path remapping on Darwin. The remap paths option
+    # requires absolute paths (since rustc will basically do a blind substitution). On Linux builds,
+    # each derivation is chrooted to `/build/{name-of-src}` which ends up being the same string for
+    # both the real and the deps-only derivations. On Darwin, however, this ends up being
+    # `/nix/var/nix/builds/{name-of-derivation}` which *is* different between the main and deps-only
+    # derivations. Since this value ends up in CARGO_BUILD_RUSTFLAGS, it effectively will lead to
+    # cache invalidation when the real derivation runs if the values differ.
+    #
+    # Moreover, we can't "just" replace the bytes ourselves since there's no guarantee that the
+    # original build path is the same length as the un-neutered store path. Thus we'll noop this for
+    # now on Darwin builders and leave it up to the caller to handle path remap if needed...
+    isDarwin = lib.optionalString stdenv.buildPlatform.isDarwin /* bash */ ''
+      echo 'automatic path remapping not supported on Darwin'
+      return 0
+    '';
   };
 } ./remapPathPrefixHook.sh

--- a/lib/setupHooks/remapPathPrefixHook.sh
+++ b/lib/setupHooks/remapPathPrefixHook.sh
@@ -1,4 +1,6 @@
 configureRustcRemapPathPrefix() {
+  @isDarwin@
+
   local remapTo="${1:-${src:?not defined}}"
   local remapFrom="${2:-$(pwd)}"
   local doNeuter="${3:-neuter}"


### PR DESCRIPTION
## Motivation
Unfortunately, we cannot support automatic path remapping on Darwin. The remap paths option
requires absolute paths (since rustc will basically do a blind substitution). On Linux builds,
each derivation is chrooted to `/build/{name-of-src}` which ends up being the same string for
both the real and the deps-only derivations. On Darwin, however, this ends up being
`/nix/var/nix/builds/{name-of-derivation}` which *is* different between the main and deps-only
derivations. Since this value ends up in CARGO_BUILD_RUSTFLAGS, it effectively will lead to
cache invalidation when the real derivation runs if the values differ.
  
Moreover, we can't "just" replace the bytes ourselves since there's no guarantee that the
original build path is the same length as the un-neutered store path. Thus we'll noop this for
now on Darwin builders and leave it up to the caller to handle path remap if needed...

Resolves https://github.com/ipetkov/crane/discussions/944

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [x] updated `docs/API.md` (or general documentation) with changes
- [x] updated `CHANGELOG.md`
