### PR TITLE
mkDummySrc: preserve mode and then make writeable separately

### DIFF
--- a/lib/mkDummySrc.nix
+++ b/lib/mkDummySrc.nix
@@ -360,7 +360,7 @@ in
 # xattrs at all, but this doesn't work when cp is built without xattr support. So instead we just
 # create the effect of --no-preserve=mode without using that flag: making $out writeable,
 # recursively.
-# 
+#
 # Without this, builds can fail when using macOS's Virtualization.framework to share the store into
 # a Linux VM, because its implementation of virtiofs doesn't seem to support xattrs.
 runCommand sourceName { } ''


### PR DESCRIPTION
`--no-preserve=mode` causes `cp` to attempt to clear out the xattrs,
which involves calling the fsetxattr syscall to set the
"system.posix_acl_access" xattr.

A previous attempt used `--no-preserve-mode` + `--preserve=xattr` to
prevent needing to change any xattrs at all, but this doesn't work when
`cp` is built without xattr support. So instead we just create the effect
of `--no-preserve=mode` without using that flag: making `$out` writeable,
recursively.

Without this, builds can fail when using macOS's Virtualization.framework
to share the store into a Linux VM, because its implementation of virtiofs
doesn't seem to support xattrs.

Specifically, this fixes building crane derivations with the Native
Linux Builder.


## Motivation
<!--
Thank you for your contribution! Please add a brief description below about the change and what is the motivation
behind it.
-->

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [ ] updated `docs/API.md` (or general documentation) with changes
- [ ] updated `CHANGELOG.md`
