### PR TITLE
downloadCargoPackageFromGit: use `cargo package` for creating the file list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * `mkDummySrc` can now pass the `cleanCargoTomlFilter` argument to `cleanCargoToml`
 * `craneLib.filters` exposes `cargoTomlAggressive`, `cargoTomlConservative`, and
   `cargoTomlDefault` for composition of custom filters for `cleanCargoToml`
+* `downloadCargoPackageFromGit` now uses `cargo package -l` for generating the file
+  list, resulting in more accurate include/exclude rule interpretation. This fixes
+  builds in some dependencies, notably `aws-lc-rs` from git.
 
 ## [0.23.0] - 2026-01-13
 


### PR DESCRIPTION
## Motivation
<!--
Thank you for your contribution! Please add a brief description below about the change and what is the motivation
behind it.
-->

This avoids pitfalls with `rg` misinterpreting include/exclude rules, because it uses THE SAME logic `cargo` uses for .crate files.

Because it uses Cargo itself.

Issues with lock file generation are side-stepped by using `--exclude-lockfile`, which I verified completely disables the check that the lockfile is up-to-date.

Fixes #962

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [ ] updated `docs/API.md` (or general documentation) with changes
- [x] updated `CHANGELOG.md`
