### PR TITLE
use --no-same-owner to fix tar errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Changed
+* `downloadCargoPackage` now extracts tarballs with `--no-same-owner`.
+  Ultimately this should make no difference since the Nix store will reset all
+  ownership permissions anyway, but it may avoid some spurious errors on certain
+  systems.
+
 ## [0.23.2] - 2026-03-23
 
 ### Added

--- a/lib/downloadCargoPackage.nix
+++ b/lib/downloadCargoPackage.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation {
   unpackPhase = ''
     runHook preUnpack
     mkdir -p crate
-    tar -xzf ${tarball} -C crate --strip-components=1
+    tar -xzf ${tarball} -C crate --strip-components=1 --no-same-owner
     runHook postUnpack
   '';
 


### PR DESCRIPTION
## Motivation
Add --no-same-owner to the tar command to fix ownership errors when building crates in Docker.

Without this flag, building a crate with `crane` can fail with errors like:
[`cargo-package-pin-utils> tar: .gitignore: Cannot change ownership to uid 460880, gid 5001: Invalid argument` ](https://git.kybe.xyz/2kybe3/kystash/actions/runs/39/jobs/0/attempt/1#jobstep-3-1511)

`--no-same-owner` prevents tar from setting the UID to the tar archive's encoded owner.
After adding this simple flag, it [compiles fine](https://git.kybe.xyz/2kybe3/kystash/actions/runs/44/jobs/0/attempt/1#jobstep-3-3361)

I thought that if it works for me, I might as well make a PR.

## Checklist
- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [ ] updated `docs/API.md` (or general documentation) with changes
- [ ] updated `CHANGELOG.md`
