### PR TITLE
refactor: drop remarshal dependency

### DIFF
--- a/checks/cleanCargoTomlTests/default.nix
+++ b/checks/cleanCargoTomlTests/default.nix
@@ -3,7 +3,6 @@
   filters,
   lib,
   linkFarmFromDrvs,
-  remarshal,
   runCommand,
   writeTOML,
 }:
@@ -22,11 +21,7 @@ let
         if lib.pathExists expectedPathSpecific then expectedPathSpecific else path + "/expected.toml";
     in
     runCommand "compare-${folderName}-${filterName}" { } ''
-      function reformat {
-        ${remarshal}/bin/remarshal --sort-keys -i "$1" --of toml
-      }
-
-      diff <(reformat ${expected}) <(reformat ${cleanedToml})
+      diff ${expected} ${cleanedToml}
       touch $out
     '';
   cmpAllFilters =

--- a/checks/mkDummySrcTests/default.nix
+++ b/checks/mkDummySrcTests/default.nix
@@ -2,7 +2,6 @@
   lib,
   linkFarmFromDrvs,
   mkDummySrc,
-  remarshal,
   runCommand,
   writeText,
 }:
@@ -18,15 +17,6 @@ let
     in
     runCommand "compare-${name}" { } ''
       echo ${expected} ${actual}
-      cp -r --no-preserve=ownership,mode ${expected} ./expected
-      cp -r --no-preserve=ownership,mode ${actual} ./actual
-
-      find ./expected ./actual \
-        -name Cargo.toml \
-        -exec mv '{}' '{}.bak' \; \
-        -exec ${remarshal}/bin/remarshal --sort-keys --if toml -i '{}.bak' --of toml -o '{}' \;
-      find ./expected ./actual -name Cargo.toml.bak -delete
-
       diff -r ./expected ./actual
       touch $out
     '';

--- a/lib/writeTOML.nix
+++ b/lib/writeTOML.nix
@@ -4,7 +4,7 @@
 
 let
   inherit (pkgsBuildBuild)
-    remarshal
+    yj
     runCommand
     ;
 in
@@ -13,8 +13,8 @@ runCommand name
   {
     contents = builtins.toJSON contents;
     passAsFile = [ "contents" ];
-    nativeBuildInputs = [ remarshal ];
+    nativeBuildInputs = [ yj ];
   }
   ''
-    remarshal -i $contentsPath -if json -of toml -o $out
+    cat $contentsPath | yj -jt > $out
   ''


### PR DESCRIPTION
## Motivation

Remarshal closure is huge and causes too many rebuilds on platforms without good hydra cache coverage (even aarch64-linux, because it depends on ffmpeg, gtk4, openblas among many other things)

Similar thing is proposed to nixpkgs: https://github.com/NixOS/nixpkgs/pull/464514

As a downside, yj which I have used to replace remarshal with doesn't support sorting keys during remarshal, but that is only used for checks, and it doesn't even seem to be required? It can be returned to checks though.

<!--
Thank you for your contribution! Please add a brief description below about the change and what is the motivation
behind it.
-->

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [ ] updated `docs/API.md` (or general documentation) with changes
- [ ] updated `CHANGELOG.md`
