### PR TITLE
{buildPackage,buildDepsOnly}: add `cargoBuildExtraArgs` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   Ultimately this should make no difference since the Nix store will reset all
   ownership permissions anyway, but it may avoid some spurious errors on certain
   systems.
+* `buildPackage` and `buildDepsOnly` now has a `cargoBuildExtraArgs` option for
+  passing arguments specifically to `cargoBuildCommand`.
 
 ## [0.23.2] - 2026-03-23
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -105,6 +105,9 @@ to influence its behavior.
     * `CARGO_PROFILE` can be set on the derivation to alter which cargo profile
       is selected; setting it to `""` will omit specifying a profile
       altogether.
+* `cargoBuildExtraArgs`: additional flags to be passed in the `cargoBuildCommand`
+  invocation
+  - Default value: `""`
 * `cargoCheckCommand`: A cargo (check) invocation to run during the derivation's build
   phase (in order to cache additional artifacts)
   - Default value: `"cargo check --profile release ${cargoCheckExtraArgs}"`
@@ -156,6 +159,7 @@ environment variables during the build, you can bring them back via
 `.overrideAttrs`.
 
 * `cargoBuildCommand`
+* `cargoBuildExtraArgs`
 * `cargoCheckCommand`
 * `cargoCheckExtraArgs`
 * `cargoExtraArgs`
@@ -204,6 +208,9 @@ install hooks.
     * `CARGO_PROFILE` can be set on the derivation to alter which cargo profile
       is selected; setting it to `""` will omit specifying a profile
       altogether.
+* `cargoBuildExtraArgs`: additional flags to be passed in the `cargoBuildCommand`
+  invocation
+  - Default value: `""`
 * `cargoExtraArgs`: additional flags to be passed in the cargo invocation (e.g.
   enabling specific features)
   - Default value: `"--locked"`
@@ -233,6 +240,7 @@ environment variables during the build, you can bring them back via
 `.overrideAttrs`.
 
 * `cargoBuildCommand`
+* `cargoBuildExtraArgs`
 * `cargoExtraArgs`
 * `cargoTestCommand`
 * `cargoTestExtraArgs`

--- a/lib/buildDepsOnly.nix
+++ b/lib/buildDepsOnly.nix
@@ -10,6 +10,7 @@
   cargoBuildCommand ? "cargoWithProfile build",
   cargoCheckCommand ? "cargoWithProfile check",
   cargoExtraArgs ? "--locked",
+  cargoBuildExtraArgs ? "",
   cargoTestCommand ? "cargoWithProfile test",
   cargoTestExtraArgs ? "--no-run",
   ...
@@ -20,6 +21,7 @@ let
     "cargoCheckCommand"
     "cargoCheckExtraArgs"
     "cargoExtraArgs"
+    "cargoBuildExtraArgs"
     "cargoTestCommand"
     "cargoTestExtraArgs"
     "outputHashes"
@@ -75,7 +77,7 @@ mkCargoDerivation (
     buildPhaseCargoCommand =
       args.buildPhaseCargoCommand or ''
         ${cargoCheckCommand} ${cargoExtraArgs} ${cargoCheckExtraArgs}
-        ${cargoBuildCommand} ${cargoExtraArgs}
+        ${cargoBuildCommand} ${cargoExtraArgs} ${cargoBuildExtraArgs}
       '';
 
     checkPhaseCargoCommand =

--- a/lib/buildPackage.nix
+++ b/lib/buildPackage.nix
@@ -12,6 +12,7 @@
 {
   cargoBuildCommand ? "cargoWithProfile build",
   cargoExtraArgs ? "--locked",
+  cargoBuildExtraArgs ? "",
   cargoTestCommand ? "cargoWithProfile test",
   cargoTestExtraArgs ? "",
   ...
@@ -23,6 +24,7 @@ let
   cleanedArgs = removeAttrs args [
     "cargoBuildCommand"
     "cargoExtraArgs"
+    "cargoBuildExtraArgs"
     "cargoTestCommand"
     "cargoTestExtraArgs"
     "outputHashes"
@@ -57,7 +59,7 @@ mkCargoDerivation (
     buildPhaseCargoCommand =
       args.buildPhaseCargoCommand or ''
         cargoBuildLog=$(mktemp cargoBuildLogXXXX.json)
-        ${cargoBuildCommand} --message-format json-render-diagnostics ${cargoExtraArgs} >"$cargoBuildLog"
+        ${cargoBuildCommand} --message-format json-render-diagnostics ${cargoExtraArgs} ${cargoBuildExtraArgs} >"$cargoBuildLog"
       '';
 
     checkPhaseCargoCommand =


### PR DESCRIPTION
## Motivation
<!--
Thank you for your contribution! Please add a brief description below about the change and what is the motivation
behind it.
-->

I wanted to pass a certain argument only to `cargo build` (and not `cargo check`, `cargo test`, etc.), but there's no option for it. There's already a `cargoCheckExtraArgs` and `cargoTestExtraArgs` option, so I've added an equivalent for `cargoBuildCommand`.

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [x] updated `docs/API.md` (or general documentation) with changes
- [x] updated `CHANGELOG.md`
