### PR TITLE
cargoNextest: `cargoNextestArchiveExtraArgs` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   Ultimately this should make no difference since the Nix store will reset all
   ownership permissions anyway, but it may avoid some spurious errors on certain
   systems.
+* `cargoNextest` now has a `cargoNextestArchiveExtraArgs` option for passing
+  flags to nextest archive invocations.
 
 ## [0.23.2] - 2026-03-23
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -699,6 +699,8 @@ Except where noted below, all derivation attributes are delegated to
   (e.g. specifying a profile)
   - Default value: `""`
   - Note that all flags from `cargo test` are supported.
+* `cargoNextestArchiveExtraArgs`: additional flags to be passed in the nextest archive invocation
+  - Default value: `""`
 * `cargoNextestPartitionsExtraArgs`: additional flags to be passed in the nextest partition invocation
   - Default value: `""`
 * `env.NEXTEST_SHOW_PROGRESS`: environment variable which controls nextest's progress output.

--- a/lib/cargoNextest.nix
+++ b/lib/cargoNextest.nix
@@ -11,6 +11,7 @@
   cargoExtraArgs ? "",
   cargoLlvmCovExtraArgs ? "--lcov --output-path $out/coverage",
   cargoNextestExtraArgs ? "",
+  cargoNextestArchiveExtraArgs ? "",
   cargoNextestPartitionsExtraArgs ? "",
   doInstallCargoArtifacts ? true,
   partitions ? 1,
@@ -101,7 +102,12 @@ else
     mkArchiveArgs = root: "--archive-format tar-zst --archive-file ${root}/archive.tar.zst";
     archive = mkCargoDerivation (mkUpdatedArgs {
       cmd = "archive";
-      moreArgs = mkArchiveArgs "$out";
+      moreArgs = builtins.concatStringsSep " " (
+        [
+          (mkArchiveArgs "$out")
+        ]
+        ++ lib.optional (cargoNextestArchiveExtraArgs != "") cargoNextestArchiveExtraArgs
+      );
       withLlvmCov =
         !(lib.asserts.assertMsg (!withLlvmCov) "withLLvmCov is not supported for partitioned runs");
     });


### PR DESCRIPTION
## Motivation
<!--
Thank you for your contribution! Please add a brief description below about the change and what is the motivation
behind it.
-->

Add option for passing flags to archive invocations of `cargo-nextest`. This is useful for passing flags such as `--all-features` or `--workspace`, because those flags are invalid once you are already running the tests from the pre-built archive.

Ref: https://github.com/ipetkov/crane/discussions/595#discussioncomment-16494611

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [x] updated `docs/API.md` (or general documentation) with changes
- [x] updated `CHANGELOG.md`
