### PR TITLE
mkCargoDerivation: deprecate overriding stdenv via argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * `cargoNextest` now accepts `cargoNextestArchiveExtraArgs` for passing
   flags to `cargo nextest archive` invocations.
 
+### Deprecations
+* `mkCargoDerivation` (and by extension all utilities which delegate to it) no
+  longer support overriding the `stdenv` used for `mkDerivation` via an
+  attribute. Instead any such overrides should be done at the `craneLib` level
+  via the new `stdenvSelector` function. For example: `(crane.mkLib
+  pkgs).overrideScope (final: prev: { stdenvSelector = p: p.clangStdenv; });`
+
 ## [0.23.2] - 2026-03-23
 
 ### Added

--- a/checks/default.nix
+++ b/checks/default.nix
@@ -10,6 +10,17 @@ let
   inherit (pkgs) lib;
   inherit (pkgs.stdenv) isDarwin;
   onlyDrvs = lib.filterAttrs (_: lib.isDerivation);
+
+  myLibClang = myLib.overrideScope (
+    _: _: {
+      stdenvSelector = p: p.clangStdenv;
+    }
+  );
+  myLibGcc = myLib.overrideScope (
+    _: _: {
+      stdenvSelector = p: p.gccStdenv;
+    }
+  );
 in
 onlyDrvs (
   lib.makeScope myLib.newScope (
@@ -385,9 +396,8 @@ onlyDrvs (
       };
 
       # https://github.com/ipetkov/crane/issues/188
-      depsOnlySourceName = myLib.buildPackage {
+      depsOnlySourceName = myLibClang.buildPackage {
         src = ./highs-sys-test;
-        stdenv = p: p.clangStdenv;
         LIBCLANG_PATH = "${pkgs.llvmPackages.libclang.lib}/lib";
         nativeBuildInputs = with pkgs; [
           cmake
@@ -671,9 +681,8 @@ onlyDrvs (
       simpleOnlyTests = myLib.buildPackage {
         src = myLib.cleanCargoSource ./simple-only-tests;
       };
-      simpleAltStdenv = myLib.buildPackage {
+      simpleAltStdenv = myLibGcc.buildPackage {
         src = ./simple;
-        stdenv = p: p.gccStdenv;
       };
       # https://github.com/ipetkov/crane/issues/104
       simpleWithCmake = myLib.buildPackage {

--- a/docs/API.md
+++ b/docs/API.md
@@ -585,6 +585,23 @@ environment variables during the build, you can bring them back via
 * `cargoExtraArgs`
 * `rustFmtExtraArgs`
 
+### `craneLib.stdenvSelector`
+
+`stdenvSelector :: set -> drv`
+
+A function which when given an instance `pkgs` (or `pkgsBuildBuild`,
+`pkgsBuildHost`, ..., etc. when cross compiling) will return the `stdenv`
+instance that should be used across all derivations. By default this has the
+value `p: p.stdenv`, i.e. use the default `stdenv` instance in nixpkgs.
+
+This can be overridden via `.overrideScope`:
+
+```nix
+craneLib.overrideScope (final: prev: {
+  stdenvSelector = p: p.clangStdenv;
+})
+```
+
 ### `craneLib.taploFmt`
 
 `taploFmt :: set -> drv`
@@ -1277,10 +1294,6 @@ This is a fairly low-level abstraction, so consider using `buildPackage` or
   - Default value: the package name listed in `Cargo.toml`
 * `pnameSuffix`: a suffix appended to `pname`
   - Default value: `""`
-* `stdenv`: a function to select the standard build environment to use for this
-  derivation. For backwards compatibility a non-function value (i.e. `stdenv =
-  pkgs.stdenv;`) will still be accepted.
-  - Default value: `p: p.stdenv`
 * `version`: the version of the derivation
   - Default value: the version listed in `Cargo.toml`
 

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -26,6 +26,7 @@
 * [Local development](./local_development.md)
 * [Custom cargo commands](./custom_cargo_commands.md)
 * [Customizing builds](./customizing_builds.md)
+* [Overriding `stdenv`](./overriding-stdenv.md)
 * [Overriding derivations after the fact](./overriding_derivations.md)
 * [Patching sources of dependencies](./patching_dependency_sources.md)
 ---

--- a/docs/overriding-stdenv.md
+++ b/docs/overriding-stdenv.md
@@ -1,0 +1,18 @@
+## Patching sources of dependency crates
+
+Overriding the `stdenv` can be done at the "`craneLib` level" like so:
+
+```nix
+let
+  craneLib = (crane.mkLib pkgs).overrideScope (final: prev: {
+    # This is a function which is provided an instance of `pkgs`
+    # (which may be tailored for cross compilation, DO NOT reuse
+    # the `pkgs` from above`) and returns the `stdenv` instance
+    # that should be used across all derivations.
+    stdenvSelector = p: p.clangStdenv;
+  });
+in
+craneLib.buildPackage {
+  # etc...
+}
+```

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -163,6 +163,7 @@ let
         callPackage ./setupHooks/removeReferencesToVendoredSources.nix
           { };
       replaceCargoLockHook = callPackage ./setupHooks/replaceCargoLockHook.nix { };
+      stdenvSelector = p: p.stdenv;
       taploFmt = callPackage ./taploFmt.nix { };
       urlForCargoPackage = callPackage ./urlForCargoPackage.nix { };
       vendorCargoDeps = callPackage ./vendorCargoDeps.nix { };

--- a/lib/downloadCargoPackage.nix
+++ b/lib/downloadCargoPackage.nix
@@ -1,13 +1,12 @@
 {
   pkgsBuildBuild,
+  stdenvSelector,
   urlForCargoPackage,
 }:
 
 let
-  inherit (pkgsBuildBuild)
-    fetchurl
-    stdenv
-    ;
+  inherit (pkgsBuildBuild) fetchurl;
+  stdenv = stdenvSelector pkgsBuildBuild;
 in
 {
   name,

--- a/lib/downloadCargoPackageFromGit.nix
+++ b/lib/downloadCargoPackageFromGit.nix
@@ -4,13 +4,12 @@
   craneUtils,
   jq,
   pkgsBuildBuild,
+  stdenvSelector,
 }:
 
 let
-  inherit (pkgsBuildBuild)
-    fetchgit
-    stdenv
-    ;
+  inherit (pkgsBuildBuild) fetchgit;
+  stdenv = stdenvSelector pkgsBuildBuild;
 
   namePrefix = "cargo-git-";
   # 211 minus one for the `-` separator

--- a/lib/mkCargoDerivation.nix
+++ b/lib/mkCargoDerivation.nix
@@ -12,6 +12,7 @@
   replaceCargoLockHook,
   rsync,
   rustc,
+  stdenvSelector,
   vendorCargoDeps,
   writeText,
   writeTOML,
@@ -19,13 +20,14 @@
 }:
 
 let
-  # Warn if an stdenv selector function is required (e.g. when cross compiling) while only a single stdenv instance is given
-  stdenvSelectorWarnMsg = ''
-    mkCargoDerivation's stdenv argument was set to a specific stdenv instance
-    while an stdenv selector function is recommended. Consider specifying a
-    function which selects an stdenv for any given `pkgs` instantiation:
+  legacyStdenvWarnMsg = ''
+    passing in an `stdenv` override into `mkCargoDerivation` is now deprecated.
+    Changing the default `stdenv` must be done at the `craneLib` level like so:
 
-    stdenv = p: p.stdenv;
+      craneLib' = craneLib.override (final: prev: {
+        # Set this to the chosen stdenv, e.g. `p.clangStdenv`
+        stdenvSelector = p: p.stdenv;
+      })
   '';
 in
 args@{
@@ -45,15 +47,15 @@ args@{
 }:
 let
   # Pick the default package stdenv if none is provided
-  argsStdenv = args.stdenv or (p: p.stdenv);
-  stdenvSelector =
+  argsStdenv = if args ? stdenv then lib.warn legacyStdenvWarnMsg args.stdenv else stdenvSelector;
+  compatStdenvSelector =
     if lib.isFunction argsStdenv then
       argsStdenv
     # If not a function, warn and return the value as is
     else
-      lib.warn stdenvSelectorWarnMsg (_: argsStdenv);
+      _: argsStdenv;
 
-  chosenStdenv = stdenvSelector pkgs;
+  chosenStdenv = compatStdenvSelector pkgs;
 
   crateName = crateNameFromCargoToml args;
   cleanedArgs = builtins.removeAttrs args [
@@ -78,7 +80,7 @@ let
   cargoLock = args.cargoLock or cargoLockFromContents;
 
   crossEnv = lib.optionalAttrs (args.doIncludeCrossToolchainEnv or true) (
-    mkCrossToolchainEnv stdenvSelector
+    mkCrossToolchainEnv compatStdenvSelector
   );
 
   baseDrvArgs =

--- a/lib/setupHooks/removeReferencesToVendoredSources.nix
+++ b/lib/setupHooks/removeReferencesToVendoredSources.nix
@@ -2,10 +2,12 @@
   lib,
   makeSetupHook,
   pkgsBuildBuild,
-  stdenv,
+  pkgs,
+  stdenvSelector,
 }:
 
 let
+  stdenv = stdenvSelector pkgs;
   darwinCodeSign = stdenv.targetPlatform.isDarwin && stdenv.targetPlatform.isAarch64;
 in
 makeSetupHook {


### PR DESCRIPTION
Instead the stdenv should be overridden at the library level like:

```nix
  craneLib' = craneLib.override (final: prev: {
    stdenvSelector = p: p.clangStdenv;
  })
```

## Motivation

Prerequisite towards supporting https://github.com/ipetkov/crane/issues/963

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [x] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [x] updated `docs/API.md` (or general documentation) with changes
- [x] updated `CHANGELOG.md`
