### PR TITLE
Update Trunk URL in docs and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -603,7 +603,7 @@ A republish of 0.19.2 which was incorrectly tagged.
 ## [0.12.2] - 2023-06-06
 
 ### Added
-* Added support for the [Trunk](https://trunkrs.dev) wasm app build tool
+* Added support for the [Trunk](https://trunk-rs.github.io/trunk/) wasm app build tool
 
 ### Changed
 * `resolver` key is no longer cleaned from Cargo.toml

--- a/docs/examples/trunk-workspace.md
+++ b/docs/examples/trunk-workspace.md
@@ -1,4 +1,4 @@
-[Trunk](https://trunkrs.dev) is a tool that allow you to build web apps using Rust and webassembly, including compiling scss, and distributing other assets.
+[Trunk](https://trunk-rs.github.io/trunk/) is a tool that allow you to build web apps using Rust and webassembly, including compiling scss, and distributing other assets.
 It can be used in conjunction with any of Rust's web frameworks for the development of full stack web applications.
 
 In this example we have a workspace with three members:

--- a/docs/examples/trunk.md
+++ b/docs/examples/trunk.md
@@ -1,4 +1,4 @@
-[Trunk](https://trunkrs.dev) is a tool that allow you to build web apps using Rust and webassembly, including compiling scss, and distributing other assets.
+[Trunk](https://trunk-rs.github.io/trunk/) is a tool that allow you to build web apps using Rust and webassembly, including compiling scss, and distributing other assets.
 
 Being a more specialized tool, it comes with some constraints that must be noted when using it in combination with crane:
 


### PR DESCRIPTION
Trunk website URL has changed. The previous URL now points to a gambling website.

MR #1012 fixed the URL, but only in README.md. This MR replaces all instances of old URL with the new one (in CHANGELOG.md and in docs for the templates `trunk` and `trunk-workspace`)

## Motivation


## Checklist
N/A.
