### PR TITLE
Customizable suffix for `buildDepsOnly`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   `remarshal`) can be done via `craneLibRemarshal = craneLib.overrideScope
   (final: prev: { writeTOML = final.writeTOMLViaRemarshal; });`
 * `buildDepsOnly` now allows the user to override the `pnameSuffix`
+* `buildTrunkPackage` now adds a `-trunk` suffix to the name of dependency derivation
 
 ## [0.23.3] - 2026-04-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   dependency chains on non-Rust projects. Bringing back the old behavior (using
   `remarshal`) can be done via `craneLibRemarshal = craneLib.overrideScope
   (final: prev: { writeTOML = final.writeTOMLViaRemarshal; });`
+* `buildDepsOnly` now allows the user to override the `pnameSuffix`
 
 ## [0.23.3] - 2026-04-16
 

--- a/lib/buildDepsOnly.nix
+++ b/lib/buildDepsOnly.nix
@@ -57,7 +57,7 @@ mkCargoDerivation (
     inherit doCheck;
 
     src = dummySrc;
-    pnameSuffix = "-deps";
+    pnameSuffix = args.pnameSuffix or "-deps";
     pname = args.pname or crateName.pname;
     version = args.version or crateName.version;
 

--- a/lib/buildTrunkPackage.nix
+++ b/lib/buildTrunkPackage.nix
@@ -63,6 +63,7 @@ mkCargoDerivation (
       args.cargoArtifacts or (buildDepsOnly (
         args
         // {
+          pnameSuffix = "-trunk-deps";
           CARGO_BUILD_TARGET = args.CARGO_BUILD_TARGET or "wasm32-unknown-unknown";
           doCheck = args.doCheck or false;
         }


### PR DESCRIPTION
## Motivation
<!--
Thank you for your contribution! Please add a brief description below about the change and what is the motivation
behind it.
-->

My project can be compiled both to native targets and the browser (using `buildTrunkPackage`). But because of the current hardcoded suffix scheme, it's impossible to distinguish between the native and web dependency derivation in the build logs because they're all labeled as `${pname}-deps`.

This can also be annoying when you're cross compiling to multiple targets. You want the dependency to be clearly named (e.g. `${pname}-windows-deps`), but the current API makes it really cumbersome to do so.

To address the above issues, this PR makes the following changes:

- You can now override the `pnameSuffix` in `buildDepsOnly`. 
- `buildTrunkPackage` now labels the default dependency derivation with `-trunk-deps` which should improve UX.


## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [ ] updated `docs/API.md` (or general documentation) with changes
- [x] updated `CHANGELOG.md`
