### PR TITLE
Fix: Do not add a newline after the cargo-nextest args

### DIFF
--- a/lib/cargoNextest.nix
+++ b/lib/cargoNextest.nix
@@ -66,8 +66,7 @@ let
         ${
           if withLlvmCov then "cargo llvm-cov nextest ${cargoLlvmCovExtraArgs}" else "cargo nextest ${cmd}"
         } \
-        ''${CARGO_PROFILE:+--cargo-profile $CARGO_PROFILE} \
-        ${cargoExtraArgs} ${cargoNextestExtraArgs} ${moreArgs}
+        ''${CARGO_PROFILE:+--cargo-profile $CARGO_PROFILE} ${cargoExtraArgs} ${cargoNextestExtraArgs} ${moreArgs}
       '';
 
       nativeBuildInputs =


### PR DESCRIPTION
When overriding the checkPhase and re-using the checkPhaseCargoCommand from the old mkCargoDerivation definition here, with all of `cargoExtraArgs`, `cargoNextestExtraArgs` and `moreArgs` empty, the trailing `\` adds a newline to the cargo-nextest call, which causes scripts to misbehave in situations like:

```nix
RUST_LOG=off ${old.checkPhaseCargoCommand} --custom-arg || somethingElse
```

With this change, this trailing newline is removed, which makes the scenario described above work.

## Motivation
<!--
Thank you for your contribution! Please add a brief description below about the change and what is the motivation
behind it.
-->

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [ ] updated `docs/API.md` (or general documentation) with changes
- [ ] updated `CHANGELOG.md`
