### PR TITLE
craneUtils: use writableTmpDirAsHomeHook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 * The default dummy source for UEFI correctly builds for no_std environments.
+* `craneUtils` is now uses `writableTmpDirAsHomeHook` to better control cargo's
+  home directory placement, avoiding issues on non-sandboxed builds.
 
 ## [0.23.3] - 2026-04-16
 

--- a/pkgs/crane-utils/default.nix
+++ b/pkgs/crane-utils/default.nix
@@ -1,6 +1,7 @@
 {
   lib,
   rustPlatform,
+  writableTmpDirAsHomeHook,
 }:
 
 rustPlatform.buildRustPackage {
@@ -13,4 +14,14 @@ rustPlatform.buildRustPackage {
     ".lock"
   ];
   cargoLock.lockFile = ./Cargo.lock;
+
+  # NB: buildRustPackage doesn't set a CARGO_HOME location by default
+  # which means it falls back on $HOME/.cargo (which points to a non-existent
+  # /homeless-shelter/.cargo by default). On non-sandboxed builds this will
+  # cause errors as Nix does not expect `/homeless-shelter` to exist. Hence
+  # we ensure HOME is set to some writable path within the current build
+  # https://github.com/ipetkov/crane/issues/815
+  nativeBuildInputs = [
+    writableTmpDirAsHomeHook
+  ];
 }


### PR DESCRIPTION
## Motivation

buildRustPackage doesn't set a CARGO_HOME location by default
which means it falls back on $HOME/.cargo (which points to a non-existent
/homeless-shelter/.cargo by default). On non-sandboxed builds this will
cause errors as Nix does not expect `/homeless-shelter` to exist. Hence
we ensure HOME is set to some writable path within the current build

Fixes https://github.com/ipetkov/crane/issues/815

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [ ] updated `docs/API.md` (or general documentation) with changes
- [x] updated `CHANGELOG.md`
