### PR TITLE
vendorCargoRegistries: avoid escaping shell args

### DIFF
--- a/lib/vendorCargoRegistries.nix
+++ b/lib/vendorCargoRegistries.nix
@@ -25,7 +25,6 @@ let
   inherit (lib)
     concatMapStrings
     concatStrings
-    escapeShellArg
     flatten
     foldl
     groupBy
@@ -65,7 +64,7 @@ let
     runCommandLocal "vendor-registry" { } ''
       mkdir -p $out
       ${concatMapStrings (p: ''
-        ln -s ${escapeShellArg (vendorCrate p)} $out/${escapeShellArg "${p.name}-${p.version}"}
+        ln -s ${vendorCrate p} $out/${p.name}-${p.version}
       '') packages}
     '';
 
@@ -158,7 +157,7 @@ let
         hashed = hash prefixedUrl;
       in
       ''
-        [source.${escapeShellArg name}]
+        [source.${name}]
         registry = "${url}"
         replace-with = "nix-sources-${hashed}"
       ''


### PR DESCRIPTION
## Motivation
Using the [evaluation profiler](https://nix.dev/manual/nix/latest/advanced-topics/eval-profiler) showed me that this was a surprisingly hot call. I believe all of these uses are unnecessary. 

The result of `vendorCrate p` should just be a store path, and the result of `escapeShellArg name` is known info, since there's only one name (crates.io). `escapeShellArg "${p.name}-${p.version}"` could _technically_ be an issue, so if it's preferred, I can drop this one - but it would require a horrible name and version to trigger.


<!--
Thank you for your contribution! Please add a brief description below about the change and what is the motivation
behind it.
-->

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [ ] updated `docs/API.md` (or general documentation) with changes
- [ ] updated `CHANGELOG.md`
