### PR TITLE
ci: deploy pages via action not branch

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -7,32 +7,43 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  deploy:
+  build:
+    name: build
     runs-on: ubuntu-latest
-    env:
-      SSH_AUTH_SOCK: /tmp/ssh_agent.sock
     steps:
-    - uses: actions/checkout@v7
-    - uses: cachix/install-nix-action@v31
-    - uses: cachix/cachix-action@v17
-      with:
-        name: crane
-        authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-    - name: mdbook build
-      run: |
-        mkdir output
-        nix build --accept-flake-config .#book --out-link result --print-build-logs
-        rsync -r -L ./result/ ./output
-    - name: git push
-      working-directory: output
-      run: |
-        git init
-        git config user.name "GitHub Actions"
-        git config user.email "github-actions-bot@users.noreply.github.com"
-        git branch -M gh-pages
-        git add .
-        git commit -m "Deploying site"
-        ssh-agent -a $SSH_AUTH_SOCK > /dev/null
-        echo "${{ secrets.DEPLOY_KEY }}" | tr -d '\r' | ssh-add -
-        git push --force "git@github.com:${GITHUB_REPOSITORY}.git" gh-pages
+      - uses: actions/checkout@v7
+      - uses: cachix/install-nix-action@v31
+      - uses: cachix/cachix-action@v17
+        with:
+          name: crane
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+      - name: mdbook build
+        run: |
+          mkdir output
+          nix build --accept-flake-config .#book --out-link result --print-build-logs
+          rsync -r -L ./result/ ./output
+      - name: upload artifact
+        id: deployment
+        uses: actions/upload-pages-artifact@v5
+        with:
+          path: ./output
+
+  deploy:
+    name: deploy
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.build.outputs.page_url }}
+    permissions:
+      pages: write      # to deploy to Pages
+      id-token: write   # to verify the deployment originates from an appropriate source
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## Motivation
This way is much simpler and does not require a deploy key (or juggling two branches)

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [ ] updated `docs/API.md` (or general documentation) with changes
- [ ] updated `CHANGELOG.md`
