### PR TITLE
Drop support for nixpkgs-25.11

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,15 +34,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # NB: current latest release of 2.33.0 has bugs
-          - install_url: https://releases.nixos.org/nix/nix-2.31.2/install
-            name: run tests
             # Latest and greatest release of Nix
-          #- install_url: https://nixos.org/nix/install
-            # The 25.11 branch ships with Nix 2.31.2
-          - install_url: https://releases.nixos.org/nix/nix-2.31.2/install
+          - install_url: https://nixos.org/nix/install
+            name: run tests
+            # The 26.05 branch ships with Nix 2.34.7
+          - install_url: https://releases.nixos.org/nix/nix-2.34.7/install
             USE_LATEST_RELEASE: "1"
-            name: run tests 25.11
+            name: run tests 26.05
     runs-on: ubuntu-latest
     name: ${{ matrix.name }}
     environment: cachix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Changed
+* **Breaking**: dropped compatibility for Nix versions below 2.31.2
+* **Breaking**: dropped compatibility for nixpkgs-25.11
+
 ## [0.23.4] - 2026-05-17
 
 ### Added

--- a/extra-tests/dummy-does-not-depend-on-flake-source-via-path/test.sh
+++ b/extra-tests/dummy-does-not-depend-on-flake-source-via-path/test.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 set -eu
 
@@ -6,13 +6,13 @@ scriptDir=$(dirname "$0")
 cd "${scriptDir}"
 
 nixpkgsOverride="$(../../ci/ref-from-lock.sh ../../test#nixpkgs)"
-craneOverride="--override-input crane ../.. --override-input nixpkgs ${nixpkgsOverride}"
-flakeSrc=$(nix flake metadata ${craneOverride} --json 2>/dev/null | jq -r '.path')
+craneOverride=(--override-input crane ../.. --override-input nixpkgs "${nixpkgsOverride}")
+flakeSrc=$(nix flake metadata "${craneOverride[@]}" --json 2>/dev/null | jq -r '.path')
 
 # Get information about the default derivation
 # Then pull out any input sources
-drvSrcs=$(nix show-derivation ${craneOverride} '.#dummy' 2>/dev/null |
-  jq -r 'to_entries[].value.inputSrcs[]')
+drvSrcs=$(nix show-derivation "${craneOverride[@]}" '.#dummy' 2>/dev/null |
+  jq -r '.derivations | to_entries[].value.inputs.srcs[]')
 
 # And lastly make sure we DO NOT find the flake root source listed
 # or else the dummy derivation will depend on _too much_ (and get

--- a/extra-tests/dummy-does-not-depend-on-flake-source-via-self/test.sh
+++ b/extra-tests/dummy-does-not-depend-on-flake-source-via-self/test.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 set -eu
 
@@ -6,13 +6,13 @@ scriptDir=$(dirname "$0")
 cd "${scriptDir}"
 
 nixpkgsOverride="$(../../ci/ref-from-lock.sh ../../test#nixpkgs)"
-craneOverride="--override-input crane ../.. --override-input nixpkgs ${nixpkgsOverride}"
-flakeSrc=$(nix flake metadata ${craneOverride} --json 2>/dev/null | jq -r '.path')
+craneOverride=(--override-input crane ../.. --override-input nixpkgs "${nixpkgsOverride}")
+flakeSrc=$(nix flake metadata "${craneOverride[@]}" --json 2>/dev/null | jq -r '.path')
 
 # Get information about the default derivation
 # Then pull out any input sources
-drvSrcs=$(nix show-derivation ${craneOverride} '.#dummy' 2>/dev/null |
-  jq -r 'to_entries[].value.inputSrcs[]')
+drvSrcs=$(nix show-derivation "${craneOverride[@]}" '.#dummy' 2>/dev/null |
+  jq -r '.derivations | to_entries[].value.inputs.srcs[]')
 
 # And lastly make sure we DO NOT find the flake root source listed
 # or else the dummy derivation will depend on _too much_ (and get

--- a/extra-tests/test.sh
+++ b/extra-tests/test.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 set -eu
 

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -12,7 +12,7 @@
 }:
 
 let
-  minSupported = "25.11";
+  minSupported = "26.05";
   current = lib.concatStringsSep "." (lib.lists.sublist 0 2 (lib.splitVersion lib.version));
   isUnsupported = lib.versionOlder current minSupported;
   msg = "crane requires at least nixpkgs-${minSupported}, supplied nixpkgs-${current}";

--- a/test/flake.lock
+++ b/test/flake.lock
@@ -104,16 +104,16 @@
     },
     "nixpkgs-latest-release": {
       "locked": {
-        "lastModified": 1782847189,
-        "narHash": "sha256-twXPFqFsrrY5r28Zh7Homgcp2gUMBgQ6WDS98Q/3xFI=",
+        "lastModified": 1783148766,
+        "narHash": "sha256-uslt2pqShTIXDdAHRHv2QkYLsVdY8Oqwz0EA48/RSM8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b6018f87da91d19d0ab4cf979885689b469cdd41",
+        "rev": "a50de1b7d8a586adc18d2395c19de7d6058e6030",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-25.11",
+        "ref": "nixos-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/test/flake.nix
+++ b/test/flake.nix
@@ -6,7 +6,7 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
-    nixpkgs-latest-release.url = "github:NixOS/nixpkgs/nixos-25.11";
+    nixpkgs-latest-release.url = "github:NixOS/nixpkgs/nixos-26.05";
 
     advisory-db = {
       url = "github:rustsec/advisory-db";


### PR DESCRIPTION
## Motivation

The 25.11 release branch is now deprecated and 26.05 is the latest supported version

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [ ] updated `docs/API.md` (or general documentation) with changes
- [x] updated `CHANGELOG.md`
