### PR TITLE
fix: speed up conservative Cargo TOML filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 * **Breaking**: dropped compatibility for Nix versions below 2.31.2
 * **Breaking**: dropped compatibility for nixpkgs-25.11
+* Reduced Nix evaluation overhead in `cargoTomlConservative` by indexing removed
+  manifest paths.
 
 ## [0.23.4] - 2026-05-17
 

--- a/checks/cleanCargoTomlTests/default.nix
+++ b/checks/cleanCargoTomlTests/default.nix
@@ -33,6 +33,45 @@ let
     name: path:
     lib.mapAttrsToList (filterName: filter: cmpCleanCargoToml name path filterName filter) filters;
 
+  cargoTomlConservativeKeptPaths = [
+    [ ]
+    [ "unknown" ]
+    [ "package" ]
+    [
+      "package"
+      "authors-near-miss"
+    ]
+    [
+      "prefix"
+      "package"
+      "authors"
+    ]
+  ];
+
+  cargoTomlConservativeRemovedPaths = [
+    [ "badges" ]
+    [
+      "badges"
+      "nested"
+    ]
+    [
+      "package"
+      "authors"
+    ]
+    [
+      "package"
+      "authors"
+      "nested"
+    ]
+  ];
+
+  cargoTomlConservativeSemantics =
+    assert lib.all filters.cargoTomlConservative cargoTomlConservativeKeptPaths;
+    assert lib.all (path: !filters.cargoTomlConservative path) cargoTomlConservativeRemovedPaths;
+    runCommand "cargo-toml-conservative-semantics" { } ''
+      touch $out
+    '';
+
   testMatrix = {
     barebones = ./barebones;
     complex = ./complex;
@@ -42,4 +81,6 @@ let
     proc-macro = ./proc-macro;
   };
 in
-linkFarmFromDrvs "cleanCargoToml" (lib.concatLists (lib.mapAttrsToList cmpAllFilters testMatrix))
+linkFarmFromDrvs "cleanCargoToml" (
+  [ cargoTomlConservativeSemantics ] ++ lib.concatLists (lib.mapAttrsToList cmpAllFilters testMatrix)
+)

--- a/lib/filters/cargoTomlConservative.nix
+++ b/lib/filters/cargoTomlConservative.nix
@@ -85,6 +85,22 @@ let
   ++ (pathsToRemovePerTarget "test")
   ++ (pathsToRemovePerTarget "bench");
 
-  cargoTomlConservative = path: !builtins.any (p: lib.lists.hasPrefix p path) pathsToRemove;
+  pathsToRemoveIndex = lib.foldl' lib.recursiveUpdate { } (
+    map (path: lib.setAttrByPath path true) pathsToRemove
+  );
+
+  isPathRemoved =
+    index: path:
+    if builtins.isBool index then
+      index
+    else if path == [ ] then
+      false
+    else
+      let
+        next = index.${builtins.head path} or null;
+      in
+      next != null && isPathRemoved next (builtins.tail path);
+
+  cargoTomlConservative = path: !isPathRemoved pathsToRemoveIndex path;
 in
 cargoTomlConservative


### PR DESCRIPTION
## Motivation

`cargoTomlConservative` currently tests each visited Cargo TOML path against every removed prefix using `builtins.any` and `lib.lists.hasPrefix`. The set of removed paths is static, so large evaluations repeatedly perform the same list-prefix work.

Build a nested attribute index once and traverse it for each candidate path. Lookup cost becomes proportional to path depth rather than the number of removal prefixes, while preserving the existing filter contract for empty paths, unknown paths, exact prefixes, and descendants.

In a downstream evaluation that invokes the filter 91,720 times, this removes roughly 5.67 million prefix comparisons.

## Checklist
- [x] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [ ] updated `docs/API.md` (or general documentation) with changes
- [x] updated `CHANGELOG.md`