### PR TITLE
use full nix store path with binutils for cross-compilation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * **Breaking**: dropped compatibility for Nix versions below 2.31.2
 * **Breaking**: dropped compatibility for nixpkgs-25.11
 
+### Fixed
+* `mkCrossToolchainEnv` now uses the full nix store path for environment variables so that the
+  compilers can be removed from `nativeBuildInputs`, which fixes compilation where it previously
+  didn't work in some cases.
+
 ## [0.23.4] - 2026-05-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 * **Breaking**: dropped compatibility for Nix versions below 2.31.2
 * **Breaking**: dropped compatibility for nixpkgs-25.11
-
-### Fixed
-* `mkCrossToolchainEnv` now uses the full nix store path for environment variables so that the
-  compilers can be removed from `nativeBuildInputs`, which fixes compilation where it previously
-  didn't work in some cases.
+* **Breaking** (technically): `mkCrossToolchainEnv` now uses the full nix store
+  path for environment variables and no longer adds `cc` compilers to
+  `nativeBuildInputs`. This fixes cross compilation for certain cases which did
+  not previously work. To bring back the previous behavior add the necessary
+  compilers to `nativeBuildInputs`.
 
 ## [0.23.4] - 2026-05-17
 

--- a/lib/mkCrossToolchainEnv.nix
+++ b/lib/mkCrossToolchainEnv.nix
@@ -14,7 +14,8 @@ let
     buildKind: chosenPkgs:
     let
       chosenStdenv = stdenvSelector chosenPkgs;
-      ccPrefix = chosenStdenv.cc.targetPrefix;
+      # Use full CC path, preventing ambiguity from relying on PATH
+      ccPrefix = "${chosenStdenv.cc}/bin/${chosenStdenv.cc.targetPrefix}";
       cargoEnv = chosenStdenv.hostPlatform.rust.cargoEnvVarTarget;
       # Configure an emulator for the platform (if we need one, and there's one available)
       runnerAvailable =
@@ -54,12 +55,6 @@ lib.optionalAttrs (selectedStdenv.buildPlatform != selectedStdenv.hostPlatform) 
       # Set the target we want to build for (= Cargo target platform, Nixpkgs host platform)
       # The configureCargoCommonVars setup hook will set CARGO_BUILD_TARGET to this value if the user hasn't specified their own target to use
       "${cranePrefix}CARGO_BUILD_TARGET" = selectedStdenv.hostPlatform.rust.rustcTarget;
-
-      # Pull in any compilers we need
-      nativeBuildInputs = [
-        (stdenvSelector pkgsBuildHost).cc
-        (stdenvSelector pkgsHostTarget).cc
-      ];
     }
 
     # NOTE: This is Cargo's host platform (i.e. the platform Cargo runs on) and Nixpkgs's build platform.


### PR DESCRIPTION
## Motivation
In my repo, we've had our own cross-compilation setup [based on the one in nixpkgs](https://gitlab.com/famedly/conduit/-/blob/ea02329046c048927c9f45270010d4bceac91689/nix/pkgs/default/cross-compilation-env.nix#L37-88), which worked until one was introduced in crane last year. I just had crane pinned to the commit before it was introduced, but now I decided to finally try fix the issue.
I'm not too familiar with cross-compilation or nix, but after trying to fix it for a while, I found [this comment](https://github.com/ipetkov/crane/discussions/622#discussioncomment-9844073), which worked. Not too sure why honestly, since the issue occurred when there was no other `cc` in `PATH`, but this fixes the issue, which btw, was the following:
```
       > error: could not compile `portable-atomic` (build script) due to 1 previous error
       > error: linking with `cc` failed: exit status: 1
       >   |
       >   = note:  "cc" "-m64" "/build/rustc8JINyV/symbols.o" "<5 object files omitted>" "-Wl,--as-needed" "-Wl,-Bstatic" "<sysroot>/lib/rustlib/x86_64-unknown-linux-gnu/lib/{libstd-*,libpanic_unwind-*,libobject-*,libmemchr-*,libaddr2line-*,libgimli-*,librustc_demangle-*,libstd_detect-*,libhashbrown-*,librustc_std_workspace_alloc-*,libminiz_oxide-*,libadler2-*,libunwind-*,libcfg_if-*,liblibc-*,liballoc-*,librustc_std_workspace_core-*,libcore-*,libcompiler_builtins-*}.rlib" "-Wl,-Bdynamic" "-lgcc_s" "-lutil" "-lrt" "-lpthread" "-lm" "-ldl" "-lc" "-L" "/build/rustc8JINyV/raw-dylibs" "-Wl,--eh-frame-hdr" "-Wl,-z,noexecstack" "-L" "<sysroot>/lib/rustlib/x86_64-unknown-linux-gnu/lib" "-o" "/build/source/target/release/build/zerocopy-34d712eb1904a11e/build_script_build-34d712eb1904a11e" "-Wl,--gc-sections" "-pie" "-Wl,-z,relro,-z,now" "-Wl,-O1" "-Wl,--strip-debug" "-nodefaultlibs"
       >   = note: some arguments are omitted. use `--verbose` to show all linker arguments
       >   = note: /nix/store/ddk8rvjihg4vhh1k6x9rc65y1zb1kx34-binutils-2.46/bin/ld.bfd: attempted static link of dynamic object `/nix/store/8lahnh9pn3lrrnhax5nk7ibvjcbjmnkm-gcc-15.2.0-lib/lib/libgcc_s.so.1'
       >           /nix/store/ddk8rvjihg4vhh1k6x9rc65y1zb1kx34-binutils-2.46/bin/ld.bfd: attempted static link of dynamic object `/nix/store/ias8xacs1h3jy7xgwi2awvim61k2ji6c-glibc-2.42-67/lib/libutil.so'
       >           /nix/store/ddk8rvjihg4vhh1k6x9rc65y1zb1kx34-binutils-2.46/bin/ld.bfd: attempted static link of dynamic object `/nix/store/ias8xacs1h3jy7xgwi2awvim61k2ji6c-glibc-2.42-67/lib/librt.so'
       >           /nix/store/ddk8rvjihg4vhh1k6x9rc65y1zb1kx34-binutils-2.46/bin/ld.bfd: attempted static link of dynamic object `/nix/store/ias8xacs1h3jy7xgwi2awvim61k2ji6c-glibc-2.42-67/lib/libpthread.so'
       >           /nix/store/ddk8rvjihg4vhh1k6x9rc65y1zb1kx34-binutils-2.46/bin/ld.bfd: attempted static link of dynamic object `/nix/store/ias8xacs1h3jy7xgwi2awvim61k2ji6c-glibc-2.42-67/lib/libm.so.6'
       >           /nix/store/ddk8rvjihg4vhh1k6x9rc65y1zb1kx34-binutils-2.46/bin/ld.bfd: attempted static link of dynamic object `/nix/store/ias8xacs1h3jy7xgwi2awvim61k2ji6c-glibc-2.42-67/lib/libmvec.so.1'
       >           /nix/store/ddk8rvjihg4vhh1k6x9rc65y1zb1kx34-binutils-2.46/bin/ld.bfd: attempted static link of dynamic object `/nix/store/ias8xacs1h3jy7xgwi2awvim61k2ji6c-glibc-2.42-67/lib/libdl.so'
       >           /nix/store/ddk8rvjihg4vhh1k6x9rc65y1zb1kx34-binutils-2.46/bin/ld.bfd: attempted static link of dynamic object `/nix/store/ias8xacs1h3jy7xgwi2awvim61k2ji6c-glibc-2.42-67/lib/libc.so.6'
       >           /nix/store/ddk8rvjihg4vhh1k6x9rc65y1zb1kx34-binutils-2.46/bin/ld.bfd: attempted static link of dynamic object `/nix/store/ias8xacs1h3jy7xgwi2awvim61k2ji6c-glibc-2.42-67/lib/ld-linux-x86-64.so.2'
       >           collect2: error: ld returned 1 exit status
```

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [ ] updated `docs/API.md` (or general documentation) with changes
- [x] updated `CHANGELOG.md`
