### PR TITLE
urlForCargoPackage: correctly handle prefix for longer crate names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * Reduced Nix evaluation overhead in `cargoTomlConservative` by indexing removed
   manifest paths.
 
+### Fixed
+* `urlForCargoPackage` was fixed to correctly handle crate prefixes for crate
+  names longer than 4 characters
+
 ## [0.23.4] - 2026-05-17
 
 ### Added

--- a/lib/urlForCargoPackage.nix
+++ b/lib/urlForCargoPackage.nix
@@ -23,7 +23,7 @@ let
     else if nameLen == 3 then
       "3/${substr 0 1 name}"
     else
-      "${substr 0 2 name}/${substr 2 4 name}";
+      "${substr 0 2 name}/${substr 2 2 name}";
 
   knownRegistries = "\n  " + lib.concatStringsSep "\n  " (builtins.attrNames crateRegistries) + "\n";
   registry =


### PR DESCRIPTION
## Motivation
`builtins.substring` takes `start len` and not `start end`

<!--
Thank you for your contribution! Please add a brief description below about the change and what is the motivation
behind it.
-->

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [ ] updated `docs/API.md` (or general documentation) with changes
- [ ] updated `CHANGELOG.md`
