### PR TITLE
inheritCargoArtifactsHook: handle various new cargo lockfiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 * `urlForCargoPackage` was fixed to correctly handle crate prefixes for crate
   names longer than 4 characters
+* Inheriting cargo artifacts produced via `installCargoArtifactsMode =
+  "use-symlink"` now handle paths to cargo's newly introduced internal lock
+  files
 
 ## [0.23.4] - 2026-05-17
 

--- a/lib/setupHooks/inheritCargoArtifactsHook.sh
+++ b/lib/setupHooks/inheritCargoArtifactsHook.sh
@@ -48,9 +48,9 @@ inheritCargoArtifacts() {
       # since the store is read-only and cargo would otherwise choke
       chmod -R u+w "${cargoTargetDir}"
 
-      # NB: cargo also doesn't like it if `.cargo-lock` files remain with a
+      # NB: cargo also doesn't like it if various `.cargo*lock` files remain with a
       # timestamp in the distant past so we need to delete them here
-      find "${cargoTargetDir}" -name '.cargo-lock' -delete
+      find "${cargoTargetDir}" -name '.cargo*lock' -delete
     else
       # Dependency .rlib and .rmeta files are content addressed and thus are not written to after
       # being built (since changing `Cargo.lock` would rebuild everything anyway), which makes them
@@ -82,10 +82,13 @@ inheritCargoArtifacts() {
       # NB: `.cargo-lock` files tend to appear in "top level" profile artifact directories.
       # Those directories usually contain a `*.d` file for each binary target, but these are NOT
       # content addressed, so we will want to copy them directly so they become writable in place
-      find "${cargoTargetDir}" -name '.cargo-lock' -delete \
+      find "${cargoTargetDir}" -name '.cargo*lock' -delete \
        -execdir bash -c '
+         set -x
          for f in *.d; do
-           cp --preserve=timestamps --no-preserve=ownership --remove-destination "$(readlink "${f}")" "${f}"
+           orig="$(readlink "${f}")"
+           [[ -n "${orig}" ]] || continue
+           cp --preserve=timestamps --no-preserve=ownership --remove-destination "${orig}" "${f}"
            chmod u+w "${f}"
          done
        ' \;


### PR DESCRIPTION
## Motivation

Cargo used to use `.cargo-lock` files but has recently started introducing more granular locks (like `.cargo-build-lock` and some others)

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [ ] added tests to verify new behavior
- [ ] added an example template or updated an existing one
- [ ] updated `docs/API.md` (or general documentation) with changes
- [x] updated `CHANGELOG.md`
